### PR TITLE
Add debug for CLI's tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@
 import json
 import re
 from unittest import mock
+import traceback
 
 import click
 from click.testing import CliRunner
@@ -36,15 +37,12 @@ def workdir(tmp_path):
 def execute(command, exit_code=0):
     runner = CliRunner()
     result = runner.invoke(cli, command)
-    if result.exception:
-        import traceback
-        print('# Command: ', command)
-        print('# Exception: ', result.exception)
-        print('# Exit code: ', result.exit_code)
+    debugging = result.output
+    if exit_code == 0 and result.exit_code != 0 and result.exc_info:
         _, _, tb = result.exc_info
-        print('# Traceback: ', traceback.print_tb(tb))
-    assert result.exit_code == exit_code, result.output
-    return result.output
+        debugging = traceback.print_tb(tb)
+    assert result.exit_code == exit_code, debugging
+    return debugging
 
 
 def client_execute(directory, command, exit_code=0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@
 
 import json
 import re
+import sys
 from unittest import mock
 import traceback
 
@@ -37,12 +38,12 @@ def workdir(tmp_path):
 def execute(command, exit_code=0):
     runner = CliRunner()
     result = runner.invoke(cli, command)
-    debugging = result.output
     if exit_code == 0 and result.exit_code != 0 and result.exc_info:
         _, _, tb = result.exc_info
-        debugging = traceback.print_tb(tb)
-    assert result.exit_code == exit_code, debugging
-    return debugging
+        traceback.print_tb(tb, file=sys.stdout)
+        pytest.fail(str(result.exception))
+    assert result.exit_code == exit_code, result.output
+    return result.output
 
 
 def client_execute(directory, command, exit_code=0):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,8 @@ def execute(command, exit_code=0):
     runner = CliRunner()
     result = runner.invoke(cli, command)
     if exit_code == 0 and result.exit_code != 0 and result.exc_info:
+        # if the test was supposed to succeed but failed,
+        # we display the exception and the full traceback
         _, _, tb = result.exc_info
         traceback.print_tb(tb, file=sys.stdout)
         pytest.fail(str(result.exception))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,13 @@ def workdir(tmp_path):
 def execute(command, exit_code=0):
     runner = CliRunner()
     result = runner.invoke(cli, command)
+    if result.exception:
+        import traceback
+        print('# Command: ', command)
+        print('# Exception: ', result.exception)
+        print('# Exit code: ', result.exit_code)
+        _, _, tb = result.exc_info
+        print('# Traceback: ', traceback.print_tb(tb))
     assert result.exit_code == exit_code, result.output
     return result.output
 


### PR DESCRIPTION
As specified in the related issue, this is sometimes hard to debug the CLI.
It could be good to add some information when a test crashes.
For instance, the full traceback, the exc_code, etc.

🔗 Related issue: #58 