### PR TITLE
Add licenses on tests

### DIFF
--- a/tests/sdk/test_describe.py
+++ b/tests/sdk/test_describe.py
@@ -1,11 +1,3 @@
-import pytest
-
-import substra
-
-from .. import datastore
-from .utils import mock_requests, mock_requests_response
-
-
 # Copyright 2018 Owkin, inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +11,14 @@ from .utils import mock_requests, mock_requests_response
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import pytest
+
+import substra
+
+from .. import datastore
+from .utils import mock_requests, mock_requests_response
+
 
 @pytest.mark.parametrize(
     'asset_name', ['dataset', 'algo', 'objective']

--- a/tests/sdk/test_describe.py
+++ b/tests/sdk/test_describe.py
@@ -6,6 +6,20 @@ from .. import datastore
 from .utils import mock_requests, mock_requests_response
 
 
+# Copyright 2018 Owkin, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @pytest.mark.parametrize(
     'asset_name', ['dataset', 'algo', 'objective']
 )

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Owkin, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 import os
 

--- a/tests/sdk/test_leaderboard.py
+++ b/tests/sdk/test_leaderboard.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Owkin, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 import substra
 


### PR DESCRIPTION
The license is missing in the following files:
• tests/sdk/test_describe.py
• tests/sdk/test_download.py
• tests/sdk/test_leaderboard.py