### PR TITLE
Update compute plan

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -22,6 +22,7 @@
 - [substra cancel compute_plan](#substra-cancel-compute_plan)
 - [substra update data_sample](#substra-update-data_sample)
 - [substra update dataset](#substra-update-dataset)
+- [substra update compute_plan](#substra-update-compute_plan)
 
 
 # Commands
@@ -746,6 +747,78 @@ Options:
   --user FILE                     User file path to use (default ~/.substra-
                                   user).
   --verbose                       Enable verbose mode.
+  --help                          Show this message and exit.
+```
+
+## substra update compute_plan
+
+```bash
+Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
+
+  Update compute plan.
+
+  The tuples path must point to a valid JSON file with the following schema:
+
+  {
+      "traintuples": list[{
+          "algo_key": str,
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "traintuple_id": str,
+          "in_models_ids": list[str],
+          "in_models_keys": list[str],
+          "tag": str,
+      }],
+      "composite_traintuples": list[{
+          "algo_key": str,
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "in_head_model_id": str,
+          "in_head_model_key": str,
+          "in_trunk_model_id": str,
+          "in_trunk_model_key": str,
+          "out_trunk_model_permissions": {
+              "authorized_ids": list[str],
+          },
+          "tag": str,
+      }]
+      "aggregatetuples": list[{
+          "algo_key": str,
+          "worker": str,
+          "in_models_ids": list[str],
+          "in_models_keys": list[str],
+          "tag": str,
+      }],
+      "testtuples": list[{
+          "objective_key": str,
+          "data_manager_key": str,
+          "test_data_sample_keys": list[str],
+          "testtuple_id": str,
+          "traintuple_id": str,
+          "traintuple_key": str,
+          "tag": str,
+      }]
+  }
+
+  Where:
+
+  * traintuples and aggregatetuples `in_models_ids` and `in_models_keys` can
+  be specified together * composite traintuples `in_head_model_id` and
+  `in_head_model_key` are mutually exclusive * composite traintuples
+  `in_trunk_model_id` and `in_trunk_model_key` are mutually exclusive *
+  testtuples `traintuple_id` and `traintuple_key` are mutually exclusive
+
+Options:
+  --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Enable logging and set log level
+  --config PATH                   Config path (default ~/.substra).
+  --profile TEXT                  Profile name to use.
+  --user FILE                     User file path to use (default ~/.substra-
+                                  user).
+  --verbose                       Enable verbose mode.
+  --yaml                          Display output as yaml.
+  --json                          Display output as json.
+  --pretty                        Pretty print output  [default: True]
   --help                          Show this message and exit.
 ```
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -460,6 +460,69 @@ List nodes.
 Client.update_dataset(self, dataset_key, data)
 ```
 Update dataset.
+## update_compute_plan
+```python
+Client.update_compute_plan(self, compute_plan_id, data)
+```
+Update compute plan.
+
+Data is a dict object with the following schema:
+
+```
+{
+    "traintuples": list[{
+        "algo_key": str,
+        "data_manager_key": str,
+        "train_data_sample_keys": list[str],
+        "traintuple_id": str,
+        "in_models_ids": list[str],
+        "in_models_keys": list[str],
+        "tag": str,
+    }],
+    "composite_traintuples": list[{
+        "algo_key": str,
+        "data_manager_key": str,
+        "train_data_sample_keys": list[str],
+        "in_head_model_id": str,
+        "in_head_model_key": str,
+        "in_trunk_model_id": str,
+        "in_trunk_model_key": str,
+        "out_trunk_model_permissions": {
+            "authorized_ids": list[str],
+        },
+        "tag": str,
+    }]
+    "aggregatetuples": list[{
+        "algo_key": str,
+        "worker": str,
+        "in_models_ids": list[str],
+        "in_models_keys": list[str],
+        "tag": str,
+    }],
+    "testtuples": list[{
+        "objective_key": str,
+        "data_manager_key": str,
+        "test_data_sample_keys": list[str],
+        "testtuple_id": str,
+        "traintuple_id": str,
+        "traintuple_key": str,
+        "tag": str,
+    }]
+}
+```
+
+Where:
+
+* traintuples and aggregatetuples `in_models_ids` and `in_models_keys` can be specified
+  together
+* composite traintuples `in_head_model_id` and `in_head_model_key` are mutually exclusive
+* composite traintuples `in_trunk_model_id` and `in_trunk_model_key` are mutually exclusive
+* testtuples `traintuple_id` and `traintuple_key` are mutually exclusive
+
+As specified in the data dict structure, output trunk models of composite
+traintuples cannot be made public.
+
+
 ## link_dataset_with_objective
 ```python
 Client.link_dataset_with_objective(self, dataset_key, objective_key)

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1121,5 +1121,73 @@ def update_dataset(ctx, dataset_key, objective_key):
     display(res)
 
 
+@update.command('compute_plan')
+@click.argument('compute_plan_id', type=click.STRING)
+@click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
+                callback=load_json_from_path, metavar="TUPLES_PATH")
+@click_global_conf_with_output_format
+@click.pass_context
+@error_printer
+def update_compute_plan(ctx, compute_plan_id, tuples):
+    """Update compute plan.
+
+    The tuples path must point to a valid JSON file with the following schema:
+
+    \b
+    {
+        "traintuples": list[{
+            "algo_key": str,
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "traintuple_id": str,
+            "in_models_ids": list[str],
+            "in_models_keys": list[str],
+            "tag": str,
+        }],
+        "composite_traintuples": list[{
+            "algo_key": str,
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "in_head_model_id": str,
+            "in_head_model_key": str,
+            "in_trunk_model_id": str,
+            "in_trunk_model_key": str,
+            "out_trunk_model_permissions": {
+                "authorized_ids": list[str],
+            },
+            "tag": str,
+        }]
+        "aggregatetuples": list[{
+            "algo_key": str,
+            "worker": str,
+            "in_models_ids": list[str],
+            "in_models_keys": list[str],
+            "tag": str,
+        }],
+        "testtuples": list[{
+            "objective_key": str,
+            "data_manager_key": str,
+            "test_data_sample_keys": list[str],
+            "testtuple_id": str,
+            "traintuple_id": str,
+            "traintuple_key": str,
+            "tag": str,
+        }]
+    }
+
+    Where:
+
+    * traintuples and aggregatetuples `in_models_ids` and `in_models_keys` can be specified together
+    * composite traintuples `in_head_model_id` and `in_head_model_key` are mutually exclusive
+    * composite traintuples `in_trunk_model_id` and `in_trunk_model_key` are mutually exclusive
+    * testtuples `traintuple_id` and `traintuple_key` are mutually exclusive
+
+    """
+    client = get_client(ctx.obj)
+    res = client.update_compute_plan(compute_plan_id, tuples)
+    printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
+    printer.print(res, is_list=False)
+
+
 if __name__ == '__main__':
     cli()

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -116,6 +116,16 @@ class CurrentNodeField(Field):
         return ''
 
 
+class MappingField(Field):
+    def get_value(self, item, expand=False):
+        mapping = super().get_value(item, False)
+        value = [
+            f'{key}:{mapping[key]}'
+            for key in mapping.keys()
+        ]
+        return value
+
+
 class BasePrinter:
     @staticmethod
     def _get_columns(items, fields):
@@ -251,6 +261,14 @@ class ComputePlanPrinter(AssetPrinter):
         Field('Status', 'status'),
     )
 
+    keys_to_ids_mapping_field = MappingField('Keys to IDs mapping', 'keysToIDsMapping')
+
+    def print_details(self, item, fields, expand):
+        if 'keysToIDsMapping' in item:
+            fields = fields + (self.keys_to_ids_mapping_field, )
+
+        super().print_details(item, fields, expand)
+
     def print_messages(self, item, profile=None):
         key_value = self.key_field.get_value(item)
         profile_arg = self.get_profile_arg(profile)
@@ -269,6 +287,12 @@ class ComputePlanPrinter(AssetPrinter):
         print('\nDisplay this compute_plan\'s testtuples:')
         print(f'\tsubstra list testtuple'
               f' -f "testtuple:computePlanID:{key_value}" {profile_arg}')
+
+        try:
+            keys_to_ids_mapping_file = item['keys_to_ids_mapping_file']
+            print(f'\nKeys to IDs mapping has been saved to {keys_to_ids_mapping_file}')
+        except KeyError:
+            pass
 
 
 class AlgoPrinter(BaseAlgoPrinter):

--- a/tests/sdk/test_update.py
+++ b/tests/sdk/test_update.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+
 from .. import datastore
 from .utils import mock_requests
 
@@ -26,3 +28,21 @@ def test_update_dataset(client, mocker):
 
     assert response == item
     assert m.is_called()
+
+
+def test_update_compute_plan(client, mocker):
+    item = {}
+    item.update(datastore.COMPUTE_PLAN)
+    item.update({'keysToIDsMapping': {'foo': 'bar'}})
+    m = mock_requests(mocker, "post", response=item)
+
+    response = client.update_compute_plan('foo', {})
+
+    assert response == item
+    assert m.is_called()
+
+    keys_to_ids_mapping_file = response['keys_to_ids_mapping_file']
+    with open(keys_to_ids_mapping_file, 'r') as f:
+        mapping = json.load(f)
+
+    assert mapping == {'foo': 'bar'}


### PR DESCRIPTION
Add support for an upcoming update compute plan endpoint, assuming:
- the endpoint is reachable by POST at `/compute_plan/<compute_plan_id>/update_ledger` (similar to update dataset)
- the add and update compute plan calls will return in their json a `keysToIDsMapping ` key that will contain the mapping

The mapping is then saved in a temp file and displayed if the call was made through the CLI.