### PR TITLE
Accept algo/metrics archives in run-local

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -347,7 +347,7 @@ Usage: substra run-local [OPTIONS] ALGO
 
   Run local.
 
-  Train and test the algo located in ALGO locally.
+  Train and test the algo located in ALGO (directory or archive) locally.
 
   This command can be used to check that objective, dataset and algo assets
   implementations are compatible.
@@ -371,8 +371,8 @@ Options:
                                   [required]
   --test-opener FILE              opener.py file to use during testing.
                                   [required]
-  --metrics DIRECTORY             metrics directory to use during both
-                                  training and testing.  [required]
+  --metrics PATH                  metrics directory or archive to use during
+                                  both training and testing.  [required]
   --rank INTEGER                  will be passed to the algo during training.
   --train-data-samples DIRECTORY  directory of data samples directories to use
                                   during training.

--- a/references/cli.md
+++ b/references/cli.md
@@ -43,7 +43,7 @@ Usage: substra add data_sample [OPTIONS] PATH
 
   Add data sample(s).
 
-  The path is either a directory reprensenting a data sample or a parent
+  The path is either a directory representing a data sample or a parent
   directory containing data samples directories (if --multiple option is
   set).
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -650,7 +650,7 @@ def leaderboard(ctx, objective_key, output_format, expand, sort, config, profile
 
 @cli.command()
 @click.argument('algo',
-                type=click.Path(exists=True, file_okay=False))
+                type=click.Path(exists=True))
 @click.option('--train-opener',
               type=click.Path(exists=True, dir_okay=False),
               required=True,
@@ -660,9 +660,9 @@ def leaderboard(ctx, objective_key, output_format, expand, sort, config, profile
               required=True,
               help='opener.py file to use during testing.')
 @click.option('--metrics',
-              type=click.Path(exists=True, file_okay=False),
+              type=click.Path(exists=True),
               required=True,
-              help='metrics directory to use during both training and testing.')
+              help='metrics directory or archive to use during both training and testing.')
 @click.option('--rank',
               type=click.INT,
               default=0,
@@ -685,7 +685,7 @@ def run_local(algo, train_opener, test_opener, metrics, rank,
               fake_data_samples):
     """Run local.
 
-    Train and test the algo located in ALGO locally.
+    Train and test the algo located in ALGO (directory or archive) locally.
 
     This command can be used to check that objective, dataset and algo assets
     implementations are compatible.

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -226,7 +226,7 @@ def add_data_sample(ctx, path, dataset_key, local, multiple, test_only,
     """Add data sample(s).
 
 
-    The path is either a directory reprensenting a data sample or a parent
+    The path is either a directory representing a data sample or a parent
     directory containing data samples directories (if --multiple option is
     set).
     """

--- a/substra/runner.py
+++ b/substra/runner.py
@@ -214,7 +214,7 @@ def _extract_archive(archive_path, to_directory):
         with tarfile.open(archive_path, 'r:*') as tf:
             tf.extractall(to_directory)
     else:
-        raise Exception('Archive must be zip or tar.gz')
+        raise ValueError('Archive must be zip or tar.gz')
 
 
 @contextlib.contextmanager

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/sdk/__init__.py
+++ b/tests/sdk/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,10 @@
 import os
+import zipfile
 
 import pytest
 
 from substra import runner
+from substra.runner import DOCKER_ALGO_TAG, DOCKER_METRICS_TAG
 
 
 @pytest.fixture
@@ -15,10 +17,13 @@ def cwdir(tmpdir):
     os.chdir(old_cwd)
 
 
-def create_dir(path):
+def create_dir(path, root=None):
+    if root:
+        path = os.path.join(root, path)
     if os.path.exists(path):
         return
     os.makedirs(path)
+    return path
 
 
 def create_file(filename, content='', root=None):
@@ -54,29 +59,108 @@ def docker_api(cwdir, mocker):
     m.from_env.return_value = client
 
 
-def test_runner(cwdir, docker_api):
+def docker_run_side_effect(sandbox_path):
+    def inner(*args, **kwargs):
+        name = args[1]
+        if name == DOCKER_ALGO_TAG:
+            create_file('model/model', root=sandbox_path)
+        if name == DOCKER_METRICS_TAG:
+            create_file('pred_train/perf.json', '{"all": 1}', root=sandbox_path)
+            create_file('pred_test/perf.json', '{"all": 1}', root=sandbox_path)
+    return inner
 
-    algo_path = create_file('algo.tar.gz')
-    train_opener_path = create_file('train/opener.py')
-    test_opener_path = create_file('test/opener.py')
-    metrics_path = create_file('metrics.tar.gz')
-    train_data_samples_path = create_dir('train_data_samples')
-    test_data_samples_path = create_dir('test_data_samples_path')
 
-    runner.compute(
-        algo_path=algo_path,
-        train_opener_file=train_opener_path,
-        test_opener_file=test_opener_path,
-        metrics_path=metrics_path,
-        train_data_path=train_data_samples_path,
-        test_data_path=test_data_samples_path,
-        rank=0,
-        inmodels=[],
-        fake_data_samples=False
-    )
+def test_runner_folders(tmp_path, mocker):
+    algo_path = create_dir('algo', root=tmp_path)
+    train_opener_path = create_file('train/opener.py', root=tmp_path)
+    test_opener_path = create_file('test/opener.py', root=tmp_path)
+    metrics_path = create_dir('metrics', root=tmp_path)
+    train_data_samples_path = create_dir('train_data_samples', root=tmp_path)
+    test_data_samples_path = create_dir('test_data_samples_path', root=tmp_path)
+    sandbox_path = create_dir('sandbox', root=tmp_path)
+
+    with mocker.patch('substra.runner.docker'), \
+            mocker.patch('substra.runner._docker_run',
+                         side_effect=docker_run_side_effect(sandbox_path)):
+        runner.compute(
+            algo_path=algo_path,
+            train_opener_file=train_opener_path,
+            test_opener_file=test_opener_path,
+            metrics_path=metrics_path,
+            train_data_path=train_data_samples_path,
+            test_data_path=test_data_samples_path,
+            rank=0,
+            inmodels=[],
+            fake_data_samples=False,
+            compute_path=sandbox_path
+        )
 
     paths = (
-        'sandbox/model/model',
+        os.path.join(tmp_path, 'sandbox/model/model'),
     )
     for p in paths:
         assert os.path.exists(p)
+
+
+def test_runner_archives(mocker, tmp_path):
+    train_opener_path = create_file('train/opener.py', root=tmp_path)
+    test_opener_path = create_file('test/opener.py', root=tmp_path)
+    train_data_samples_path = create_dir('train_data_samples', root=tmp_path)
+    test_data_samples_path = create_dir('test_data_samples_path', root=tmp_path)
+    sandbox_path = create_dir('sandbox', root=tmp_path)
+
+    algo_path = create_file('algo.zip', root=tmp_path)
+    with zipfile.ZipFile(algo_path, 'w') as z:
+        z.write(create_file('Dockerfile', root=tmp_path))
+        z.write(create_file('algo.py', root=tmp_path))
+
+    metrics_path = create_file('metrics.zip', root=tmp_path)
+    with zipfile.ZipFile(metrics_path, 'w') as z:
+        z.write(create_file('Dockerfile', root=tmp_path))
+        z.write(create_file('metrics.py', root=tmp_path))
+
+    with mocker.patch('substra.runner.docker'), \
+            mocker.patch('substra.runner._docker_run',
+                         side_effect=docker_run_side_effect(sandbox_path)):
+        runner.compute(
+            algo_path=algo_path,
+            train_opener_file=train_opener_path,
+            test_opener_file=test_opener_path,
+            metrics_path=metrics_path,
+            train_data_path=train_data_samples_path,
+            test_data_path=test_data_samples_path,
+            rank=0,
+            inmodels=[],
+            fake_data_samples=False,
+            compute_path=sandbox_path
+        )
+
+    paths = (
+        os.path.join(tmp_path, 'sandbox/model/model'),
+    )
+    for p in paths:
+        assert os.path.exists(p)
+
+
+def test_runner_invalid_archives(tmp_path):
+    algo_path = create_file('algo.zip', root=tmp_path)
+    train_opener_path = create_file('train/opener.py', root=tmp_path)
+    test_opener_path = create_file('test/opener.py', root=tmp_path)
+    metrics_path = create_file('metrics.zip', root=tmp_path)
+    train_data_samples_path = create_dir('train_data_samples', root=tmp_path)
+    test_data_samples_path = create_dir('test_data_samples_path', root=tmp_path)
+    sandbox_path = create_dir('sandbox', root=tmp_path)
+
+    with pytest.raises(Exception, match="Archive must be zip or tar.gz"):
+        runner.compute(
+            algo_path=algo_path,
+            train_opener_file=train_opener_path,
+            test_opener_file=test_opener_path,
+            metrics_path=metrics_path,
+            train_data_path=train_data_samples_path,
+            test_data_path=test_data_samples_path,
+            rank=0,
+            inmodels=[],
+            fake_data_samples=False,
+            compute_path=sandbox_path
+        )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,7 +18,6 @@ import zipfile
 import pytest
 
 from substra import runner
-from substra.runner import DOCKER_ALGO_TAG, DOCKER_METRICS_TAG
 
 
 @pytest.fixture
@@ -74,14 +73,14 @@ def docker_api(cwdir, mocker):
 
 
 def docker_run_side_effect(sandbox_path):
-    def inner(*args, **kwargs):
+    def create_expected_docker_outputs(*args, **kwargs):
         name = args[1]
-        if name == DOCKER_ALGO_TAG:
+        if name == runner.DOCKER_ALGO_TAG:
             create_file('model/model', root=sandbox_path)
-        if name == DOCKER_METRICS_TAG:
+        if name == runner.DOCKER_METRICS_TAG:
             create_file('pred_train/perf.json', '{"all": 1}', root=sandbox_path)
             create_file('pred_test/perf.json', '{"all": 1}', root=sandbox_path)
-    return inner
+    return create_expected_docker_outputs
 
 
 def test_runner_folders(tmp_path, mocker):
@@ -165,7 +164,7 @@ def test_runner_invalid_archives(tmp_path):
     test_data_samples_path = create_dir('test_data_samples_path', root=tmp_path)
     sandbox_path = create_dir('sandbox', root=tmp_path)
 
-    with pytest.raises(Exception, match="Archive must be zip or tar.gz"):
+    with pytest.raises(ValueError, match="Archive must be zip or tar.gz"):
         runner.compute(
             algo_path=algo_path,
             train_opener_file=train_opener_path,


### PR DESCRIPTION
The run-local command currently only accepts directories for the ALGO arg and --metrics option. This prevents user from testing that their archives are indeed valid.

With this PR, users can now pass either folders or archive paths to these 2 parameters.