### PR TITLE
Update compute plan

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -22,6 +22,7 @@
 - [substra cancel compute_plan](#substra-cancel-compute_plan)
 - [substra update data_sample](#substra-update-data_sample)
 - [substra update dataset](#substra-update-dataset)
+- [substra update compute_plan](#substra-update-compute_plan)
 
 
 # Commands
@@ -743,6 +744,65 @@ Options:
   --user FILE                     User file path to use (default ~/.substra-
                                   user).
   --verbose                       Enable verbose mode.
+  --help                          Show this message and exit.
+```
+
+## substra update compute_plan
+
+```bash
+Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
+
+  Update compute plan.
+
+  The tuples path must point to a valid JSON file with the following schema:
+
+  {
+      "traintuples": list[{
+          "algo_key": str,
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "traintuple_id": str,
+          "in_models_ids": list[str],
+          "tag": str,
+      }],
+      "composite_traintuples": list[{
+          "algo_key": str,
+          "data_manager_key": str,
+          "train_data_sample_keys": list[str],
+          "in_head_model_id": str,
+          "in_trunk_model_id": str,
+          "out_trunk_model_permissions": {
+              "authorized_ids": list[str],
+          },
+          "tag": str,
+      }]
+      "aggregatetuples": list[{
+          "algo_key": str,
+          "worker": str,
+          "in_models_ids": list[str],
+          "tag": str,
+      }],
+      "testtuples": list[{
+          "objective_key": str,
+          "data_manager_key": str,
+          "test_data_sample_keys": list[str],
+          "testtuple_id": str,
+          "traintuple_id": str,
+          "tag": str,
+      }]
+  }
+
+Options:
+  --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Enable logging and set log level
+  --config PATH                   Config path (default ~/.substra).
+  --profile TEXT                  Profile name to use.
+  --user FILE                     User file path to use (default ~/.substra-
+                                  user).
+  --verbose                       Enable verbose mode.
+  --yaml                          Display output as yaml.
+  --json                          Display output as json.
+  --pretty                        Pretty print output  [default: True]
   --help                          Show this message and exit.
 ```
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -766,6 +766,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "tag": str,
       }],
       "composite_traintuples": list[{
+          "composite_traintuple_id": str,
           "algo_key": str,
           "data_manager_key": str,
           "train_data_sample_keys": list[str],
@@ -777,6 +778,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "tag": str,
       }]
       "aggregatetuples": list[{
+          "aggregatetuple_id": str,
           "algo_key": str,
           "worker": str,
           "in_models_ids": list[str],
@@ -786,7 +788,6 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "objective_key": str,
           "data_manager_key": str,
           "test_data_sample_keys": list[str],
-          "testtuple_id": str,
           "traintuple_id": str,
           "tag": str,
       }]

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -460,6 +460,58 @@ List nodes.
 Client.update_dataset(self, dataset_key, data)
 ```
 Update dataset.
+## update_compute_plan
+```python
+Client.update_compute_plan(self, compute_plan_id, data)
+```
+Update compute plan.
+
+Data is a dict object with the following schema:
+
+```
+{
+    "traintuples": list[{
+        "traintuple_id": str,
+        "algo_key": str,
+        "data_manager_key": str,
+        "train_data_sample_keys": list[str],
+        "in_models_ids": list[str],
+        "tag": str,
+    }],
+    "composite_traintuples": list[{
+        "composite_traintuple_id": str,
+        "algo_key": str,
+        "data_manager_key": str,
+        "train_data_sample_keys": list[str],
+        "in_head_model_id": str,
+        "in_trunk_model_id": str,
+        "out_trunk_model_permissions": {
+            "authorized_ids": list[str],
+        },
+        "tag": str,
+    }]
+    "aggregatetuples": list[{
+        "aggregatetuple_id": str,
+        "algo_key": str,
+        "worker": str,
+        "in_models_ids": list[str],
+        "tag": str,
+    }],
+    "testtuples": list[{
+        "objective_key": str,
+        "data_manager_key": str,
+        "test_data_sample_keys": list[str],
+        "testtuple_id": str,
+        "traintuple_id": str,
+        "tag": str,
+    }]
+}
+```
+
+As specified in the data dict structure, output trunk models of composite
+traintuples cannot be made public.
+
+
 ## link_dataset_with_objective
 ```python
 Client.link_dataset_with_objective(self, dataset_key, objective_key)

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -501,7 +501,6 @@ Data is a dict object with the following schema:
         "objective_key": str,
         "data_manager_key": str,
         "test_data_sample_keys": list[str],
-        "testtuple_id": str,
         "traintuple_id": str,
         "tag": str,
     }]

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1134,6 +1134,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "tag": str,
         }],
         "composite_traintuples": list[{
+            "composite_traintuple_id": str,
             "algo_key": str,
             "data_manager_key": str,
             "train_data_sample_keys": list[str],
@@ -1145,6 +1146,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "tag": str,
         }]
         "aggregatetuples": list[{
+            "aggregatetuple_id": str,
             "algo_key": str,
             "worker": str,
             "in_models_ids": list[str],
@@ -1154,7 +1156,6 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "objective_key": str,
             "data_manager_key": str,
             "test_data_sample_keys": list[str],
-            "testtuple_id": str,
             "traintuple_id": str,
             "tag": str,
         }]

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1111,5 +1111,61 @@ def update_dataset(ctx, dataset_key, objective_key):
     display(res)
 
 
+@update.command('compute_plan')
+@click.argument('compute_plan_id', type=click.STRING)
+@click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
+                callback=load_json_from_path, metavar="TUPLES_PATH")
+@click_global_conf_with_output_format
+@click.pass_context
+@error_printer
+def update_compute_plan(ctx, compute_plan_id, tuples):
+    """Update compute plan.
+
+    The tuples path must point to a valid JSON file with the following schema:
+
+    \b
+    {
+        "traintuples": list[{
+            "algo_key": str,
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "traintuple_id": str,
+            "in_models_ids": list[str],
+            "tag": str,
+        }],
+        "composite_traintuples": list[{
+            "algo_key": str,
+            "data_manager_key": str,
+            "train_data_sample_keys": list[str],
+            "in_head_model_id": str,
+            "in_trunk_model_id": str,
+            "out_trunk_model_permissions": {
+                "authorized_ids": list[str],
+            },
+            "tag": str,
+        }]
+        "aggregatetuples": list[{
+            "algo_key": str,
+            "worker": str,
+            "in_models_ids": list[str],
+            "tag": str,
+        }],
+        "testtuples": list[{
+            "objective_key": str,
+            "data_manager_key": str,
+            "test_data_sample_keys": list[str],
+            "testtuple_id": str,
+            "traintuple_id": str,
+            "tag": str,
+        }]
+    }
+
+    """
+    client = get_client(ctx.obj)
+    res = client.update_compute_plan(compute_plan_id, tuples)
+    printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
+    printer.print(res, is_list=False)
+
+
 if __name__ == '__main__':
     cli()

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -128,6 +128,19 @@ class ProgressField(Field):
         return f'{done_count}/{tuple_count}'
 
 
+class MappingField(Field):
+    def get_value(self, item, expand=False):
+        mapping = super().get_value(item) or {}
+        if expand:
+            value = [
+                f'{key}:{mapping[key]}'
+                for key in mapping.keys()
+            ]
+        else:
+            value = f'{len(mapping.keys())} values'
+        return value
+
+
 class BasePrinter:
     @staticmethod
     def _get_columns(items, fields):
@@ -263,6 +276,7 @@ class ComputePlanPrinter(AssetPrinter):
         KeysField('Testtuple keys', 'testtupleKeys'),
         ProgressField('Progress', 'doneCount', 'tupleCount'),
         Field('Status', 'status'),
+        MappingField('ID to key mapping', 'IDToKey'),
     )
 
     def print_messages(self, item, profile=None):

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -132,12 +132,9 @@ class MappingField(Field):
     def get_value(self, item, expand=False):
         mapping = super().get_value(item) or {}
         if expand:
-            value = [
-                f'{key}:{mapping[key]}'
-                for key in mapping.keys()
-            ]
+            value = [f'{k}:{v}' for k, v in mapping.items()]
         else:
-            value = f'{len(mapping.keys())} values'
+            value = f'{len(mapping)} values'
         return value
 
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -698,6 +698,63 @@ class Client(object):
         )
 
     @logit
+    def update_compute_plan(self, compute_plan_id, data):
+        """Update compute plan.
+
+        Data is a dict object with the following schema:
+
+```
+        {
+            "traintuples": list[{
+                "traintuple_id": str,
+                "algo_key": str,
+                "data_manager_key": str,
+                "train_data_sample_keys": list[str],
+                "in_models_ids": list[str],
+                "tag": str,
+            }],
+            "composite_traintuples": list[{
+                "composite_traintuple_id": str,
+                "algo_key": str,
+                "data_manager_key": str,
+                "train_data_sample_keys": list[str],
+                "in_head_model_id": str,
+                "in_trunk_model_id": str,
+                "out_trunk_model_permissions": {
+                    "authorized_ids": list[str],
+                },
+                "tag": str,
+            }]
+            "aggregatetuples": list[{
+                "aggregatetuple_id": str,
+                "algo_key": str,
+                "worker": str,
+                "in_models_ids": list[str],
+                "tag": str,
+            }],
+            "testtuples": list[{
+                "objective_key": str,
+                "data_manager_key": str,
+                "test_data_sample_keys": list[str],
+                "testtuple_id": str,
+                "traintuple_id": str,
+                "tag": str,
+            }]
+        }
+```
+
+        As specified in the data dict structure, output trunk models of composite
+        traintuples cannot be made public.
+
+        """
+        return self.client.request(
+            'post',
+            assets.COMPUTE_PLAN,
+            path=f"{compute_plan_id}/update_ledger/",
+            json=data,
+        )
+
+    @logit
     def link_dataset_with_objective(self, dataset_key, objective_key):
         """Link dataset with objective."""
         return self.update_dataset(

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -736,7 +736,6 @@ class Client(object):
                 "objective_key": str,
                 "data_manager_key": str,
                 "test_data_sample_keys": list[str],
-                "testtuple_id": str,
                 "traintuple_id": str,
                 "tag": str,
             }]

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -328,53 +328,21 @@ NODES = [
 ]
 
 COMPUTE_PLAN = {
-    "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
-    "algoKey": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-    "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-    "traintuples": [
-        {
-            "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
-            "algo": {
-                "name": "Logistic regression",
-                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/",  # noqa: E501
-            },
-            "creator": "MyPeer2MSP",
-            "dataset": {
-                "worker": "MyPeer2MSP",
-                "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-                "perf": 1
-            },
-            "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
-            "inModels": None,
-            "log": "",
-            "objective": {
-                "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-                "metrics": {
-                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
-                    "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/",  # noqa: E501
-
-                }
-            },
-            "outModel": {
-                "hash": "af716d0315e847b500376420aaa65a5192f67a5635163d7c0f44cdf72d5b3772",
-                "storageAddress": "http://testserver/model/af716d0315e847b500376420aaa65a5192f67a5635163d7c0f44cdf72d5b3772/file/",  # noqa: E501
-
-            },
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "done",
-            "tag": ""
-        }
+    "computePlanID": "e983a1855368bd0a0190183af9a8e560580d1fc8d86c84268fd55c1910114ca3",
+    "traintupleKeys": [
+        "1197bbfc4a189ea037a6835895a81bb80db37f52f82cc40d74e285b7194f4c91"
     ],
-    "testtuples": []
+    "aggregatetupleKeys": None,
+    "compositeTraintupleKeys": None,
+    "testtupleKeys": [
+        "6c94a1df7af13ebd176b05ae9686489fe563122fee7bca4d35ed9b606f96180c"
+    ],
+    "tag": "",
+    "status": "done",
+    "tupleCount": 2,
+    "doneCount": 2,
+    "IDToKey": {
+        "62378ca1b5c84e73a3d588adab7e20b2":
+        "1197bbfc4a189ea037a6835895a81bb80db37f52f82cc40d74e285b7194f4c91",
+    }
 }

--- a/tests/sdk/test_update.py
+++ b/tests/sdk/test_update.py
@@ -26,3 +26,13 @@ def test_update_dataset(client, mocker):
 
     assert response == item
     m.assert_called()
+
+
+def test_update_compute_plan(client, mocker):
+    item = datastore.COMPUTE_PLAN
+    m = mock_requests(mocker, "post", response=item)
+
+    response = client.update_compute_plan('foo', {})
+
+    assert response == item
+    m.assert_called


### PR DESCRIPTION
- New sdk method: `update_compute_plan`
- New CLI asset (`compute_plan`) for command `update`


Companion PRs:
* https://github.com/SubstraFoundation/substra-backend/pull/137
* https://github.com/SubstraFoundation/substra-tests/pull/69
* https://github.com/SubstraFoundation/substra-chaincode/pull/89