### PR TITLE
Update usage of mocker

### DIFF
--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -82,10 +82,10 @@ def test_request_http_errors(mocker, status_code, http_response, sdk_exception):
 
 
 def test_request_connection_error(mocker):
-    with mocker.patch('substra.sdk.rest_client.requests.post',
-                      side_effect=requests.exceptions.ConnectionError):
-        with pytest.raises(exceptions.ConnectionError):
-            rest_client.Client(CONFIG).add('foo', {})
+    mocker.patch('substra.sdk.rest_client.requests.post',
+                 side_effect=requests.exceptions.ConnectionError)
+    with pytest.raises(exceptions.ConnectionError):
+        rest_client.Client(CONFIG).add('foo', {})
 
 
 def test_add_timeout_with_retry(mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,15 +96,15 @@ def mock_client_call(mocker, method_name, response="", side_effect=None):
 def test_command_list(asset_name, workdir, mocker):
     item = getattr(datastore, asset_name.upper())
     method_name = f'list_{asset_name}'
-    with mock_client_call(mocker, method_name, [item]) as m:
-        output = client_execute(workdir, ['list', asset_name])
+    m = mock_client_call(mocker, method_name, [item])
+    output = client_execute(workdir, ['list', asset_name])
     assert m.is_called()
     assert item['key'] in output
 
 
 def test_command_list_node(workdir, mocker):
-    with mock_client_call(mocker, 'list_node', datastore.NODES):
-        output = client_execute(workdir, ['list', 'node'])
+    mock_client_call(mocker, 'list_node', datastore.NODES)
+    output = client_execute(workdir, ['list', 'node'])
     assert output == ('NODE ID                     \n'
                       'foo                         \n'
                       'bar         (current)       \n')
@@ -124,10 +124,10 @@ def test_command_list_node(workdir, mocker):
 def test_command_add(asset_name, params, workdir, mocker):
     method_name = f'add_{asset_name}'
 
-    with mock_client_call(mocker, method_name, response={}) as m:
-        json_file = workdir / "valid_json_file.json"
-        json_file.write_text(json.dumps({}))
-        client_execute(workdir, ['add', asset_name] + params + [str(json_file)])
+    m = mock_client_call(mocker, method_name, response={})
+    json_file = workdir / "valid_json_file.json"
+    json_file.write_text(json.dumps({}))
+    client_execute(workdir, ['add', asset_name] + params + [str(json_file)])
     assert m.is_called()
 
     invalid_json_file = workdir / "invalid_json_file.txt"
@@ -146,13 +146,13 @@ def test_command_add_objective(workdir, mocker):
     json_file = workdir / "valid_json_file.json"
     json_file.write_text(json.dumps({}))
 
-    with mock_client_call(mocker, 'add_objective', response={}) as m:
-        client_execute(workdir, ['add', 'objective', str(json_file), '--dataset-key', 'foo',
-                                 '--data-samples-path', str(json_file)])
+    m = mock_client_call(mocker, 'add_objective', response={})
+    client_execute(workdir, ['add', 'objective', str(json_file), '--dataset-key', 'foo',
+                             '--data-samples-path', str(json_file)])
     assert m.is_called()
 
-    with mock_client_call(mocker, 'add_objective', response={}) as m:
-        client_execute(workdir, ['add', 'objective', str(json_file)])
+    m = mock_client_call(mocker, 'add_objective', response={})
+    client_execute(workdir, ['add', 'objective', str(json_file)])
     assert m.is_called()
 
     res = client_execute(workdir, ['add', 'objective', 'non_existing_file.txt', '--dataset-key',
@@ -177,8 +177,8 @@ def test_command_add_objective(workdir, mocker):
 
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):
-    with mock_client_call(mocker, 'add_testtuple', response={}) as m:
-        client_execute(workdir, ['add', 'testtuple', '--traintuple-key', 'foo'])
+    m = mock_client_call(mocker, 'add_testtuple', response={})
+    client_execute(workdir, ['add', 'testtuple', '--traintuple-key', 'foo'])
     assert m.is_called()
 
 
@@ -186,9 +186,9 @@ def test_command_add_data_sample(workdir, mocker):
     temp_dir = workdir / "test"
     temp_dir.mkdir()
 
-    with mock_client_call(mocker, 'add_data_samples') as m:
-        client_execute(workdir, ['add', 'data_sample', str(temp_dir), '--dataset-key', 'foo',
-                                 '--test-only'])
+    m =  mock_client_call(mocker, 'add_data_samples')
+    client_execute(workdir, ['add', 'data_sample', str(temp_dir), '--dataset-key', 'foo',
+                             '--test-only'])
     assert m.is_called()
 
     res = client_execute(workdir, ['add', 'data_sample', 'dir', '--dataset-key', 'foo'],
@@ -197,14 +197,14 @@ def test_command_add_data_sample(workdir, mocker):
 
 
 def test_command_add_already_exists(workdir, mocker):
-    with mock_client_call(mocker, 'add_dataset',
-                          side_effect=substra.exceptions.AlreadyExists('foo', 409)) as m:
-        json_file = workdir / "valid_json_file.json"
-        json_file.write_text(json.dumps({}))
-        output = client_execute(workdir, ['add', 'dataset', str(json_file)], exit_code=1)
+    m = mock_client_call(mocker, 'add_dataset',
+                         side_effect=substra.exceptions.AlreadyExists('foo', 409))
+    json_file = workdir / "valid_json_file.json"
+    json_file.write_text(json.dumps({}))
+    output = client_execute(workdir, ['add', 'dataset', str(json_file)], exit_code=1)
 
-        assert 'already exists' in output
-        assert m.is_called()
+    assert 'already exists' in output
+    assert m.is_called()
 
 
 @pytest.mark.parametrize(
@@ -213,29 +213,29 @@ def test_command_add_already_exists(workdir, mocker):
 def test_command_get(asset_name, workdir, mocker):
     item = getattr(datastore, asset_name.upper())
     method_name = f'get_{asset_name}'
-    with mock_client_call(mocker, method_name, item) as m:
-        output = client_execute(workdir, ['get', asset_name, 'fakekey'])
+    m = mock_client_call(mocker, method_name, item)
+    output = client_execute(workdir, ['get', asset_name, 'fakekey'])
     assert m.is_called()
     assert item['key'] in output
 
 
 def test_command_describe(workdir, mocker):
     response = "My description."
-    with mock_client_call(mocker, 'describe_objective', response) as m:
-        output = client_execute(workdir, ['describe', 'objective', 'fakekey'])
+    m = mock_client_call(mocker, 'describe_objective', response)
+    output = client_execute(workdir, ['describe', 'objective', 'fakekey'])
     assert m.is_called()
     assert response in output
 
 
 def test_command_download(workdir, mocker):
-    with mock_client_call(mocker, 'download_objective') as m:
-        client_execute(workdir, ['download', 'objective', 'fakekey'])
+    m = mock_client_call(mocker, 'download_objective')
+    client_execute(workdir, ['download', 'objective', 'fakekey'])
     assert m.is_called()
 
 
 def test_command_update_dataset(workdir, mocker):
-    with mock_client_call(mocker, 'update_dataset') as m:
-        client_execute(workdir, ['update', 'dataset', 'key1', 'key2'])
+    m = mock_client_call(mocker, 'update_dataset')
+    client_execute(workdir, ['update', 'dataset', 'key1', 'key2'])
     assert m.is_called()
 
 
@@ -247,8 +247,8 @@ def test_command_update_data_sample(workdir, mocker):
     json_file = workdir / "valid_json_file.json"
     json_file.write_text(json.dumps(data_samples))
 
-    with mock_client_call(mocker, 'link_dataset_with_data_samples') as m:
-        client_execute(workdir, ['update', 'data_sample', str(json_file), '--dataset-key', 'foo'])
+    m = mock_client_call(mocker, 'link_dataset_with_data_samples')
+    client_execute(workdir, ['update', 'data_sample', str(json_file), '--dataset-key', 'foo'])
     assert m.is_called()
 
     invalid_json_file = workdir / "invalid_json_file.json"
@@ -295,7 +295,7 @@ def test_error_printer(mocker, exception):
     mock_click_context = mock.MagicMock()
     mock_click_context.params = {'verbose': False}
 
-    with mocker.patch('substra.cli.interface.click.get_current_context',
-                      return_value=mock_click_context):
-        with pytest.raises(click.ClickException, match='foo'):
-            foo()
+    mocker.patch('substra.cli.interface.click.get_current_context',
+                 return_value=mock_click_context)
+    with pytest.raises(click.ClickException, match='foo'):
+        foo()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -92,21 +92,21 @@ def test_runner_folders(tmp_path, mocker):
     test_data_samples_path = create_dir('test_data_samples_path', root=tmp_path)
     sandbox_path = create_dir('sandbox', root=tmp_path)
 
-    with mocker.patch('substra.runner.docker'), \
-            mocker.patch('substra.runner._docker_run',
-                         side_effect=docker_run_side_effect(sandbox_path)):
-        runner.compute(
-            algo_path=algo_path,
-            train_opener_file=train_opener_path,
-            test_opener_file=test_opener_path,
-            metrics_path=metrics_path,
-            train_data_path=train_data_samples_path,
-            test_data_path=test_data_samples_path,
-            rank=0,
-            inmodels=[],
-            fake_data_samples=False,
-            compute_path=sandbox_path
-        )
+    mocker.patch('substra.runner.docker')
+    mocker.patch('substra.runner._docker_run',
+                 side_effect=docker_run_side_effect(sandbox_path))
+    runner.compute(
+        algo_path=algo_path,
+        train_opener_file=train_opener_path,
+        test_opener_file=test_opener_path,
+        metrics_path=metrics_path,
+        train_data_path=train_data_samples_path,
+        test_data_path=test_data_samples_path,
+        rank=0,
+        inmodels=[],
+        fake_data_samples=False,
+        compute_path=sandbox_path
+    )
 
     paths = (
         os.path.join(tmp_path, 'sandbox/model/model'),
@@ -132,21 +132,21 @@ def test_runner_archives(mocker, tmp_path):
         z.write(create_file('Dockerfile', root=tmp_path))
         z.write(create_file('metrics.py', root=tmp_path))
 
-    with mocker.patch('substra.runner.docker'), \
-            mocker.patch('substra.runner._docker_run',
-                         side_effect=docker_run_side_effect(sandbox_path)):
-        runner.compute(
-            algo_path=algo_path,
-            train_opener_file=train_opener_path,
-            test_opener_file=test_opener_path,
-            metrics_path=metrics_path,
-            train_data_path=train_data_samples_path,
-            test_data_path=test_data_samples_path,
-            rank=0,
-            inmodels=[],
-            fake_data_samples=False,
-            compute_path=sandbox_path
-        )
+    mocker.patch('substra.runner.docker'), \
+    mocker.patch('substra.runner._docker_run',
+                 side_effect=docker_run_side_effect(sandbox_path))
+    runner.compute(
+        algo_path=algo_path,
+        train_opener_file=train_opener_path,
+        test_opener_file=test_opener_path,
+        metrics_path=metrics_path,
+        train_data_path=train_data_samples_path,
+        test_data_path=test_data_samples_path,
+        rank=0,
+        inmodels=[],
+        fake_data_samples=False,
+        compute_path=sandbox_path
+    )
 
     paths = (
         os.path.join(tmp_path, 'sandbox/model/model'),


### PR DESCRIPTION
Since the last release of pytest-mock, mocker.patch isn't compatible with context managers anymore : https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager

This made the tests in test_runner.py fail.

This PR updates them to follow the proper usage of mocker.

See also https://github.com/pytest-dev/pytest-mock/releases/tag/v1.12.0