### PR TITLE
New cancel compute_plan command

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -19,6 +19,7 @@
 - [substra download](#substra-download)
 - [substra leaderboard](#substra-leaderboard)
 - [substra run-local](#substra-run-local)
+- [substra cancel compute_plan](#substra-cancel-compute_plan)
 - [substra update data_sample](#substra-update-data_sample)
 - [substra update dataset](#substra-update-dataset)
 
@@ -626,6 +627,24 @@ Options:
   --fake-data-samples             use fake data samples during both training
                                   and testing.
   --help                          Show this message and exit.
+```
+
+## substra cancel compute_plan
+
+```bash
+Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_ID
+
+  Cancel execution of a compute plan.
+
+Options:
+  --config PATH   Config path (default ~/.substra).
+  --profile TEXT  Profile name to use.
+  --user FILE     User file path to use (default ~/.substra-user).
+  --verbose       Enable verbose mode.
+  --yaml          Display output as yaml.
+  --json          Display output as json.
+  --pretty        Pretty print output  [default: True]
+  --help          Show this message and exit.
 ```
 
 ## substra update data_sample

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -540,3 +540,8 @@ Get objective description.
 Client.leaderboard(self, objective_key, sort='desc')
 ```
 Get objective leaderboard
+## cancel_compute_plan
+```python
+Client.cancel_compute_plan(self, compute_plan_id)
+```
+Cancel execution of compute plan.

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1046,7 +1046,7 @@ def cancel_compute_plan(ctx, compute_plan_id):
     client = get_client(ctx.obj)
     # method must exist in sdk
     res = client.cancel_compute_plan(compute_plan_id)
-    printer = printers.get_asset_printer(compute_plan_id, ctx.obj.output_format)
+    printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, profile=ctx.obj.profile)
 
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1032,6 +1032,26 @@ def run_local(algo, train_opener, test_opener, metrics, rank,
 
 @cli.group()
 @click.pass_context
+def cancel(ctx):
+    """Cancel execution of an asset."""
+    pass
+
+
+@cancel.command('compute_plan')
+@click.argument('compute_plan_id', type=click.STRING)
+@click_global_conf_with_output_format
+@click.pass_context
+def cancel_compute_plan(ctx, compute_plan_id):
+    """Cancel execution of a compute plan."""
+    client = get_client(ctx.obj)
+    # method must exist in sdk
+    res = client.cancel_compute_plan(compute_plan_id)
+    printer = printers.get_asset_printer(compute_plan_id, ctx.obj.output_format)
+    printer.print(res, profile=ctx.obj.profile)
+
+
+@cli.group()
+@click.pass_context
 def update(ctx):
     """Update asset."""
     pass

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -248,7 +248,7 @@ class ComputePlanPrinter(AssetPrinter):
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
         KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
         KeysField('Testtuple keys', 'testtupleKeys'),
-        KeysField('Status', 'status'),
+        Field('Status', 'status'),
     )
 
     def print_messages(self, item, profile=None):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -241,12 +241,14 @@ class ComputePlanPrinter(AssetPrinter):
         CountField('Composite traintuples count', 'compositeTraintupleKeys'),
         CountField('Aggregatetuples count', 'aggregatetupleKeys'),
         CountField('Testtuples count', 'testtupleKeys'),
+        Field('Status', 'status'),
     )
     single_fields = (
         KeysField('Traintuple keys', 'traintupleKeys'),
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
         KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
         KeysField('Testtuple keys', 'testtupleKeys'),
+        KeysField('Status', 'status'),
     )
 
     def print_messages(self, item, profile=None):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -771,3 +771,11 @@ class Client(object):
         """Get objective leaderboard"""
         return self.client.request('get', assets.OBJECTIVE, f'{objective_key}/leaderboard',
                                    params={'sort': sort})
+
+    def cancel_compute_plan(self, compute_plan_id):
+        """Cancel execution of compute plan."""
+        return self.client.request(
+            'post',
+            assets.COMPUTE_PLAN,
+            path=f"{compute_plan_id}/cancel",
+        )

--- a/tests/sdk/test_cancel.py
+++ b/tests/sdk/test_cancel.py
@@ -1,0 +1,25 @@
+# Copyright 2018 Owkin, inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import datastore
+from .utils import mock_requests
+
+
+def test_cancel_compute_plan(client, mocker):
+    m = mock_requests(mocker, "post", response=datastore.COMPUTE_PLAN)
+
+    response = client.cancel_compute_plan("magic-key")
+
+    assert response == datastore.COMPUTE_PLAN
+    assert m.is_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,6 +293,12 @@ def test_command_download(workdir, mocker):
     assert m.is_called()
 
 
+def test_command_cancel_compute_plan(workdir, mocker):
+    m = mock_client_call(mocker, 'cancel_compute_plan')
+    client_execute(workdir, ['cancel', 'compute_plan', 'fakekey'])
+    assert m.is_called()
+
+
 def test_command_update_dataset(workdir, mocker):
     m = mock_client_call(mocker, 'update_dataset')
     client_execute(workdir, ['update', 'dataset', 'key1', 'key2'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -208,7 +208,8 @@ def test_command_add_composite_traintuple(mocker, workdir, params, message, exit
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):
     m = mock_client_call(mocker, 'add_testtuple', response={})
-    client_execute(workdir, ['add', 'testtuple', '--objective-key', 'foo', '--traintuple-key', 'foo'])
+    client_execute(workdir, ['add', 'testtuple', '--objective-key', 'foo',
+                             '--traintuple-key', 'foo'])
     assert m.is_called()
 
 
@@ -294,7 +295,7 @@ def test_command_download(workdir, mocker):
 
 
 def test_command_cancel_compute_plan(workdir, mocker):
-    m = mock_client_call(mocker, 'cancel_compute_plan')
+    m = mock_client_call(mocker, 'cancel_compute_plan', datastore.COMPUTE_PLAN)
     client_execute(workdir, ['cancel', 'compute_plan', 'fakekey'])
     assert m.is_called()
 


### PR DESCRIPTION
In link with the "fail fast" mission, we need to have in both the CLI and SDK cancel compute plan commands / methods.

🔗 Related issue: #55 

Companion PR:
- [tests](https://github.com/SubstraFoundation/substra-tests/pull/26)
- [backend](https://github.com/SubstraFoundation/substra-backend/pull/65)
- [chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/53)
- [frontend](https://github.com/SubstraFoundation/substra-frontend/pull/33)