### PR TITLE
Avoid KeyError when keys are missing in the data_samples file

### DIFF
--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -416,7 +416,7 @@ def add_objective(ctx, data, dataset_key, data_samples):
         data['test_data_manager_key'] = dataset_key
 
     if data_samples:
-        data['test_data_sample_keys'] = data_samples['keys']
+        data['test_data_sample_keys'] = data_samples.get('keys', None)
 
     res = client.add_objective(data)
     printer = printers.get_asset_printer(assets.OBJECTIVE, ctx.obj.output_format)
@@ -626,7 +626,7 @@ def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_m
     }
 
     if data_samples:
-        data['train_data_sample_keys'] = data_samples['keys']
+        data['train_data_sample_keys'] = data_samples.get('keys', None)
 
     if tag:
         data['tag'] = tag
@@ -734,7 +734,7 @@ def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_sam
     }
 
     if data_samples:
-        data['train_data_sample_keys'] = data_samples['keys']
+        data['train_data_sample_keys'] = data_samples.get('keys', None)
 
     if out_trunk_model_permissions:
         data['out_trunk_model_permissions'] = out_trunk_model_permissions
@@ -778,7 +778,7 @@ def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag):
     }
 
     if data_samples:
-        data['test_data_sample_keys'] = data_samples['keys']
+        data['test_data_sample_keys'] = data_samples.get('keys', None)
 
     if tag:
         data['tag'] = tag
@@ -1068,7 +1068,7 @@ def update_data_sample(ctx, data_samples, dataset_key):
     - keys: list of data sample keys
     """
     client = get_client(ctx.obj)
-    res = client.link_dataset_with_data_samples(dataset_key, data_samples['keys'])
+    res = client.link_dataset_with_data_samples(dataset_key, data_samples.get('keys', None))
     display(res)
 
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -196,6 +196,14 @@ def validate_json(ctx, param, value):
     return data
 
 
+def load_data_samples_keys(data_samples):
+    try:
+        return data_samples['keys']
+    except KeyError:
+        raise click.ClickException('The file specified for the \'--data-samples-path\' option must '
+                                   'contains a \'keys\' attribute')
+
+
 def error_printer(fn):
     """Command decorator to pretty print a few selected exceptions from sdk."""
     @functools.wraps(fn)
@@ -416,7 +424,7 @@ def add_objective(ctx, data, dataset_key, data_samples):
         data['test_data_manager_key'] = dataset_key
 
     if data_samples:
-        data['test_data_sample_keys'] = data_samples.get('keys', None)
+        data['test_data_sample_keys'] = load_data_samples_keys(data_samples)
 
     res = client.add_objective(data)
     printer = printers.get_asset_printer(assets.OBJECTIVE, ctx.obj.output_format)
@@ -626,7 +634,7 @@ def add_traintuple(ctx, objective_key, algo_key, dataset_key, data_samples, in_m
     }
 
     if data_samples:
-        data['train_data_sample_keys'] = data_samples.get('keys', None)
+        data['train_data_sample_keys'] = load_data_samples_keys(data_samples)
 
     if tag:
         data['tag'] = tag
@@ -734,7 +742,7 @@ def add_composite_traintuple(ctx, objective_key, algo_key, dataset_key, data_sam
     }
 
     if data_samples:
-        data['train_data_sample_keys'] = data_samples.get('keys', None)
+        data['train_data_sample_keys'] = load_data_samples_keys(data_samples)
 
     if out_trunk_model_permissions:
         data['out_trunk_model_permissions'] = out_trunk_model_permissions
@@ -778,7 +786,7 @@ def add_testtuple(ctx, dataset_key, traintuple_key, data_samples, tag):
     }
 
     if data_samples:
-        data['test_data_sample_keys'] = data_samples.get('keys', None)
+        data['test_data_sample_keys'] = load_data_samples_keys(data_samples)
 
     if tag:
         data['tag'] = tag
@@ -1068,7 +1076,7 @@ def update_data_sample(ctx, data_samples, dataset_key):
     - keys: list of data sample keys
     """
     client = get_client(ctx.obj)
-    res = client.link_dataset_with_data_samples(dataset_key, data_samples.get('keys', None))
+    res = client.link_dataset_with_data_samples(dataset_key, load_data_samples_keys(data_samples))
     display(res)
 
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -200,8 +200,8 @@ def load_data_samples_keys(data_samples, option="--data-samples-path"):
     try:
         return data_samples['keys']
     except KeyError:
-        raise click.ClickException(f'The file specified for \'{option}\' must contains a \'keys\' '
-                                   f'attribute')
+        raise click.BadParameter('The file specified must contain a \'keys\' attribute',
+                                 param_hint=option)
 
 
 def error_printer(fn):

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -196,12 +196,12 @@ def validate_json(ctx, param, value):
     return data
 
 
-def load_data_samples_keys(data_samples):
+def load_data_samples_keys(data_samples, option="--data-samples-path"):
     try:
         return data_samples['keys']
     except KeyError:
-        raise click.ClickException('The file specified for the \'--data-samples-path\' option must '
-                                   'contains a \'keys\' attribute')
+        raise click.ClickException(f'The file specified for \'{option}\' must contains a \'keys\' '
+                                   f'attribute')
 
 
 def error_printer(fn):
@@ -1076,7 +1076,8 @@ def update_data_sample(ctx, data_samples, dataset_key):
     - keys: list of data sample keys
     """
     client = get_client(ctx.obj)
-    res = client.link_dataset_with_data_samples(dataset_key, load_data_samples_keys(data_samples))
+    res = client.link_dataset_with_data_samples(
+        dataset_key, load_data_samples_keys(data_samples, option="data_samples"))
     display(res)
 
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -200,8 +200,7 @@ def load_data_samples_keys(data_samples, option="--data-samples-path"):
     try:
         return data_samples['keys']
     except KeyError:
-        raise click.BadParameter('The file specified must contain a \'keys\' attribute',
-                                 param_hint=option)
+        raise click.BadParameter(f'File must contain a "keys" attribute.', param_hint=f'"{option}"')
 
 
 def error_printer(fn):
@@ -1077,7 +1076,7 @@ def update_data_sample(ctx, data_samples, dataset_key):
     """
     client = get_client(ctx.obj)
     res = client.link_dataset_with_data_samples(
-        dataset_key, load_data_samples_keys(data_samples, option="data_samples"))
+        dataset_key, load_data_samples_keys(data_samples, option="DATA_SAMPLES_PATH"))
     display(res)
 
 


### PR DESCRIPTION
Currently, when the `keys` attribute is missing in the data_samples file we try to use, an error is raised and a full traceback is returned.
The commands impacted are the followings:
- add_objective
- add_traintuple
- add_composite_traintuple
- add_testtuple
- update_data_sample


🔗 Related issue: #50 