### PR TITLE
Add clear error message when sdk can't fetch from keyring

### DIFF
--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -145,3 +145,8 @@ class BadConfiguration(SDKException):
 class UserException(SDKException):
     """User Exception"""
     pass
+
+
+class KeyringException(SDKException):
+    """Could not retrieve password from keyring"""
+    pass

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -89,9 +89,16 @@ class Client():
             raise exceptions.BadConfiguration('Your configuration is outdated, please update it.')
 
         username = config['auth']['username']
+        password = keyring.get_password(profile_name, username)
+
+        if password is None:
+            raise exceptions.KeyringException(
+                Exception("Fetching password error: Check your keyring installation")
+            )
+
         self._auth = {
             'username': username,
-            'password': keyring.get_password(profile_name, username)
+            'password': password
         }
 
     def __request(self, request_name, url, **request_kwargs):

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -93,7 +93,7 @@ class Client():
 
         if password is None:
             raise exceptions.KeyringException(
-                Exception("Fetching password error: Check your keyring installation")
+                'Fetching password error: Check your keyring installation'
             )
 
         self._auth = {


### PR DESCRIPTION
resolve #75 

The documentation part of this issue is covered by https://github.com/SubstraFoundation/substra/pull/110.