### PR TITLE
Update examples with headers fix in rest_client

### DIFF
--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -26,7 +26,7 @@ compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.j
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')

--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -23,9 +23,6 @@ current_directory = os.path.dirname(__file__)
 assets_keys_path = os.path.join(current_directory, '../../titanic/assets_keys.json')
 compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.json')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 

--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -27,7 +27,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -24,7 +24,7 @@ compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.j
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 with open(compute_plan_keys_path, 'r') as f:

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -21,9 +21,6 @@ import substra
 current_directory = os.path.dirname(__file__)
 compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.json')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -25,7 +25,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 with open(compute_plan_keys_path, 'r') as f:

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,6 +1,0 @@
-{
-  "profile_name": "owkin",
-  "url": "http://substra-backend.owkin.xyz:8000",
-  "username": "substra",
-  "password": "p@$swr0d44"
-}

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -26,7 +26,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -22,9 +22,6 @@ current_directory = os.path.dirname(__file__)
 assets_keys_path = os.path.join(current_directory, '../../titanic/assets_keys.json')
 folds_keys_path = os.path.join(current_directory, '../folds_keys.json')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -25,7 +25,7 @@ folds_keys_path = os.path.join(current_directory, '../folds_keys.json')
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -14,9 +14,10 @@ In order to run this example, you'll need to:
 * [install the `substratools` library](https://github.com/substrafoundation/substra-tools)
 * [pull the `substra-tools` docker images](https://github.com/substrafoundation/substra-tools#pull-from-private-docker-registry)
 * have one or two profiles:
-   * with Docker: `.`
-   * with Skaffold: `substra config --profile node-1 --username USERNAME --password PASSWORD URL`
-   * you need to use the `node-1` profile
+    ```sh
+    substra config --profile node-1 --username node-1 --password 'p@$swr0d44' http://substra-backend.owkin.xyz:8000
+    substra login --profile node-1
+    ```
 
 ## Data preparation
 

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -13,9 +13,9 @@ In order to run this example, you'll need to:
 * [install the `substra` cli](../../README.md#install)
 * [install the `substratools` library](https://github.com/substrafoundation/substra-tools)
 * [pull the `substra-tools` docker images](https://github.com/substrafoundation/substra-tools#pull-from-private-docker-registry)
-* have one or two profiles:
+* create a substra profile to define the substra network to target, for instance:
     ```sh
-    substra config --profile node-1 --username node-1 --password 'p@$swr0d44' http://substra-backend.owkin.xyz:8000
+    substra config --profile node-1 --username node-1 --password 'p@$swr0d44' http://substra-backend.node-1.com
     substra login --profile node-1
     ```
 

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -13,6 +13,10 @@ In order to run this example, you'll need to:
 * [install the `substra` cli](../../README.md#install)
 * [install the `substratools` library](https://github.com/substrafoundation/substra-tools)
 * [pull the `substra-tools` docker images](https://github.com/substrafoundation/substra-tools#pull-from-private-docker-registry)
+* have one or two profiles:
+   * with Docker: `.`
+   * with Skaffold: `substra config --profile node-1 --username USERNAME --password PASSWORD URL`
+   * you need to use the `node-1` profile
 
 ## Data preparation
 

--- a/examples/titanic/scripts/add_dataset_objective.py
+++ b/examples/titanic/scripts/add_dataset_objective.py
@@ -49,7 +49,7 @@ assets_directory = os.path.join(current_directory, '../assets')
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 DATASET = {

--- a/examples/titanic/scripts/add_dataset_objective.py
+++ b/examples/titanic/scripts/add_dataset_objective.py
@@ -46,9 +46,6 @@ def progress_bar(length):
 current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 

--- a/examples/titanic/scripts/add_dataset_objective.py
+++ b/examples/titanic/scripts/add_dataset_objective.py
@@ -50,7 +50,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 DATASET = {

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -25,7 +25,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 ALGO = {

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -24,7 +24,7 @@ assets_directory = os.path.join(current_directory, '../assets')
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 ALGO = {

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -21,9 +21,6 @@ import substra
 current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -25,7 +25,6 @@ with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
 client = substra.Client()
-client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
 client.login()
 
 ALGO_KEYS_JSON_FILENAME = 'algo_random_forest_keys.json'

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -24,7 +24,7 @@ assets_directory = os.path.join(current_directory, '../assets')
 with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
     config = json.load(f)
 
-client = substra.Client()
+client = substra.Client(profile_name="node-1")
 client.login()
 
 ALGO_KEYS_JSON_FILENAME = 'algo_random_forest_keys.json'

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -21,9 +21,6 @@ import substra
 current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
-with open(os.path.join(current_directory, '../../config.json'), 'r') as f:
-    config = json.load(f)
-
 client = substra.Client(profile_name="node-1")
 client.login()
 


### PR DESCRIPTION
🔗 **Related PRs**:
- [Fix rest client login headers](https://github.com/SubstraFoundation/substra/pull/106)
- [Update tests with headers fix in rest_client](https://github.com/SubstraFoundation/substra/pull/109)

We are currently modifying the way the login headers works in #106. We are removing the config.json (where the password is set) and storing its content through the headers instead.
This PR has been opened in order to apply these changes in the examples we can find on the `substra` repository.
We are just replacing this:
```py
client = substra.Client()
client.add_profile(config['profile_name'], config['username'], config['password'],  config['url'])
client.login()
``` 

by this:
```py
client = substra.Client(profile_name="node-1")
client.login()
```