### PR TITLE
Change retry strategy on post request on ledger timeout

### DIFF
--- a/tests/sdk/test_describe.py
+++ b/tests/sdk/test_describe.py
@@ -17,7 +17,7 @@ import pytest
 import substra
 
 from .. import datastore
-from .utils import mock_requests, mock_response
+from .utils import mock_response, mock_requests, mock_requests_responses
 
 
 @pytest.mark.parametrize(
@@ -25,12 +25,11 @@ from .utils import mock_requests, mock_response
 )
 def test_describe_asset(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_response(item)
-
-    description_response = mock_response('foo')
-
-    m = mocker.patch('substra.sdk.rest_client.requests.get',
-                     side_effect=[asset_response, description_response])
+    responses = [
+        mock_response(item),  # metadata
+        mock_response('foo'),  # data
+    ]
+    m = mock_requests_responses(mocker, 'get', responses)
 
     method = getattr(client, f'describe_{asset_name}')
     response = method("magic-key")
@@ -57,12 +56,11 @@ def test_describe_asset_not_found(asset_name, client, mocker):
 )
 def test_describe_description_not_found(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_response(item)
-
-    description_response = mock_response('foo', 404)
-
-    m = mocker.patch('substra.sdk.rest_client.requests.get',
-                     side_effect=[asset_response, description_response])
+    responses = [
+        mock_response(item),  # metadata
+        mock_response('foo', 404),  # data
+    ]
+    m = mock_requests_responses(mocker, 'get', responses)
 
     method = getattr(client, f'describe_{asset_name}')
 

--- a/tests/sdk/test_describe.py
+++ b/tests/sdk/test_describe.py
@@ -17,7 +17,7 @@ import pytest
 import substra
 
 from .. import datastore
-from .utils import mock_requests, mock_requests_response
+from .utils import mock_requests, mock_response
 
 
 @pytest.mark.parametrize(
@@ -25,9 +25,9 @@ from .utils import mock_requests, mock_requests_response
 )
 def test_describe_asset(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_requests_response(item)
+    asset_response = mock_response(item)
 
-    description_response = mock_requests_response('foo')
+    description_response = mock_response('foo')
 
     m = mocker.patch('substra.sdk.rest_client.requests.get',
                      side_effect=[asset_response, description_response])
@@ -57,9 +57,9 @@ def test_describe_asset_not_found(asset_name, client, mocker):
 )
 def test_describe_description_not_found(asset_name, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_requests_response(item)
+    asset_response = mock_response(item)
 
-    description_response = mock_requests_response('foo', 404)
+    description_response = mock_response('foo', 404)
 
     m = mocker.patch('substra.sdk.rest_client.requests.get',
                      side_effect=[asset_response, description_response])

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -18,7 +18,7 @@ import os
 import substra
 
 from .. import datastore
-from .utils import mock_requests, mock_requests_response
+from .utils import mock_requests, mock_response
 
 
 @pytest.mark.parametrize(
@@ -32,9 +32,9 @@ from .utils import mock_requests, mock_requests_response
 )
 def test_download_asset(asset_name, filename, tmp_path, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_requests_response(item)
+    asset_response = mock_response(item)
 
-    description_response = mock_requests_response('foo')
+    description_response = mock_response('foo')
 
     m = mocker.patch('substra.sdk.rest_client.requests.get',
                      side_effect=[asset_response, description_response])
@@ -65,9 +65,9 @@ def test_download_asset_not_found(asset_name, tmp_path, client, mocker):
 )
 def test_download_content_not_found(asset_name, tmp_path, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_requests_response(item)
+    asset_response = mock_response(item)
 
-    description_response = mock_requests_response('foo', status=404)
+    description_response = mock_response('foo', status=404)
 
     m = mocker.patch('substra.sdk.rest_client.requests.get',
                      side_effect=[asset_response, description_response])

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -18,7 +18,7 @@ import os
 import substra
 
 from .. import datastore
-from .utils import mock_requests, mock_response
+from .utils import mock_requests_responses, mock_requests, mock_response
 
 
 @pytest.mark.parametrize(
@@ -32,12 +32,11 @@ from .utils import mock_requests, mock_response
 )
 def test_download_asset(asset_name, filename, tmp_path, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_response(item)
-
-    description_response = mock_response('foo')
-
-    m = mocker.patch('substra.sdk.rest_client.requests.get',
-                     side_effect=[asset_response, description_response])
+    responses = [
+        mock_response(item),  # metadata
+        mock_response('foo'),  # data
+    ]
+    m = mock_requests_responses(mocker, 'get', responses)
 
     method = getattr(client, f'download_{asset_name}')
     method("foo", tmp_path)
@@ -65,12 +64,11 @@ def test_download_asset_not_found(asset_name, tmp_path, client, mocker):
 )
 def test_download_content_not_found(asset_name, tmp_path, client, mocker):
     item = getattr(datastore, asset_name.upper())
-    asset_response = mock_response(item)
-
-    description_response = mock_response('foo', status=404)
-
-    m = mocker.patch('substra.sdk.rest_client.requests.get',
-                     side_effect=[asset_response, description_response])
+    responses = [
+        mock_response(item),  # metadata
+        mock_response('foo', status=404),  # description
+    ]
+    m = mock_requests_responses(mocker, 'get', responses)
 
     method = getattr(client, f'download_{asset_name}')
 

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -17,7 +17,7 @@ import requests
 
 from substra.sdk import rest_client, exceptions
 
-from .utils import mock_requests
+from .utils import mock_response, mock_requests, mock_requests_responses
 
 
 CONFIG = {
@@ -90,11 +90,13 @@ def test_request_connection_error(mocker):
 
 def test_add_timeout_with_retry(mocker):
     asset_name = "traintuple"
-    m_post = mock_requests(mocker, "post", response={"pkhash": "a-key"}, status=408)
-    m_get = mock_requests(mocker, "get", response={"pkhash": "a-key"})
+    responses = [
+        mock_response(response={"pkhash": "a-key"}, status=408),
+        mock_response(response={"pkhash": "a-key"}),
+    ]
+    m_post = mock_requests_responses(mocker, "post", responses)
     asset = rest_client.Client(CONFIG).add(asset_name, retry_timeout=60)
-    assert len(m_post.call_args_list) == 1
-    assert len(m_get.call_args_list) == 1
+    assert len(m_post.call_args_list) == 2
     assert asset == {"pkhash": "a-key"}
 
 

--- a/tests/sdk/utils.py
+++ b/tests/sdk/utils.py
@@ -17,7 +17,7 @@ from unittest import mock
 import requests
 
 
-def mock_requests_response(response=None, status=200, headers=None):
+def mock_response(response=None, status=200, headers=None):
     headers = headers or {}
     m = mock.MagicMock(spec=requests.Response)
     m.status_code = status
@@ -32,12 +32,13 @@ def mock_requests_response(response=None, status=200, headers=None):
     return m
 
 
-def mock_requests(mocker, method, response=None, status=200, headers=None):
-
-    def _req(*args, **kwargs):
-        return mock_requests_response(response, status, headers)
-
+def mock_requests_responses(mocker, method, responses):
     return mocker.patch(
         f'substra.sdk.rest_client.requests.{method}',
-        side_effect=_req,
+        side_effect=responses,
     )
+
+
+def mock_requests(mocker, method, response=None, status=200, headers=None):
+    r = mock_response(response, status, headers)
+    return mock_requests_responses(mocker, method, (r, ))


### PR DESCRIPTION
This is required as we don't know on a ledger timeout error if the request will be processed by the chaincode.