### PR TITLE
add server gateway (bad, timout, unavailable) errors support and retry

### DIFF
--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -58,6 +58,10 @@ class InternalServerError(HTTPError):
     pass
 
 
+class GatewayTimeout(HTTPError):
+    pass
+
+
 class InvalidRequest(HTTPError):
     @classmethod
     def from_request_exception(cls, request_exception):

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -58,7 +58,7 @@ class InternalServerError(HTTPError):
     pass
 
 
-class GatewayTimeout(HTTPError):
+class GatewayUnavailable(HTTPError):
     pass
 
 

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -134,10 +134,14 @@ class Client():
             if e.response.status_code == 500:
                 raise exceptions.InternalServerError.from_request_exception(e)
 
+            if e.response.status_code in [502, 503, 504]:
+                raise exceptions.GatewayTimeout.from_request_exception(e)
+
             raise exceptions.HTTPError.from_request_exception(e)
 
         return r
 
+    @utils.retry_on_exception(exceptions=(exceptions.GatewayTimeout))
     def request(self, request_name, asset_name, path=None, json_response=True,
                 **request_kwargs):
         """Base request."""

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -135,13 +135,13 @@ class Client():
                 raise exceptions.InternalServerError.from_request_exception(e)
 
             if e.response.status_code in [502, 503, 504]:
-                raise exceptions.GatewayTimeout.from_request_exception(e)
+                raise exceptions.GatewayUnavailable.from_request_exception(e)
 
             raise exceptions.HTTPError.from_request_exception(e)
 
         return r
 
-    @utils.retry_on_exception(exceptions=(exceptions.GatewayTimeout))
+    @utils.retry_on_exception(exceptions=(exceptions.GatewayUnavailable))
     def request(self, request_name, asset_name, path=None, json_response=True,
                 **request_kwargs):
         """Base request."""

--- a/substra/sdk/utils.py
+++ b/substra/sdk/utils.py
@@ -156,7 +156,7 @@ def parse_filters(filters):
     return 'search=%s' % quote(''.join(filters))
 
 
-def retry_on_exception(exceptions, timeout=False):
+def retry_on_exception(exceptions, timeout=300):
     """Retry function in case of exception(s)."""
     def _retry(f):
         @functools.wraps(f)


### PR DESCRIPTION
This PR aims to be resilient to backend bad gateway errors, that could happen if server is restarting or down for a short time.

Having a retry mechanism will allow not stoping the current script if the server is temporarily unavailable.