### PR TITLE
Update compute plan's documentation

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -244,6 +244,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "tag": str,
       }],
       "composite_traintuples": list[{
+          "composite_traintuple_id": str,
           "algo_key": str,
           "data_manager_key": str,
           "train_data_sample_keys": list[str],
@@ -255,6 +256,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "tag": str,
       }]
       "aggregatetuples": list[{
+          "aggregatetuple_id": str,
           "algo_key": str,
           "worker": str,
           "in_models_ids": list[str],
@@ -264,7 +266,6 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "objective_key": str,
           "data_manager_key": str,
           "test_data_sample_keys": list[str],
-          "testtuple_id": str,
           "traintuple_id": str,
           "tag": str,
       }]

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -335,7 +335,6 @@ Data is a dict object with the following schema:
         "objective_key": str,
         "data_manager_key": str,
         "test_data_sample_keys": list[str],
-        "testtuple_id": str,
         "traintuple_id": str,
         "tag": str,
     }]

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -497,6 +497,7 @@ def add_compute_plan(ctx, tuples):
             "tag": str,
         }],
         "composite_traintuples": list[{
+            "composite_traintuple_id": str,
             "algo_key": str,
             "data_manager_key": str,
             "train_data_sample_keys": list[str],
@@ -508,6 +509,7 @@ def add_compute_plan(ctx, tuples):
             "tag": str,
         }]
         "aggregatetuples": list[{
+            "aggregatetuple_id": str,
             "algo_key": str,
             "worker": str,
             "in_models_ids": list[str],
@@ -517,7 +519,6 @@ def add_compute_plan(ctx, tuples):
             "objective_key": str,
             "data_manager_key": str,
             "test_data_sample_keys": list[str],
-            "testtuple_id": str,
             "traintuple_id": str,
             "tag": str,
         }]

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -565,7 +565,6 @@ class Client(object):
                 "objective_key": str,
                 "data_manager_key": str,
                 "test_data_sample_keys": list[str],
-                "testtuple_id": str,
                 "traintuple_id": str,
                 "tag": str,
             }]


### PR DESCRIPTION
🔗 **Related issue:** #112 

When using the `substra add compute_plan --help` command, the JSON file schema provided is the following:
```json
{
      "traintuples": list[{
          "algo_key": str,
          "data_manager_key": str,
          "train_data_sample_keys": list[str],
          "traintuple_id": str,
          "in_models_ids": list[str],
          "tag": str,
      }],
      "composite_traintuples": list[{
          "algo_key": str,
          "data_manager_key": str,
          "train_data_sample_keys": list[str],
          "in_head_model_id": str,
          "in_trunk_model_id": str,
          "out_trunk_model_permissions": {
              "authorized_ids": list[str],
          },
          "tag": str,
      }]
      "aggregatetuples": list[{
          "algo_key": str,
          "worker": str,
          "in_models_ids": list[str],
          "tag": str,
      }],
      "testtuples": list[{
          "objective_key": str,
          "data_manager_key": str,
          "test_data_sample_keys": list[str],
          "testtuple_id": str,
          "traintuple_id": str,
          "tag": str,
      }]
  }
```

But when I try to reproduce this schema and to add a `compute_plan`, I get this error:
```sh
Requests error status 400: {"composite_traintuples":[{"composite_traintuple_id":["This field is required."],"out_trunk_model_permissions":{"public":["This field is required."]}}],"aggregatetuples":[{"aggregatetuple_id":["This field is required."]}]}
Error: Request failed: InvalidRequest: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/compute_plan/
```