### PR TITLE
Add missing fields in compute_plan JSON's schema example

### DIFF
--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -497,17 +497,20 @@ def add_compute_plan(ctx, tuples):
             "tag": str,
         }],
         "composite_traintuples": list[{
+            "composite_traintuple_id": str,
             "algo_key": str,
             "data_manager_key": str,
             "train_data_sample_keys": list[str],
             "in_head_model_id": str,
             "in_trunk_model_id": str,
             "out_trunk_model_permissions": {
+                "public": bool,
                 "authorized_ids": list[str],
             },
             "tag": str,
         }]
         "aggregatetuples": list[{
+            "aggregatetuple_id": str,
             "algo_key": str,
             "worker": str,
             "in_models_ids": list[str],


### PR DESCRIPTION
🔗 **Related issue:** https://github.com/SubstraFoundation/substra/issues/112

When using the `substra add compute_plan --help` command, the JSON file schema provided is the following:
```json
{
      "traintuples": list[{
          "algo_key": str,
          "data_manager_key": str,
          "train_data_sample_keys": list[str],
          "traintuple_id": str,
          "in_models_ids": list[str],
          "tag": str,
      }],
      "composite_traintuples": list[{
          "algo_key": str,
          "data_manager_key": str,
          "train_data_sample_keys": list[str],
          "in_head_model_id": str,
          "in_trunk_model_id": str,
          "out_trunk_model_permissions": {
              "authorized_ids": list[str],
          },
          "tag": str,
      }]
      "aggregatetuples": list[{
          "algo_key": str,
          "worker": str,
          "in_models_ids": list[str],
          "tag": str,
      }],
      "testtuples": list[{
          "objective_key": str,
          "data_manager_key": str,
          "test_data_sample_keys": list[str],
          "testtuple_id": str,
          "traintuple_id": str,
          "tag": str,
      }]
  }
```

But when I try to reproduce this schema and to add a `compute_plan`, I get this error:
```sh
Requests error status 400: {"composite_traintuples":[{"composite_traintuple_id":["This field is required."],"out_trunk_model_permissions":{"public":["This field is required."]}}],"aggregatetuples":[{"aggregatetuple_id":["This field is required."]}]}
Error: Request failed: InvalidRequest: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/compute_plan/
```