### PR TITLE
Remove reference to private docker registry

### DIFF
--- a/docs/local_install.md
+++ b/docs/local_install.md
@@ -14,7 +14,7 @@ This guide will help you to get Substra source code and to start a local instanc
 
 - docker:
   - on macOS, by default, docker has access only to the user directory.
-    - Substra requires access to `/tmp/substra`, update accordingly the docker desktop configuration (`Preferences` > `File Sharing`).
+    - Substra requires access to a local folder that you can set through the `SUBSTRA_PATH` variable env (defaults to `/tmp/substra`). Make sure the directory of your choice is accessible by updating accordingly the docker desktop configuration (`Preferences` > `File Sharing`).
     - Ensure also that the docker daemon has enough resources to execute the ML pipeline, for instance: CPUs>1, Memory>4.0 GiB (`Preferences` > `Advanced`).
   - on Linux environment, please refer to this [guide](https://github.com/SubstraFoundation/substra-backend/blob/master/README.md) to configure docker.
 

--- a/docs/local_install.md
+++ b/docs/local_install.md
@@ -14,7 +14,7 @@ This guide will help you to get Substra source code and to start a local instanc
 
 - docker:
   - on macOS, by default, docker has access only to the user directory.
-    - Substra requires access to `/substra`, update accordingly the docker desktop configuration (`Preferences` > `File Sharing`).
+    - Substra requires access to `/tmp/substra`, update accordingly the docker desktop configuration (`Preferences` > `File Sharing`).
     - Ensure also that the docker daemon has enough resources to execute the ML pipeline, for instance: CPUs>1, Memory>4.0 GiB (`Preferences` > `Advanced`).
   - on Linux environment, please refer to this [guide](https://github.com/SubstraFoundation/substra-backend/blob/master/README.md) to configure docker.
 
@@ -72,16 +72,6 @@ pip install substra
 $ substra --version
 0.1.0
 ```
-
-## Pull substra-tools image from private docker repository
-
-It is required to run the algo, opener and metrics scripts on the substra
-platform.
-
-- Install Google Cloud SDK: https://cloud.google.com/sdk/install
-- Authenticate with your google account: `gcloud auth login`
-- Configure docker to use your google credentials for google based docker registery: `gcloud auth configure-docker`
-- Pull image: `docker pull substrafoundation/substra-tools`
 
 ## Start the Substra network
 

--- a/examples/compute_plan/assets/algo_sgd/Dockerfile
+++ b/examples/compute_plan/assets/algo_sgd/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM eu.gcr.io/substra-208412/substra-tools:0.2.0
+FROM substrafoundation/substra-tools:0.2.0
 
 # install dependencies
 RUN pip3 install pandas numpy sklearn pillow scipy keras

--- a/examples/titanic/assets/algo_constant/Dockerfile
+++ b/examples/titanic/assets/algo_constant/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM eu.gcr.io/substra-208412/substra-tools:0.2.0
+FROM substrafoundation/substra-tools:0.2.0
 
 # install dependencies
 RUN pip3 install pandas numpy sklearn pillow scipy keras

--- a/examples/titanic/assets/algo_random_forest/Dockerfile
+++ b/examples/titanic/assets/algo_random_forest/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM eu.gcr.io/substra-208412/substra-tools:0.2.0
+FROM substrafoundation/substra-tools:0.2.0
 
 # install dependencies
 RUN pip3 install pandas numpy sklearn pillow scipy keras

--- a/examples/titanic/assets/objective/Dockerfile
+++ b/examples/titanic/assets/objective/Dockerfile
@@ -1,5 +1,5 @@
 # this base image works in both CPU and GPU enabled environments
-FROM eu.gcr.io/substra-208412/substra-tools:0.2.0
+FROM substrafoundation/substra-tools:0.2.0
 
 # install dependencies
 RUN pip3 install sklearn


### PR DESCRIPTION
Since our docker images are now available on the public docker registry, the references to our private one are irrelevant. This PR replaces them with the new public ones.

Also, the MacOS Catalina update forced us to update the default working dir of the substra platform in `/tmp/substra`, I updated the guide accordingly.