### PR TITLE
Replace is_called() by assert_called() in tests

### DIFF
--- a/tests/sdk/test_add.py
+++ b/tests/sdk/test_add.py
@@ -25,8 +25,8 @@ def test_add_dataset(client, dataset_query, mocker):
     response = client.add_dataset(dataset_query)
 
     assert response == datastore.DATASET
-    assert m_post.is_called()
-    assert m_get.is_called()
+    m_post.assert_called()
+    m_get.assert_called()
 
 
 def test_add_dataset_invalid_args(client, dataset_query, mocker):
@@ -59,8 +59,8 @@ def test_add_objective(client, objective_query, mocker):
     response = client.add_objective(objective_query)
 
     assert response == datastore.OBJECTIVE
-    assert m_post.is_called()
-    assert m_get.is_called()
+    m_post.assert_called()
+    m_get.assert_called()
 
 
 def test_add_algo(client, algo_query, mocker):
@@ -69,8 +69,8 @@ def test_add_algo(client, algo_query, mocker):
     response = client.add_algo(algo_query)
 
     assert response == datastore.ALGO
-    assert m_post.is_called()
-    assert m_get.is_called()
+    m_post.assert_called()
+    m_get.assert_called()
 
 
 def test_add_aggregate_algo(client, algo_query, mocker):
@@ -79,8 +79,8 @@ def test_add_aggregate_algo(client, algo_query, mocker):
     response = client.add_aggregate_algo(algo_query)
 
     assert response == datastore.AGGREGATE_ALGO
-    assert m_post.is_called()
-    assert m_get.is_called()
+    m_post.assert_called()
+    m_get.assert_called()
 
 
 def test_add_composite_algo(client, algo_query, mocker):
@@ -89,8 +89,8 @@ def test_add_composite_algo(client, algo_query, mocker):
     response = client.add_composite_algo(algo_query)
 
     assert response == datastore.COMPOSITE_ALGO
-    assert m_post.is_called()
-    assert m_get.is_called()
+    m_post.assert_called()
+    m_get.assert_called()
 
 
 def test_add_data_sample(client, data_sample_query, mocker):
@@ -99,7 +99,7 @@ def test_add_data_sample(client, data_sample_query, mocker):
     response = client.add_data_sample(data_sample_query)
 
     assert response == server_response[0]
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_add_data_sample_already_exists(client, data_sample_query, mocker):
@@ -107,7 +107,7 @@ def test_add_data_sample_already_exists(client, data_sample_query, mocker):
     response = client.add_data_sample(data_sample_query, exist_ok=True)
 
     assert response == {"pkhash": "42"}
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_add_data_samples(client, data_samples_query, mocker):
@@ -116,4 +116,4 @@ def test_add_data_samples(client, data_samples_query, mocker):
     response = client.add_data_samples(data_samples_query)
 
     assert response == server_response
-    assert m.is_called()
+    m.assert_called()

--- a/tests/sdk/test_cancel.py
+++ b/tests/sdk/test_cancel.py
@@ -22,4 +22,4 @@ def test_cancel_compute_plan(client, mocker):
     response = client.cancel_compute_plan("magic-key")
 
     assert response == datastore.COMPUTE_PLAN
-    assert m.is_called()
+    m.assert_called()

--- a/tests/sdk/test_describe.py
+++ b/tests/sdk/test_describe.py
@@ -36,7 +36,7 @@ def test_describe_asset(asset_name, client, mocker):
     response = method("magic-key")
 
     assert response == 'foo'
-    assert m.is_called()
+    m.assert_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -44,7 +44,7 @@ def test_download_asset(asset_name, filename, tmp_path, client, mocker):
 
     temp_file = str(tmp_path) + '/' + filename
     assert os.path.exists(temp_file)
-    assert m.is_called()
+    m.assert_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/test_get.py
+++ b/tests/sdk/test_get.py
@@ -40,7 +40,7 @@ def test_get_asset(asset_name, client, mocker):
     response = method("magic-key")
 
     assert response == item
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_get_asset_not_found(client, mocker):

--- a/tests/sdk/test_leaderboard.py
+++ b/tests/sdk/test_leaderboard.py
@@ -27,7 +27,7 @@ def test_leaderboard(client, mocker):
     response = client.leaderboard("magic-key")
 
     assert response == item
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_leaderboard_not_found(client, mocker):

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -39,7 +39,7 @@ def test_list_asset(asset_name, client, mocker):
     response = method()
 
     assert response == [item]
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_list_asset_flatten(client, mocker):
@@ -49,7 +49,7 @@ def test_list_asset_flatten(client, mocker):
     response = client.list_algo()
 
     assert response == items
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_list_asset_with_filters(client, mocker):
@@ -60,7 +60,7 @@ def test_list_asset_with_filters(client, mocker):
     response = client.list_algo(filters)
 
     assert response == items
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_list_asset_with_filters_failure(client, mocker):
@@ -71,5 +71,5 @@ def test_list_asset_with_filters_failure(client, mocker):
     with pytest.raises(ValueError) as exc_info:
         client.list_algo(filters)
 
-    assert m.is_called()
+    m.assert_not_called()
     assert str(exc_info.value).startswith("Cannot load filters")

--- a/tests/sdk/test_update.py
+++ b/tests/sdk/test_update.py
@@ -25,4 +25,4 @@ def test_update_dataset(client, mocker):
         {'objective_key': 'an another key', })
 
     assert response == item
-    assert m.is_called()
+    m.assert_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,14 +215,12 @@ def test_command_add_composite_traintuple(mocker, workdir, params):
     (['--trunk-model-key', 'e'], r'The --head-model-key option is required')
 ])
 def test_command_add_composite_traintuple_missing_model_key(mocker, workdir, params, message):
-    m = mock_client_call(mocker, 'add_composite_traintuple', response={})
     json_file = workdir / "valid_json_file.json"
     json_file.write_text(json.dumps({}))
     res = client_execute(workdir, ['add', 'composite_traintuple', '--algo-key', 'foo',
                                    '--dataset-key', 'foo', '--data-samples-path', str(json_file)]
                          + params, exit_code=2)
     assert re.search(message, res)
-    m.assert_not_called()
 
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,7 +115,7 @@ def test_command_list(asset_name, key_field, workdir, mocker):
     method_name = f'list_{asset_name}'
     m = mock_client_call(mocker, method_name, [item])
     output = client_execute(workdir, ['list', asset_name])
-    assert m.is_called()
+    m.assert_called()
     assert item[key_field] in output
 
 
@@ -149,7 +149,7 @@ def test_command_add(asset_name, params, workdir, mocker):
     json_file = workdir / "valid_json_file.json"
     json_file.write_text(json.dumps({}))
     client_execute(workdir, ['add', asset_name] + params + [str(json_file)])
-    assert m.is_called()
+    m.assert_called()
 
     invalid_json_file = workdir / "invalid_json_file.txt"
     invalid_json_file.write_text("foo")
@@ -170,11 +170,11 @@ def test_command_add_objective(workdir, mocker):
     m = mock_client_call(mocker, 'add_objective', response={})
     client_execute(workdir, ['add', 'objective', str(json_file), '--dataset-key', 'foo',
                              '--data-samples-path', str(json_file)])
-    assert m.is_called()
+    m.assert_called()
 
     m = mock_client_call(mocker, 'add_objective', response={})
     client_execute(workdir, ['add', 'objective', str(json_file)])
-    assert m.is_called()
+    m.assert_called()
 
     res = client_execute(workdir, ['add', 'objective', 'non_existing_file.txt', '--dataset-key',
                                    'foo', '--data-samples-path', str(json_file)], exit_code=2)
@@ -204,21 +204,20 @@ def test_command_add_objective(workdir, mocker):
     (['--trunk-model-key', 'e'], r'The --head-model-key option is required', 2)
 ])
 def test_command_add_composite_traintuple(mocker, workdir, params, message, exit_code):
-    with mock_client_call(mocker, 'add_composite_traintuple', response={}) as m:
+    with mock_client_call(mocker, 'add_composite_traintuple', response={}):
         json_file = workdir / "valid_json_file.json"
         json_file.write_text(json.dumps({}))
         res = client_execute(workdir, ['add', 'composite_traintuple',
                                        '--algo-key', 'foo', '--dataset-key', 'foo'] + params +
                              ['--data-samples-path', str(json_file)], exit_code=exit_code)
         assert re.search(message, res)
-    assert m.is_called()
 
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):
     m = mock_client_call(mocker, 'add_testtuple', response={})
     client_execute(workdir, ['add', 'testtuple', '--objective-key', 'foo',
                              '--traintuple-key', 'foo'])
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_command_add_data_sample(workdir, mocker):
@@ -228,7 +227,7 @@ def test_command_add_data_sample(workdir, mocker):
     m = mock_client_call(mocker, 'add_data_samples')
     client_execute(workdir, ['add', 'data_sample', str(temp_dir), '--dataset-key', 'foo',
                              '--test-only'])
-    assert m.is_called()
+    m.assert_called()
 
     res = client_execute(workdir, ['add', 'data_sample', 'dir', '--dataset-key', 'foo'],
                          exit_code=2)
@@ -253,7 +252,7 @@ def test_command_add_already_exists(workdir, mocker, asset_name, params):
                             exit_code=1)
 
     assert 'already exists' in output
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_command_add_data_sample_already_exists(workdir, mocker):
@@ -264,7 +263,7 @@ def test_command_add_data_sample_already_exists(workdir, mocker):
     output = client_execute(workdir, ['add', 'data_sample', str(temp_dir), '--dataset-key', 'foo'],
                             exit_code=1)
     assert 'already exists' in output
-    assert m.is_called()
+    m.assert_called()
 
 
 @pytest.mark.parametrize('asset_name,key_field', [
@@ -284,7 +283,7 @@ def test_command_get(asset_name, key_field, workdir, mocker):
     method_name = f'get_{asset_name}'
     m = mock_client_call(mocker, method_name, item)
     output = client_execute(workdir, ['get', asset_name, 'fakekey'])
-    assert m.is_called()
+    m.assert_called()
     assert item[key_field] in output
 
 
@@ -292,26 +291,26 @@ def test_command_describe(workdir, mocker):
     response = "My description."
     m = mock_client_call(mocker, 'describe_objective', response)
     output = client_execute(workdir, ['describe', 'objective', 'fakekey'])
-    assert m.is_called()
+    m.assert_called()
     assert response in output
 
 
 def test_command_download(workdir, mocker):
     m = mock_client_call(mocker, 'download_objective')
     client_execute(workdir, ['download', 'objective', 'fakekey'])
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_command_cancel_compute_plan(workdir, mocker):
     m = mock_client_call(mocker, 'cancel_compute_plan', datastore.COMPUTE_PLAN)
     client_execute(workdir, ['cancel', 'compute_plan', 'fakekey'])
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_command_update_dataset(workdir, mocker):
     m = mock_client_call(mocker, 'update_dataset')
     client_execute(workdir, ['update', 'dataset', 'key1', 'key2'])
-    assert m.is_called()
+    m.assert_called()
 
 
 def test_command_update_data_sample(workdir, mocker):
@@ -324,7 +323,7 @@ def test_command_update_data_sample(workdir, mocker):
 
     m = mock_client_call(mocker, 'link_dataset_with_data_samples')
     client_execute(workdir, ['update', 'data_sample', str(json_file), '--dataset-key', 'foo'])
-    assert m.is_called()
+    m.assert_called()
 
     invalid_json_file = workdir / "invalid_json_file.json"
     invalid_json_file.write_text('test')


### PR DESCRIPTION
🔗 Related issue: #83 

Currently, when using `is_called()` in the tests, the assert is always passing, even when it shouldn't.
As an example (provided in the issue), this test is passing but should not :
```python
def test_foo(mocker):
    m = mock_requests(mocker, "post", response='foo')
    assert m.is_called()
```

When checking the documentation of unittest.mock (https://docs.python.org/3/library/unittest.mock.html), it looks like this method doesn't exists at all.
I think we should use `assert_called()`, which is the assert we actually wanted.