### PR TITLE
Cannot add aggregatetuple without in-model key(s)

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -411,7 +411,7 @@ Usage: substra add aggregatetuple [OPTIONS]
 
 Options:
   --algo-key TEXT                 [required]
-  --in-model-key TEXT             In model traintuple key.
+  --in-model-key TEXT             In model traintuple key.  [required]
   --worker TEXT                   Node ID for worker execution.  [required]
   --rank INTEGER
   --tag TEXT

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -652,7 +652,7 @@ def add_traintuple(ctx, algo_key, dataset_key, data_samples, in_models_keys, tag
 @add.command('aggregatetuple')
 @click.option('--algo-key', required=True)
 @click.option('--in-model-key', 'in_models_keys', type=click.STRING, multiple=True,
-              help='In model traintuple key.')
+              help='In model traintuple key.', required=True)
 @click.option('--worker', required=True, help='Node ID for worker execution.')
 @click.option('--rank', type=click.INT)
 @click.option('--tag')


### PR DESCRIPTION
🔗 **This PR is related to this issue: #114**

Currently, this is possible to add an aggregatetuple without passing the `--in-model-key` argument.
The objective of this PR is to avoid being able to do so.