### PR TITLE
get and list compute_plans

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -6,6 +6,7 @@
 - [substra add dataset](#substra-add-dataset)
 - [substra add objective](#substra-add-objective)
 - [substra add algo](#substra-add-algo)
+- [substra add compute_plan](#substra-add-compute_plan)
 - [substra add traintuple](#substra-add-traintuple)
 - [substra add testtuple](#substra-add-testtuple)
 - [substra get](#substra-get)
@@ -203,6 +204,45 @@ Options:
   --help          Show this message and exit.
 ```
 
+## substra add compute_plan
+
+```bash
+Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
+
+  Add compute plan.
+
+  The tuples path must point to a valid JSON file with the following schema:
+
+  {
+      "traintuples": list[{
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "traintuple_id": str,
+          "in_models_ids": list[str],
+          "tag": str,
+      }],
+      "testtuples": list[{
+          "data_manager_key": str,
+          "test_data_sample_keys": list[str],
+          "testtuple_id": str,
+          "traintuple_id": str,
+          "tag": str,
+      }]
+  }
+
+Options:
+  --algo-key TEXT       [required]
+  --objective-key TEXT  [required]
+  --yaml                Display output as yaml.
+  --json                Display output as json.
+  --pretty              Pretty print output  [default: True]
+  --config PATH         Config path (default ~/.substra).
+  --profile TEXT        Profile name to use.
+  --user FILE           User file path to use (default ~/.substra-user).
+  --verbose             Enable verbose mode.
+  --help                Show this message and exit.
+```
+
 ## substra add traintuple
 
 ```bash
@@ -272,7 +312,8 @@ Options:
 ## substra get
 
 ```bash
-Usage: substra get [OPTIONS] [algo|dataset|objective|testtuple|traintuple]
+Usage: substra get [OPTIONS]
+                   [algo|compute_plan|dataset|objective|testtuple|traintuple]
                    ASSET_KEY
 
   Get asset definition.
@@ -292,8 +333,8 @@ Options:
 ## substra list
 
 ```bash
-Usage: substra list [OPTIONS] [algo|data_sample|dataset|objective|testtuple|tr
-                    aintuple|node]
+Usage: substra list [OPTIONS] [algo|compute_plan|data_sample|dataset|objective
+                    |testtuple|traintuple|node]
 
   List assets.
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -243,6 +243,11 @@ Data is a dict object with the following schema:
 Client.get_algo(self, algo_key)
 ```
 Get algo by key.
+## get_compute_plan
+```python
+Client.get_compute_plan(self, compute_plan_key)
+```
+Get compute plan by key.
 ## get_dataset
 ```python
 Client.get_dataset(self, dataset_key)
@@ -268,6 +273,11 @@ Get traintuple by key.
 Client.list_algo(self, filters=None, is_complex=False)
 ```
 List algos.
+## list_compute_plan
+```python
+Client.list_compute_plan(self, filters=None, is_complex=False)
+```
+List compute plans.
 ## list_data_sample
 ```python
 Client.list_data_sample(self, filters=None, is_complex=False)

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -438,6 +438,54 @@ def add_algo(ctx, data, output_format, config, profile, user, verbose):
     printer.print(res, is_list=False)
 
 
+@add.command('compute_plan')
+@click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
+                callback=load_json_from_path, metavar="TUPLES_PATH")
+@click.option('--algo-key', required=True)
+@click.option('--objective-key', required=True)
+@click_option_output_format
+@click_option_config
+@click_option_profile
+@click_option_user
+@click_option_verbose
+@click.pass_context
+@error_printer
+def add_compute_plan(ctx, tuples, algo_key, objective_key, output_format,
+                     config, profile, user, verbose):
+    """Add compute plan.
+
+    The tuples path must point to a valid JSON file with the following schema:
+
+    \b
+    {
+        "traintuples": list[{
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "traintuple_id": str,
+            "in_models_ids": list[str],
+            "tag": str,
+        }],
+        "testtuples": list[{
+            "data_manager_key": str,
+            "test_data_sample_keys": list[str],
+            "testtuple_id": str,
+            "traintuple_id": str,
+            "tag": str,
+        }]
+    }
+
+    """
+    client = get_client(config, profile, user)
+    data = {
+        "algo_key": algo_key,
+        "objective_key": objective_key
+    }
+    data.update(tuples)
+    res = client.add_compute_plan(data)
+    printer = printers.get_asset_printer(assets.COMPUTE_PLAN, output_format)
+    printer.print(res, is_list=False)
+
+
 @add.command('traintuple')
 @click.option('--objective-key', required=True)
 @click.option('--algo-key', required=True)

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -540,6 +540,7 @@ def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag,
 @cli.command()
 @click.argument('asset-name', type=click.Choice([
     assets.ALGO,
+    assets.COMPUTE_PLAN,
     assets.DATASET,
     assets.OBJECTIVE,
     assets.TESTTUPLE,
@@ -572,6 +573,7 @@ def get(ctx, asset_name, asset_key, expand, output_format, config, profile, user
 @cli.command('list')
 @click.argument('asset-name', type=click.Choice([
     assets.ALGO,
+    assets.COMPUTE_PLAN,
     assets.DATA_SAMPLE,
     assets.DATASET,
     assets.OBJECTIVE,

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -95,6 +95,14 @@ class KeysField(Field):
         return value
 
 
+class CountField(Field):
+    def get_value(self, item, **kwargs):
+        value = super().get_value(item)
+        if value:
+            return len(value)
+        return 0
+
+
 class InModelTraintupleKeysField(KeysField):
     def _get_key(self, v):
         return v.get('traintupleKey')
@@ -228,22 +236,30 @@ class AlgoPrinter(AssetPrinter):
 class ComputePlanPrinter(AssetPrinter):
     asset_name = 'compute_plan'
 
+    key_field = Field('Compute plan ID', 'computePlanID')
+
     list_fields = (
-        # Field('Name', 'name'),
+        Field('Algo key', 'algoKey'),
+        Field('Objective key', 'objectiveKey'),
+        CountField('Traintuples count', 'traintuples'),
+        CountField('Testtuples count', 'testtuples'),
     )
     single_fields = (
-        # Field('Name', 'name'),
-        # Field('Owner', 'owner'),
-        # PermissionField('Permissions', 'permissions'),
+        Field('Algo key', 'algoKey'),
+        Field('Objective key', 'objectiveKey'),
+        KeysField('Traintuple keys', 'traintupleKeys'),
+        KeysField('Testtuple keys', 'traintupleKeys'),
     )
 
     def print_messages(self, item):
         key_value = self.key_field.get_value(item)
 
+        print()
         print('Display this compute_plan\'s traintuples:')
-        print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}')
+        print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}"')
+        print()
         print('Display this compute_plan\'s testtuples:')
-        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}')
+        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}"')
 
 
 class ObjectivePrinter(AssetPrinter):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -248,7 +248,7 @@ class ComputePlanPrinter(AssetPrinter):
         Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
         KeysField('Traintuple keys', 'traintuples'),
-        KeysField('Testtuple keys', 'traintuples'),
+        KeysField('Testtuple keys', 'testtuples'),
     )
 
     def print_messages(self, item, profile=None):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -247,19 +247,18 @@ class ComputePlanPrinter(AssetPrinter):
     single_fields = (
         Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
-        KeysField('Traintuple keys', 'traintupleKeys'),
-        KeysField('Testtuple keys', 'traintupleKeys'),
+        KeysField('Traintuple keys', 'traintuples'),
+        KeysField('Testtuple keys', 'traintuples'),
     )
 
-    def print_messages(self, item):
+    def print_messages(self, item, profile=None):
         key_value = self.key_field.get_value(item)
+        profile_arg = self.get_profile_arg(profile)
 
-        print()
-        print('Display this compute_plan\'s traintuples:')
-        print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}"')
-        print()
-        print('Display this compute_plan\'s testtuples:')
-        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}"')
+        print('\nDisplay this compute_plan\'s traintuples:')
+        print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}" {profile_arg}')
+        print('\nDisplay this compute_plan\'s testtuples:')
+        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}" {profile_arg}')
 
 
 class ObjectivePrinter(AssetPrinter):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -225,6 +225,27 @@ class AlgoPrinter(AssetPrinter):
     download_message = 'Download this algorithm\'s code:'
 
 
+class ComputePlanPrinter(AssetPrinter):
+    asset_name = 'compute_plan'
+
+    list_fields = (
+        # Field('Name', 'name'),
+    )
+    single_fields = (
+        # Field('Name', 'name'),
+        # Field('Owner', 'owner'),
+        # PermissionField('Permissions', 'permissions'),
+    )
+
+    def print_messages(self, item):
+        key_value = self.key_field.get_value(item)
+
+        print('Display this compute_plan\'s traintuples:')
+        print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}')
+        print('Display this compute_plan\'s testtuples:')
+        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}')
+
+
 class ObjectivePrinter(AssetPrinter):
     asset_name = 'objective'
 
@@ -365,6 +386,7 @@ class LeaderBoardPrinter(BasePrinter):
 
 PRINTERS = {
     assets.ALGO: AlgoPrinter,
+    assets.COMPUTE_PLAN: ComputePlanPrinter,
     assets.OBJECTIVE: ObjectivePrinter,
     assets.DATASET: DatasetPrinter,
     assets.DATA_SAMPLE: DataSamplePrinter,

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -408,6 +408,10 @@ class Client(object):
         """Get algo by key."""
         return self.client.get(assets.ALGO, algo_key)
 
+    def get_compute_plan(self, compute_plan_key):
+        """Get compute plan by key."""
+        return self.client.get(assets.COMPUTE_PLAN, compute_plan_key)
+
     def get_dataset(self, dataset_key):
         """Get dataset by key."""
         return self.client.get(assets.DATASET, dataset_key)
@@ -427,6 +431,10 @@ class Client(object):
     def list_algo(self, filters=None, is_complex=False):
         """List algos."""
         return self.client.list(assets.ALGO, filters=filters)
+
+    def list_compute_plan(self, filters=None, is_complex=False):
+        """List compute plans."""
+        return self.client.list(assets.COMPUTE_PLAN, filters=filters)
 
     def list_data_sample(self, filters=None, is_complex=False):
         """List data samples."""

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -173,3 +173,5 @@ NODES = [
     {'id': 'foo', 'isCurrent': False},
     {'id': 'bar', 'isCurrent': True},
 ]
+
+COMPUTE_PLAN = {}

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -174,4 +174,54 @@ NODES = [
     {'id': 'bar', 'isCurrent': True},
 ]
 
-COMPUTE_PLAN = {}
+COMPUTE_PLAN = {
+    "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+    "algoKey": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+    "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+    "traintuples": [
+        {
+            "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "algo": {
+                "name": "Logistic regression",
+                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/",  # noqa: E501
+            },
+            "creator": "MyPeer2MSP",
+            "dataset": {
+                "worker": "MyPeer2MSP",
+                "keys": [
+                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
+                    "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
+                ],
+                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+                "perf": 1
+            },
+            "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "inModels": None,
+            "log": "",
+            "objective": {
+                "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+                "metrics": {
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
+                    "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/",  # noqa: E501
+
+                }
+            },
+            "outModel": {
+                "hash": "af716d0315e847b500376420aaa65a5192f67a5635163d7c0f44cdf72d5b3772",
+                "storageAddress": "http://testserver/model/af716d0315e847b500376420aaa65a5192f67a5635163d7c0f44cdf72d5b3772/file/",  # noqa: E501
+
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        }
+    ],
+    "testtuples": []
+}

--- a/tests/sdk/test_get.py
+++ b/tests/sdk/test_get.py
@@ -20,7 +20,7 @@ from .utils import mock_requests
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple']
+    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
 )
 def test_get_asset(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -19,7 +19,7 @@ from .utils import mock_requests
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple']
+    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
 )
 def test_list_asset(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,7 +91,7 @@ def mock_client_call(mocker, method_name, response="", side_effect=None):
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple']
+    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
 )
 def test_command_list(asset_name, workdir, mocker):
     item = getattr(datastore, asset_name.upper())
@@ -208,7 +208,7 @@ def test_command_add_already_exists(workdir, mocker):
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple']
+    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
 )
 def test_command_get(asset_name, workdir, mocker):
     item = getattr(datastore, asset_name.upper())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,15 +91,22 @@ def mock_client_call(mocker, method_name, response="", side_effect=None):
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
+    'asset_name,key_field', [
+        ('objective', 'key'),
+        ('dataset', 'key'),
+        ('algo', 'key'),
+        ('testtuple', 'key'),
+        ('traintuple', 'key'),
+        ('compute_plan', 'computePlanID'),
+    ]
 )
-def test_command_list(asset_name, workdir, mocker):
+def test_command_list(asset_name, key_field, workdir, mocker):
     item = getattr(datastore, asset_name.upper())
     method_name = f'list_{asset_name}'
     m = mock_client_call(mocker, method_name, [item])
     output = client_execute(workdir, ['list', asset_name])
     assert m.is_called()
-    assert item['key'] in output
+    assert item[key_field] in output
 
 
 def test_command_list_node(workdir, mocker):
@@ -230,15 +237,22 @@ def test_command_add_data_sample_already_exists(workdir, mocker):
 
 
 @pytest.mark.parametrize(
-    'asset_name', ['objective', 'dataset', 'algo', 'testtuple', 'traintuple', 'compute_plan']
+    'asset_name,key_field', [
+        ('objective', 'key'),
+        ('dataset', 'key'),
+        ('algo', 'key'),
+        ('testtuple', 'key'),
+        ('traintuple', 'key'),
+        ('compute_plan', 'computePlanID'),
+    ]
 )
-def test_command_get(asset_name, workdir, mocker):
+def test_command_get(asset_name, key_field, workdir, mocker):
     item = getattr(datastore, asset_name.upper())
     method_name = f'get_{asset_name}'
     m = mock_client_call(mocker, method_name, item)
     output = client_execute(workdir, ['get', asset_name, 'fakekey'])
     assert m.is_called()
-    assert item['key'] in output
+    assert item[key_field] in output
 
 
 def test_command_describe(workdir, mocker):


### PR DESCRIPTION
* Allow get and list for compute_plans.
* Add "add compute_plan" command to the CLI (previously only available in SDK)

This PR depends on https://github.com/SubstraFoundation/substra-backend/pull/34

While ensuring that the new commands were tested, I realized that the 409 errors in the cli were only tested for datasets. I updated the test so that all assets are tested.