### PR TITLE
doc: add missing rank attribute for add_traintuple method

### DIFF
--- a/references/sdk.md
+++ b/references/sdk.md
@@ -220,6 +220,7 @@ Create new traintuple asset.
     "train_data_sample_keys": list[str],
     "in_models_keys": list[str],
     "tag": str,
+    "rank": int,
     "compute_plan_id": str,
 }
 ```
@@ -264,6 +265,7 @@ Create new composite traintuple asset.
         "authorized_ids": list[str],
     },
     "tag": str,
+    "rank": int,
     "compute_plan_id": str,
 }
 ```

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -410,6 +410,7 @@ class Client(object):
             "train_data_sample_keys": list[str],
             "in_models_keys": list[str],
             "tag": str,
+            "rank": int,
             "compute_plan_id": str,
         }
 ```
@@ -461,6 +462,7 @@ class Client(object):
                 "authorized_ids": list[str],
             },
             "tag": str,
+            "rank": int,
             "compute_plan_id": str,
         }
 ```


### PR DESCRIPTION
This issue has been reported by @camillemarini and @jmorel.
It has been also fixed in the PR #52 that is currently under review. 

For bug fixes we should try to create independent PRs. It will allow to review them faster and then to merge them faster.