### PR TITLE
Update tests with headers fix in rest_client

### DIFF
--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -48,33 +48,11 @@ def test_add_load_profile_from_file(tmpdir):
     }
 
     path.write_text(json.dumps(conf), "UTF-8")
-    keyring.set_password('node-1', conf['node-1']['auth']['username'], 'foo')
     manager = configuration.Manager(str(path))
     profile = manager.load_profile('node-1')
 
-    assert conf['node-1']['auth']['username'] == profile['auth']['username']
+    assert conf['node-1'] == profile
     assert keyring.get_password(service_name='node-1', username='node-1') == 'foo'
-
-
-def test_add_load_bad_profile_from_file(tmpdir):
-    path = tmpdir / 'substra.cfg'
-    conf = {
-       "node-1": {
-           "auth": {
-               "username": "node-1"
-           },
-           "insecure": False,
-           "url": "http://substra-backend.node-1.com",
-           "version": "0.0"
-       },
-    }
-
-    path.write_text(json.dumps(conf), "UTF-8")
-    keyring.set_password('node-1', conf['node-1']['auth']['username'], 'foo')
-    manager = configuration.Manager(str(path))
-
-    with pytest.raises(configuration.ProfileNotFoundError):
-        manager.load_profile('foo')
 
 
 def test_load_profile_fail(tmpdir):

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -52,7 +52,6 @@ def test_add_load_profile_from_file(tmpdir):
     profile = manager.load_profile('node-1')
 
     assert conf['node-1'] == profile
-    assert keyring.get_password(service_name='node-1', username='node-1') == 'foo'
 
 
 def test_load_profile_fail(tmpdir):

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -47,26 +47,15 @@ def test_add_load_profile_from_file(tmpdir):
        },
     }
 
-    # todo: write conf to path
     path.write_text(json.dumps(conf), "UTF-8")
-
-    # todo: add matching password to keyring
     keyring.set_password('node-1', conf['node-1']['auth']['username'], 'foo')
-
     manager = configuration.Manager(str(path))
-
     profile = manager.load_profile('node-1')
 
     assert conf['node-1']['auth']['username'] == profile['auth']['username']
-
-    # todo assert keyring password == profile.password
     assert keyring.get_password(service_name='node-1', username='node-1') == 'foo'
 
-    # todo: manager = configuration.Manager(config=str(path), profile='node-1')
-    # todo: same asserts
 
-
-# todo: make sure bad profile name raise an error
 def test_add_load_bad_profile_from_file(tmpdir):
     path = tmpdir / 'substra.cfg'
     conf = {
@@ -85,7 +74,7 @@ def test_add_load_bad_profile_from_file(tmpdir):
     manager = configuration.Manager(str(path))
 
     with pytest.raises(configuration.ProfileNotFoundError):
-       manager.load_profile('foo')
+        manager.load_profile('foo')
 
 
 def test_load_profile_fail(tmpdir):

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import json
 
-import keyring
 import pytest
 
 import substra.sdk.config as configuration
@@ -52,6 +51,17 @@ def test_add_load_profile_from_file(tmpdir):
     profile = manager.load_profile('node-1')
 
     assert conf['node-1'] == profile
+
+
+def test_add_load_bad_profile_from_file(tmpdir):
+    path = tmpdir / 'substra.cfg'
+    conf = "node-1"
+
+    path.write_text(conf, "UTF-8")
+    manager = configuration.Manager(str(path))
+
+    with pytest.raises(configuration.ConfigException):
+        manager.load_profile('node-1')
 
 
 def test_load_profile_fail(tmpdir):

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 
+import keyring
 import pytest
 
 import substra.sdk.config as configuration
@@ -30,6 +32,60 @@ def test_add_load_profile(tmpdir):
 
     profile_2 = manager.load_profile('owkin')
     assert profile_1 == profile_2
+
+
+def test_add_load_profile_from_file(tmpdir):
+    path = tmpdir / 'substra.cfg'
+    conf = {
+       "node-1": {
+           "auth": {
+               "username": "node-1"
+           },
+           "insecure": False,
+           "url": "http://substra-backend.node-1.com",
+           "version": "0.0"
+       },
+    }
+
+    # todo: write conf to path
+    path.write_text(json.dumps(conf), "UTF-8")
+
+    # todo: add matching password to keyring
+    keyring.set_password('node-1', conf['node-1']['auth']['username'], 'foo')
+
+    manager = configuration.Manager(str(path))
+
+    profile = manager.load_profile('node-1')
+
+    assert conf['node-1']['auth']['username'] == profile['auth']['username']
+
+    # todo assert keyring password == profile.password
+    assert keyring.get_password(service_name='node-1', username='node-1') == 'foo'
+
+    # todo: manager = configuration.Manager(config=str(path), profile='node-1')
+    # todo: same asserts
+
+
+# todo: make sure bad profile name raise an error
+def test_add_load_bad_profile_from_file(tmpdir):
+    path = tmpdir / 'substra.cfg'
+    conf = {
+       "node-1": {
+           "auth": {
+               "username": "node-1"
+           },
+           "insecure": False,
+           "url": "http://substra-backend.node-1.com",
+           "version": "0.0"
+       },
+    }
+
+    path.write_text(json.dumps(conf), "UTF-8")
+    keyring.set_password('node-1', conf['node-1']['auth']['username'], 'foo')
+    manager = configuration.Manager(str(path))
+
+    with pytest.raises(configuration.ProfileNotFoundError):
+       manager.load_profile('foo')
 
 
 def test_load_profile_fail(tmpdir):


### PR DESCRIPTION
🔗 **Related PRs**:
- [Fix rest client login headers](https://github.com/SubstraFoundation/substra/pull/106)
- [Update examples with headers fix in rest_client](https://github.com/SubstraFoundation/substra/pull/108)

This PR aims to update the tests with the fixed headers in the rest client.