### PR TITLE
improve debugging when writing CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def workdir(tmp_path):
 def execute(command, exit_code=0):
     runner = CliRunner()
     result = runner.invoke(cli, command)
-    assert result.exit_code == exit_code
+    assert result.exit_code == exit_code, result.output
     return result.output
 
 


### PR DESCRIPTION
When writing tests for the CLI, it is hard to understand why the command
could fail because the output is not printed in the tests output.

When the exit_code is not the one expected, the command output will be
printed to the tests output.