### PR TITLE
Display compute plan progress in CLI

### DIFF
--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -116,13 +116,15 @@ class CurrentNodeField(Field):
         return ''
 
 
-class ComputePlanProgressField(Field):
-    def __init__(self, name):
+class ProgressField(Field):
+    def __init__(self, name, progress_ref, total_ref):
         self.name = name
+        self.progress_ref = progress_ref
+        self.total_ref = total_ref
 
     def get_value(self, item, expand=False):
-        done_count = find_dict_composite_key_value(item, 'doneCount')
-        tuple_count = find_dict_composite_key_value(item, 'tupleCount')
+        done_count = find_dict_composite_key_value(item, self.progress_ref)
+        tuple_count = find_dict_composite_key_value(item, self.total_ref)
         return f'{done_count}/{tuple_count}'
 
 
@@ -251,7 +253,7 @@ class ComputePlanPrinter(AssetPrinter):
         CountField('Composite traintuples count', 'compositeTraintupleKeys'),
         CountField('Aggregatetuples count', 'aggregatetupleKeys'),
         CountField('Testtuples count', 'testtupleKeys'),
-        ComputePlanProgressField('Progress'),
+        ProgressField('Progress', 'doneCount', 'tupleCount'),
         Field('Status', 'status'),
     )
     single_fields = (
@@ -259,7 +261,7 @@ class ComputePlanPrinter(AssetPrinter):
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
         KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
         KeysField('Testtuple keys', 'testtupleKeys'),
-        ComputePlanProgressField('Progress'),
+        ProgressField('Progress', 'doneCount', 'tupleCount'),
         Field('Status', 'status'),
     )
 

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -116,6 +116,16 @@ class CurrentNodeField(Field):
         return ''
 
 
+class ComputePlanProgressField(Field):
+    def __init__(self, name):
+        self.name = name
+
+    def get_value(self, item, expand=False):
+        done_count = find_dict_composite_key_value(item, 'doneCount')
+        tuple_count = find_dict_composite_key_value(item, 'tupleCount')
+        return f'{done_count}/{tuple_count}'
+
+
 class BasePrinter:
     @staticmethod
     def _get_columns(items, fields):
@@ -241,6 +251,7 @@ class ComputePlanPrinter(AssetPrinter):
         CountField('Composite traintuples count', 'compositeTraintupleKeys'),
         CountField('Aggregatetuples count', 'aggregatetupleKeys'),
         CountField('Testtuples count', 'testtupleKeys'),
+        ComputePlanProgressField('Progress'),
         Field('Status', 'status'),
     )
     single_fields = (
@@ -248,6 +259,7 @@ class ComputePlanPrinter(AssetPrinter):
         KeysField('Composite traintuple keys', 'compositeTraintupleKeys'),
         KeysField('Aggregatetuple keys', 'aggregatetupleKeys'),
         KeysField('Testtuple keys', 'testtupleKeys'),
+        ComputePlanProgressField('Progress'),
         Field('Status', 'status'),
     )
 


### PR DESCRIPTION
Since the compute plan now contains doneCount and tupleCount properties, we can display the overall progress to the user.