### PR TITLE
Rename leaderboard variable in substra/cli/interface.py::leaderboard

### DIFF
--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -949,9 +949,9 @@ def download(ctx, asset_name, key, folder):
 def leaderboard(ctx, expand, objective_key, sort):
     """Display objective leaderboard"""
     client = get_client(ctx.obj)
-    leaderboard = client.leaderboard(objective_key, sort=sort)
+    board = client.leaderboard(objective_key, sort=sort)
     printer = printers.get_leaderboard_printer(ctx.obj.output_format)
-    printer.print(leaderboard, expand=expand)
+    printer.print(board, expand=expand)
 
 
 @cli.command()


### PR DESCRIPTION
As specified in this issue (#59), it could be good to rename the `leaderboard` variable in `substra/cli/interface.py::leaderboard`, because it's already defined before and may cause issues.

🔗 Related issue: #59 