### PR TITLE
Generic compute plan

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -219,9 +219,27 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
 
   {
       "traintuples": list[{
+          "algo_key": str,
           "data_manager_key": str,
           "train_data_sample_keys": list[str],
           "traintuple_id": str,
+          "in_models_ids": list[str],
+          "tag": str,
+      }],
+      "composite_traintuples": list[{
+          "algo_key": str,
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "in_head_model_id": str,
+          "in_trunk_model_id": str,
+          "out_trunk_model_permissions": {
+              "authorized_ids": list[str],
+          },
+          "tag": str,
+      }]
+      "aggregatetuples": list[{
+          "algo_key": str,
+          "worker": str,
           "in_models_ids": list[str],
           "tag": str,
       }],
@@ -235,7 +253,6 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
   }
 
 Options:
-  --algo-key TEXT       [required]
   --objective-key TEXT  [required]
   --yaml                Display output as yaml.
   --json                Display output as json.

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -301,12 +301,29 @@ Data is a dict object with the following schema:
 
 ```
 {
-    "algo_key": str,
     "objective_key": str,
     "traintuples": list[{
+        "algo_key": str,
         "data_manager_key": str,
         "train_data_sample_keys": list[str],
         "traintuple_id": str,
+        "in_models_ids": list[str],
+        "tag": str,
+    }],
+    "composite_traintuples": list[{
+        "algo_key": str,
+        "data_manager_key": str,
+        "train_data_sample_keys": list[str],
+        "in_head_model_id": str,
+        "in_trunk_model_id": str,
+        "out_trunk_model_permissions": {
+            "authorized_ids": list[str],
+        },
+        "tag": str,
+    }]
+    "aggregatetuples": list[{
+        "algo_key": str,
+        "worker": str,
         "in_models_ids": list[str],
         "tag": str,
     }],

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -825,7 +825,7 @@ def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag,
 def get(ctx, asset_name, asset_key, expand, output_format, config, profile, user, verbose):
     """Get asset definition."""
     expand_valid_assets = (assets.DATASET, assets.TRAINTUPLE, assets.OBJECTIVE, assets.TESTTUPLE,
-                           assets.COMPOSITE_TRAINTUPLE, assets.AGGREGATETUPLE)
+                           assets.COMPOSITE_TRAINTUPLE, assets.AGGREGATETUPLE, assets.COMPUTE_PLAN)
     if expand and asset_name not in expand_valid_assets:  # fail fast
         raise click.UsageError(
             f'--expand option is available with assets {expand_valid_assets}')

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -441,7 +441,6 @@ def add_algo(ctx, data, output_format, config, profile, user, verbose):
 @add.command('compute_plan')
 @click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
                 callback=load_json_from_path, metavar="TUPLES_PATH")
-@click.option('--algo-key', required=True)
 @click.option('--objective-key', required=True)
 @click_option_output_format
 @click_option_config
@@ -450,7 +449,7 @@ def add_algo(ctx, data, output_format, config, profile, user, verbose):
 @click_option_verbose
 @click.pass_context
 @error_printer
-def add_compute_plan(ctx, tuples, algo_key, objective_key, output_format,
+def add_compute_plan(ctx, tuples, objective_key, output_format,
                      config, profile, user, verbose):
     """Add compute plan.
 
@@ -459,9 +458,27 @@ def add_compute_plan(ctx, tuples, algo_key, objective_key, output_format,
     \b
     {
         "traintuples": list[{
+            "algo_key": str,
             "data_manager_key": str,
             "train_data_sample_keys": list[str],
             "traintuple_id": str,
+            "in_models_ids": list[str],
+            "tag": str,
+        }],
+        "composite_traintuples": list[{
+            "algo_key": str,
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "in_head_model_id": str,
+            "in_trunk_model_id": str,
+            "out_trunk_model_permissions": {
+                "authorized_ids": list[str],
+            },
+            "tag": str,
+        }]
+        "aggregatetuples": list[{
+            "algo_key": str,
+            "worker": str,
             "in_models_ids": list[str],
             "tag": str,
         }],
@@ -477,7 +494,6 @@ def add_compute_plan(ctx, tuples, algo_key, objective_key, output_format,
     """
     client = get_client(config, profile, user)
     data = {
-        "algo_key": algo_key,
         "objective_key": objective_key
     }
     data.update(tuples)

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -239,14 +239,18 @@ class ComputePlanPrinter(AssetPrinter):
     list_fields = (
         Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
-        CountField('Traintuples count', 'traintuples'),
-        CountField('Testtuples count', 'testtuples'),
+        CountField('Traintuples count', 'traintupleKeys'),
+        CountField('Composite traintuples count', 'compositeTraintupleKeys'),
+        CountField('Aggregatetuples count', 'aggregatetupleKeys'),
+        CountField('Testtuples count', 'testtupleKeys'),
     )
     single_fields = (
         Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
-        KeysField('Traintuple keys', 'traintuples'),
-        KeysField('Testtuple keys', 'testtuples'),
+        KeysField('Traintuple keys', 'traintupleKeys'),
+        KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
+        KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
+        KeysField('Testtuple keys', 'testtupleKeys'),
     )
 
     def print_messages(self, item, profile=None):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -259,6 +259,15 @@ class ComputePlanPrinter(AssetPrinter):
 
         print('\nDisplay this compute_plan\'s traintuples:')
         print(f'\tsubstra list traintuple -f "traintuple:computePlanID:{key_value}" {profile_arg}')
+
+        print('\nDisplay this compute_plan\'s composite_traintuples:')
+        print(f'\tsubstra list composite_traintuple'
+              f' -f "composite_traintuple:computePlanID:{key_value}" {profile_arg}')
+
+        print('\nDisplay this compute_plan\'s aggregatetuples:')
+        print(f'\tsubstra list aggregatetuple'
+              f' -f "aggregatetuple:computePlanID:{key_value}" {profile_arg}')
+
         print('\nDisplay this compute_plan\'s testtuples:')
         print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}" {profile_arg}')
 

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -339,6 +339,7 @@ class TraintuplePrinter(AssetPrinter):
         Field('Algo name', 'algo.name'),
         Field('Status', 'status'),
         Field('Perf', 'dataset.perf'),
+        Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
     )
@@ -370,6 +371,7 @@ class AggregateTuplePrinter(AssetPrinter):
         Field('Algo name', 'algo.name'),
         Field('Status', 'status'),
         Field('Perf', 'dataset.perf'),
+        Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
     )
@@ -400,6 +402,7 @@ class CompositeTraintuplePrinter(AssetPrinter):
         Field('Composite algo name', 'algo.name'),
         Field('Status', 'status'),
         Field('Perf', 'dataset.perf'),
+        Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
     )

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -266,8 +266,7 @@ class ComputePlanPrinter(AssetPrinter):
         print(f'\tsubstra list aggregatetuple'
               f' -f "aggregatetuple:computePlanID:{key_value}" {profile_arg}')
 
-        print('\nDisplay this compute_plan\'s testtuples:')
-        print(f'\tsubstra list testtuple -f "testtuple:computePlanID:{key_value}" {profile_arg}')
+        # TODO add a command to display the related testtuples once testtuples have a computePlanID
 
 
 class AlgoPrinter(BaseAlgoPrinter):
@@ -440,7 +439,8 @@ class TesttuplePrinter(AssetPrinter):
         Field('Tag', 'tag'),
     )
     single_fields = (
-        Field('Traintuple key', 'model.traintupleKey'),
+        Field('Traintuple key', 'traintupleKey'),
+        Field('Traintuple type', 'traintupleType'),
         Field('Algo key', 'algo.hash'),
         Field('Algo name', 'algo.name'),
         Field('Objective key', 'objective.hash'),
@@ -471,7 +471,7 @@ class LeaderBoardPrinter(BasePrinter):
     testtuple_fields = (
         Field('Perf', 'perf'),
         Field('Algo name', 'algo.name'),
-        Field('Traintuple key', 'model.traintupleKey'),
+        Field('Traintuple key', 'traintupleKey'),
     )
 
     def print(self, leaderboard, expand):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -237,7 +237,6 @@ class ComputePlanPrinter(AssetPrinter):
     key_field = Field('Compute plan ID', 'computePlanID')
 
     list_fields = (
-        Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
         CountField('Traintuples count', 'traintupleKeys'),
         CountField('Composite traintuples count', 'compositeTraintupleKeys'),
@@ -245,7 +244,6 @@ class ComputePlanPrinter(AssetPrinter):
         CountField('Testtuples count', 'testtupleKeys'),
     )
     single_fields = (
-        Field('Algo key', 'algoKey'),
         Field('Objective key', 'objectiveKey'),
         KeysField('Traintuple keys', 'traintupleKeys'),
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -501,12 +501,29 @@ class Client(object):
 
 ```
         {
-            "algo_key": str,
             "objective_key": str,
             "traintuples": list[{
+                "algo_key": str,
                 "data_manager_key": str,
                 "train_data_sample_keys": list[str],
                 "traintuple_id": str,
+                "in_models_ids": list[str],
+                "tag": str,
+            }],
+            "composite_traintuples": list[{
+                "algo_key": str,
+                "data_manager_key": str,
+                "train_data_sample_keys": list[str],
+                "in_head_model_id": str,
+                "in_trunk_model_id": str,
+                "out_trunk_model_permissions": {
+                    "authorized_ids": list[str],
+                },
+                "tag": str,
+            }]
+            "aggregatetuples": list[{
+                "algo_key": str,
+                "worker": str,
                 "in_models_ids": list[str],
                 "tag": str,
             }],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ def test_command_list_node(workdir, mocker):
     ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
                     '--in-model-key', 'foo', '--in-model-key', 'bar', '--data-samples-path']),
     ('testtuple', ['--traintuple-key', 'foo', '--data-samples-path']),
-    ('compute_plan', ['--algo-key', 'foo', '--objective-key', 'foo']),
+    ('compute_plan', ['--objective-key', 'foo']),
     ('composite_traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
                               '--data-samples-path']),
 ])
@@ -233,7 +233,7 @@ def test_command_add_data_sample(workdir, mocker):
     ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
                     '--data-samples-path']),
     ('testtuple', ['--traintuple-key', 'foo', '--data-samples-path']),
-    ('compute_plan', ['--algo-key', 'foo', '--objective-key', 'foo']),
+    ('compute_plan', ['--objective-key', 'foo']),
     ('objective', []),
 ])
 def test_command_add_already_exists(workdir, mocker, asset_name, params):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -132,7 +132,7 @@ def test_runner_archives(mocker, tmp_path):
         z.write(create_file('Dockerfile', root=tmp_path))
         z.write(create_file('metrics.py', root=tmp_path))
 
-    mocker.patch('substra.runner.docker'), \
+    mocker.patch('substra.runner.docker')
     mocker.patch('substra.runner._docker_run',
                  side_effect=docker_run_side_effect(sandbox_path))
     runner.compute(


### PR DESCRIPTION
* Adds composite_traintuples and aggregatetuples to the structure of a compute plan
* Removes the global `algo_key` option of the `add compute_plan` command and moves it to the contents of each tuple
* Fixes a typo in test_runner.py