### PR TITLE
Fail fast: remove evaluation for train like tuples

### DIFF
--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -58,12 +58,14 @@ testtuples = []
 previous_id = None
 for train_data_sample_key in train_data_sample_keys:
     traintuple = {
+        'algo_key': algo_key,
         'data_manager_key': dataset_key,
         'train_data_sample_keys': [train_data_sample_key],
         'traintuple_id': uuid.uuid4().hex,
         'in_models_ids': [previous_id] if previous_id else [],
     }
     testtuple = {
+        'objective_key': objective_key,
         'traintuple_id': traintuple['traintuple_id']
     }
     traintuples.append(traintuple)
@@ -73,10 +75,10 @@ for train_data_sample_key in train_data_sample_keys:
 
 print('Adding compute plan...')
 compute_plan = client.add_compute_plan({
-    "algo_key": algo_key,
-    "objective_key": objective_key,
-    "traintuples": traintuples,
-    "testtuples": testtuples,
+    'traintuples': traintuples,
+    'testtuples': testtuples,
+    'composite_traintuples': [],
+    'aggregatetuples': [],
 })
 compute_plan_id = compute_plan.get('computePlanID')
 

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -49,7 +49,6 @@ for i, fold in enumerate(folds_keys['folds']):
     # traintuple
     traintuple = client.add_traintuple({
         'algo_key': algo_key,
-        'objective_key': objective_key,
         'data_manager_key': dataset_key,
         'train_data_sample_keys': fold['train_data_sample_keys'],
         'tag': tag,
@@ -59,6 +58,7 @@ for i, fold in enumerate(folds_keys['folds']):
 
     # testtuple
     testtuple = client.add_testtuple({
+        'objective_key': objective_key,
         'traintuple_key': traintuple_key,
         'data_manager_key': dataset_key,
         'test_data_sample_keys': fold['test_data_sample_keys'],

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -73,7 +73,6 @@ algo_key = client.add_algo({
 print('Registering traintuple...')
 traintuple = client.add_traintuple({
     'algo_key': algo_key,
-    'objective_key': assets_keys['objective_key'],
     'data_manager_key': assets_keys['dataset_key'],
     'train_data_sample_keys': assets_keys['train_data_sample_keys']
 }, exist_ok=True)
@@ -85,6 +84,7 @@ assert traintuple_key, 'Missing traintuple key'
 ########################################################
 print('Registering testtuple...')
 testtuple = client.add_testtuple({
+    'objective_key': assets_keys['objective_key'],
     'traintuple_key': traintuple_key
 }, exist_ok=True)
 testtuple_key = testtuple.get('key') or testtuple.get('pkhash')

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -75,7 +75,6 @@ algo_key = client.add_algo({
 print('Registering traintuple...')
 traintuple = client.add_traintuple({
     'algo_key': algo_key,
-    'objective_key': assets_keys['objective_key'],
     'data_manager_key': assets_keys['dataset_key'],
     'train_data_sample_keys': assets_keys['train_data_sample_keys']
 }, exist_ok=True)
@@ -87,6 +86,7 @@ assert traintuple_key, 'Missing traintuple key'
 ########################################################
 print('Registering testtuple...')
 testtuple = client.add_testtuple({
+    'objective_key': assets_keys['objective_key'],
     'traintuple_key': traintuple_key
 }, exist_ok=True)
 testtuple_key = testtuple.get('key') or testtuple.get('pkhash')

--- a/references/cli.md
+++ b/references/cli.md
@@ -244,6 +244,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "tag": str,
       }],
       "testtuples": list[{
+          "objective_key": str,
           "data_manager_key": str,
           "test_data_sample_keys": list[str],
           "testtuple_id": str,
@@ -253,15 +254,14 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
   }
 
 Options:
-  --objective-key TEXT  [required]
-  --config PATH         Config path (default ~/.substra).
-  --profile TEXT        Profile name to use.
-  --user FILE           User file path to use (default ~/.substra-user).
-  --verbose             Enable verbose mode.
-  --yaml                Display output as yaml.
-  --json                Display output as json.
-  --pretty              Pretty print output  [default: True]
-  --help                Show this message and exit.
+  --config PATH   Config path (default ~/.substra).
+  --profile TEXT  Profile name to use.
+  --user FILE     User file path to use (default ~/.substra-user).
+  --verbose       Enable verbose mode.
+  --yaml          Display output as yaml.
+  --json          Display output as json.
+  --pretty        Pretty print output  [default: True]
+  --help          Show this message and exit.
 ```
 
 ## substra add aggregate_algo
@@ -356,7 +356,6 @@ Usage: substra add traintuple [OPTIONS]
   - keys: list of data sample keys
 
 Options:
-  --objective-key TEXT      [required]
   --algo-key TEXT           [required]
   --dataset-key TEXT        [required]
   --data-samples-path FILE  [required]
@@ -380,20 +379,19 @@ Usage: substra add aggregatetuple [OPTIONS]
   Add aggregatetuple.
 
 Options:
-  --objective-key TEXT  [required]
-  --algo-key TEXT       [required]
-  --in-model-key TEXT   In model traintuple key.
-  --worker TEXT         Node ID for worker execution.  [required]
+  --algo-key TEXT      [required]
+  --in-model-key TEXT  In model traintuple key.
+  --worker TEXT        Node ID for worker execution.  [required]
   --rank INTEGER
   --tag TEXT
-  --config PATH         Config path (default ~/.substra).
-  --profile TEXT        Profile name to use.
-  --user FILE           User file path to use (default ~/.substra-user).
-  --verbose             Enable verbose mode.
-  --yaml                Display output as yaml.
-  --json                Display output as json.
-  --pretty              Pretty print output  [default: True]
-  --help                Show this message and exit.
+  --config PATH        Config path (default ~/.substra).
+  --profile TEXT       Profile name to use.
+  --user FILE          User file path to use (default ~/.substra-user).
+  --verbose            Enable verbose mode.
+  --yaml               Display output as yaml.
+  --json               Display output as json.
+  --pretty             Pretty print output  [default: True]
+  --help               Show this message and exit.
 ```
 
 ## substra add composite_traintuple
@@ -421,7 +419,6 @@ Usage: substra add composite_traintuple [OPTIONS]
   }
 
 Options:
-  --objective-key TEXT            [required]
   --algo-key TEXT                 [required]
   --dataset-key TEXT              [required]
   --data-samples-path FILE        [required]
@@ -459,6 +456,7 @@ Usage: substra add testtuple [OPTIONS]
   - keys: list of data sample keys
 
 Options:
+  --objective-key TEXT      [required]
   --dataset-key TEXT
   --traintuple-key TEXT     [required]
   --data-samples-path FILE

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -284,8 +284,6 @@ Create new testtuple asset.
     "traintuple_key": str,
     "test_data_sample_keys": list[str],
     "tag": str,
-    "rank": int,
-    "compute_plan_id": str,
 }
 ```
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -215,11 +215,11 @@ Create new traintuple asset.
 ```
 {
     "algo_key": str,
-    "objective_key": str,
     "data_manager_key": str,
     "train_data_sample_keys": list[str],
     "in_models_keys": list[str],
     "tag": str,
+    "rank": int,
     "compute_plan_id": str,
 }
 ```
@@ -236,7 +236,6 @@ Create new aggregatetuple asset.
 ```
 {
     "algo_key": str,
-    "objective_key": str,
     "in_models_keys": list[str],
     "tag": str,
     "compute_plan_id": str,
@@ -256,7 +255,6 @@ Create new composite traintuple asset.
 ```
 {
     "algo_key": str,
-    "objective_key": str,
     "data_manager_key": str,
     "in_head_model_key": str,
     "in_trunk_model_key": str,
@@ -264,6 +262,7 @@ Create new composite traintuple asset.
         "authorized_ids": list[str],
     },
     "tag": str,
+    "rank": int,
     "compute_plan_id": str,
 }
 ```
@@ -280,10 +279,12 @@ Create new testtuple asset.
 
 ```
 {
+    "objective_key": str,
     "data_manager_key": str,
     "traintuple_key": str,
     "test_data_sample_keys": list[str],
     "tag": str,
+    "rank": int,
     "compute_plan_id": str,
 }
 ```
@@ -301,7 +302,6 @@ Data is a dict object with the following schema:
 
 ```
 {
-    "objective_key": str,
     "traintuples": list[{
         "algo_key": str,
         "data_manager_key": str,
@@ -328,6 +328,7 @@ Data is a dict object with the following schema:
         "tag": str,
     }],
     "testtuples": list[{
+        "objective_key": str,
         "data_manager_key": str,
         "test_data_sample_keys": list[str],
         "testtuple_id": str,

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -462,11 +462,10 @@ def add_algo(ctx, data):
 @add.command('compute_plan')
 @click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
                 callback=load_json_from_path, metavar="TUPLES_PATH")
-@click.option('--objective-key', required=True)
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_compute_plan(ctx, tuples, objective_key):
+def add_compute_plan(ctx, tuples):
     """Add compute plan.
 
     The tuples path must point to a valid JSON file with the following schema:
@@ -499,6 +498,7 @@ def add_compute_plan(ctx, tuples, objective_key):
             "tag": str,
         }],
         "testtuples": list[{
+            "objective_key": str,
             "data_manager_key": str,
             "test_data_sample_keys": list[str],
             "testtuple_id": str,
@@ -509,11 +509,7 @@ def add_compute_plan(ctx, tuples, objective_key):
 
     """
     client = get_client(ctx.obj)
-    data = {
-        "objective_key": objective_key
-    }
-    data.update(tuples)
-    res = client.add_compute_plan(data)
+    res = client.add_compute_plan(tuples)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, is_list=False)
 
@@ -591,7 +587,6 @@ def add_composite_algo(ctx, data):
 
 
 @add.command('traintuple')
-@click.option('--objective-key', required=True)
 @click.option('--algo-key', required=True)
 @click.option('--dataset-key', required=True)
 @click.option('--data-samples-path', 'data_samples', required=True,
@@ -603,7 +598,7 @@ def add_composite_algo(ctx, data):
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_models_keys, tag):
+def add_traintuple(ctx, algo_key, dataset_key, data_samples, in_models_keys, tag):
     """Add traintuple.
 
     The option --data-samples-path must point to a valid JSON file with the
@@ -621,7 +616,6 @@ def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_m
     client = get_client(ctx.obj)
     data = {
         'algo_key': algo_key,
-        'objective_key': objective_key,
         'data_manager_key': dataset_key,
     }
 
@@ -639,7 +633,6 @@ def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_m
 
 
 @add.command('aggregatetuple')
-@click.option('--objective-key', required=True)
 @click.option('--algo-key', required=True)
 @click.option('--in-model-key', 'in_models_keys', type=click.STRING, multiple=True,
               help='In model traintuple key.')
@@ -649,12 +642,11 @@ def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_m
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_aggregatetuple(ctx, objective_key, algo_key, in_models_keys, worker, rank, tag):
+def add_aggregatetuple(ctx, algo_key, in_models_keys, worker, rank, tag):
     """Add aggregatetuple."""
     client = get_client(ctx.obj)
     data = {
         'algo_key': algo_key,
-        'objective_key': objective_key,
         'worker': worker,
     }
 
@@ -672,7 +664,6 @@ def add_aggregatetuple(ctx, objective_key, algo_key, in_models_keys, worker, ran
 
 
 @add.command('composite_traintuple')
-@click.option('--objective-key', required=True)
 @click.option('--algo-key', required=True)
 @click.option('--dataset-key', required=True)
 @click.option('--data-samples-path', 'data_samples', required=True,
@@ -690,8 +681,8 @@ def add_aggregatetuple(ctx, objective_key, algo_key, in_models_keys, worker, ran
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples,
-                             head_model_key, trunk_model_key, out_trunk_model_permissions, tag):
+def add_composite_traintuple(ctx, algo_key, dataset_key, data_samples, head_model_key,
+                             trunk_model_key, out_trunk_model_permissions, tag):
     """Add composite traintuple.
 
     The option --data-samples-path must point to a valid JSON file with the
@@ -727,7 +718,6 @@ def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_sam
     client = get_client(ctx.obj)
     data = {
         'algo_key': algo_key,
-        'objective_key': objective_key,
         'data_manager_key': dataset_key,
         'in_head_model_key': head_model_key,
         'in_trunk_model_key': trunk_model_key,
@@ -747,6 +737,7 @@ def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_sam
 
 
 @add.command('testtuple')
+@click.option('--objective-key', required=True)
 @click.option('--dataset-key')
 @click.option('--traintuple-key', required=True)
 @click.option('--data-samples-path', 'data_samples',
@@ -756,7 +747,7 @@ def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_sam
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag):
+def add_testtuple(ctx, objective_key, dataset_key, traintuple_key, data_samples, tag):
     """Add testtuple.
 
     The option --data-samples-path must point to a valid JSON file with the
@@ -773,6 +764,7 @@ def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag):
     """
     client = get_client(ctx.obj)
     data = {
+        'objective_key': objective_key,
         'data_manager_key': dataset_key,
         'traintuple_key': traintuple_key,
     }

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -237,14 +237,12 @@ class ComputePlanPrinter(AssetPrinter):
     key_field = Field('Compute plan ID', 'computePlanID')
 
     list_fields = (
-        Field('Objective key', 'objectiveKey'),
         CountField('Traintuples count', 'traintupleKeys'),
         CountField('Composite traintuples count', 'compositeTraintupleKeys'),
         CountField('Aggregatetuples count', 'aggregatetupleKeys'),
         CountField('Testtuples count', 'testtupleKeys'),
     )
     single_fields = (
-        Field('Objective key', 'objectiveKey'),
         KeysField('Traintuple keys', 'traintupleKeys'),
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
         KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
@@ -266,7 +264,9 @@ class ComputePlanPrinter(AssetPrinter):
         print(f'\tsubstra list aggregatetuple'
               f' -f "aggregatetuple:computePlanID:{key_value}" {profile_arg}')
 
-        # TODO add a command to display the related testtuples once testtuples have a computePlanID
+        print('\nDisplay this compute_plan\'s testtuples:')
+        print(f'\tsubstra list testtuples'
+              f' -f "testtuple:computePlanID:{key_value}" {profile_arg}')
 
 
 class AlgoPrinter(BaseAlgoPrinter):
@@ -338,7 +338,6 @@ class TraintuplePrinter(AssetPrinter):
     list_fields = (
         Field('Algo name', 'algo.name'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
@@ -347,9 +346,7 @@ class TraintuplePrinter(AssetPrinter):
         Field('Model key', 'outModel.hash'),
         Field('Algo key', 'algo.hash'),
         Field('Algo name', 'algo.name'),
-        Field('Objective key', 'objective.hash'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Dataset key', 'dataset.openerHash'),
         KeysField('Train data sample keys', 'dataset.keys'),
         InModelTraintupleKeysField('In model traintuple keys', 'inModels'),
@@ -370,7 +367,6 @@ class AggregateTuplePrinter(AssetPrinter):
     list_fields = (
         Field('Algo name', 'algo.name'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
@@ -379,9 +375,7 @@ class AggregateTuplePrinter(AssetPrinter):
         Field('Model key', 'outModel.hash'),
         Field('Algo key', 'algo.hash'),
         Field('Algo name', 'algo.name'),
-        Field('Objective key', 'objective.hash'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Dataset key', 'dataset.openerHash'),
         InModelTraintupleKeysField('In model keys', 'inModels'),
         Field('Rank', 'rank'),
@@ -401,7 +395,6 @@ class CompositeTraintuplePrinter(AssetPrinter):
     list_fields = (
         Field('Composite algo name', 'algo.name'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Compute Plan Id', 'computePlanID'),
@@ -414,9 +407,7 @@ class CompositeTraintuplePrinter(AssetPrinter):
         PermissionField('Out trunk model permissions', 'outTrunkModel.permissions'),
         Field('Composite algo key', 'algo.hash'),
         Field('Composite algo name', 'algo.name'),
-        Field('Objective key', 'objective.hash'),
         Field('Status', 'status'),
-        Field('Perf', 'dataset.perf'),
         Field('Dataset key', 'dataset.openerHash'),
         KeysField('Train data sample keys', 'dataset.keys'),
         Field('In head model key', 'inHeadModelKey'),
@@ -439,7 +430,9 @@ class TesttuplePrinter(AssetPrinter):
         Field('Certified', 'certified'),
         Field('Status', 'status'),
         Field('Perf', 'dataset.perf'),
+        Field('Rank', 'rank'),
         Field('Tag', 'tag'),
+        Field('Compute Plan Id', 'computePlanID'),
     )
     single_fields = (
         Field('Traintuple key', 'traintupleKey'),
@@ -452,7 +445,9 @@ class TesttuplePrinter(AssetPrinter):
         Field('Perf', 'dataset.perf'),
         Field('Dataset key', 'dataset.openerHash'),
         KeysField('Test data sample keys', 'dataset.keys'),
+        Field('Rank', 'rank'),
         Field('Tag', 'tag'),
+        Field('Compute Plan Id', 'computePlanID'),
         Field('Log', 'log'),
         Field('Creator', 'creator'),
         Field('Worker', 'dataset.worker'),

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -405,11 +405,11 @@ class Client(object):
 ```
         {
             "algo_key": str,
-            "objective_key": str,
             "data_manager_key": str,
             "train_data_sample_keys": list[str],
             "in_models_keys": list[str],
             "tag": str,
+            "rank": int,
             "compute_plan_id": str,
         }
 ```
@@ -429,7 +429,6 @@ class Client(object):
 ```
         {
             "algo_key": str,
-            "objective_key": str,
             "in_models_keys": list[str],
             "tag": str,
             "compute_plan_id": str,
@@ -453,7 +452,6 @@ class Client(object):
 ```
         {
             "algo_key": str,
-            "objective_key": str,
             "data_manager_key": str,
             "in_head_model_key": str,
             "in_trunk_model_key": str,
@@ -461,6 +459,7 @@ class Client(object):
                 "authorized_ids": list[str],
             },
             "tag": str,
+            "rank": int,
             "compute_plan_id": str,
         }
 ```
@@ -481,10 +480,12 @@ class Client(object):
 
 ```
         {
+            "objective_key": str,
             "data_manager_key": str,
             "traintuple_key": str,
             "test_data_sample_keys": list[str],
             "tag": str,
+            "rank": int,
             "compute_plan_id": str,
         }
 ```
@@ -505,7 +506,6 @@ class Client(object):
 
 ```
         {
-            "objective_key": str,
             "traintuples": list[{
                 "algo_key": str,
                 "data_manager_key": str,
@@ -532,6 +532,7 @@ class Client(object):
                 "tag": str,
             }],
             "testtuples": list[{
+                "objective_key": str,
                 "data_manager_key": str,
                 "test_data_sample_keys": list[str],
                 "testtuple_id": str,

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -485,8 +485,6 @@ class Client(object):
             "traintuple_key": str,
             "test_data_sample_keys": list[str],
             "tag": str,
-            "rank": int,
-            "compute_plan_id": str,
         }
 ```
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,16 +124,15 @@ def test_command_list_node(workdir, mocker):
     ('algo', []),
     ('aggregate_algo', []),
     ('composite_algo', []),
-    ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
+    ('traintuple', ['--algo-key', 'foo', '--dataset-key', 'foo',
                     '--data-samples-path']),
-    ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
+    ('traintuple', ['--algo-key', 'foo', '--dataset-key', 'foo',
                     '--in-model-key', 'foo', '--data-samples-path']),
-    ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
+    ('traintuple', ['--algo-key', 'foo', '--dataset-key', 'foo',
                     '--in-model-key', 'foo', '--in-model-key', 'bar', '--data-samples-path']),
-    ('testtuple', ['--traintuple-key', 'foo', '--data-samples-path']),
-    ('compute_plan', ['--objective-key', 'foo']),
-    ('composite_traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
-                              '--data-samples-path']),
+    ('testtuple', ['--objective-key', 'foo', '--traintuple-key', 'foo', '--data-samples-path']),
+    ('compute_plan', []),
+    ('composite_traintuple', ['--algo-key', 'foo', '--dataset-key', 'foo', '--data-samples-path']),
 ])
 def test_command_add(asset_name, params, workdir, mocker):
     method_name = f'add_{asset_name}'
@@ -200,7 +199,7 @@ def test_command_add_composite_traintuple(mocker, workdir, params, message, exit
     with mock_client_call(mocker, 'add_composite_traintuple', response={}) as m:
         json_file = workdir / "valid_json_file.json"
         json_file.write_text(json.dumps({}))
-        res = client_execute(workdir, ['add', 'composite_traintuple', '--objective-key', 'foo',
+        res = client_execute(workdir, ['add', 'composite_traintuple',
                                        '--algo-key', 'foo', '--dataset-key', 'foo'] + params +
                              ['--data-samples-path', str(json_file)], exit_code=exit_code)
         assert re.search(message, res)
@@ -209,7 +208,7 @@ def test_command_add_composite_traintuple(mocker, workdir, params, message, exit
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):
     m = mock_client_call(mocker, 'add_testtuple', response={})
-    client_execute(workdir, ['add', 'testtuple', '--traintuple-key', 'foo'])
+    client_execute(workdir, ['add', 'testtuple', '--objective-key', 'foo', '--traintuple-key', 'foo'])
     assert m.is_called()
 
 
@@ -230,10 +229,10 @@ def test_command_add_data_sample(workdir, mocker):
 @pytest.mark.parametrize('asset_name, params', [
     ('dataset', []),
     ('algo', []),
-    ('traintuple', ['--objective-key', 'foo', '--algo-key', 'foo', '--dataset-key', 'foo',
+    ('traintuple', ['--algo-key', 'foo', '--dataset-key', 'foo',
                     '--data-samples-path']),
-    ('testtuple', ['--traintuple-key', 'foo', '--data-samples-path']),
-    ('compute_plan', ['--objective-key', 'foo']),
+    ('testtuple', ['--objective-key', 'foo', '--traintuple-key', 'foo', '--data-samples-path']),
+    ('compute_plan', []),
     ('objective', []),
 ])
 def test_command_add_already_exists(workdir, mocker, asset_name, params):


### PR DESCRIPTION
Companion PR: [backend](https://github.com/SubstraFoundation/substra-backend/pull/63)

- Removes the objective key from traintuples, aggregatetuples, composite traintuples and compute plans.
- Requires objective key in testtuples.
- Misc fixes regarding the printers following the structure change (adding rank everywhere, removing perf from train like tuples)