### PR TITLE
Handle FileNotFoundError when config file not found (WIP)

### DIFF
--- a/substra/sdk/config.py
+++ b/substra/sdk/config.py
@@ -47,11 +47,16 @@ class ProfileNotFoundError(ConfigException):
 
 
 def _read_config(path):
-    with open(path) as fh:
-        try:
-            return json.load(fh)
-        except json.decoder.JSONDecodeError:
-            raise ConfigException(f"Cannot parse config file '{path}'")
+    try:
+        fh = open(path)
+    except FileNotFoundError:
+        raise ConfigException(f"Cannot find config file '{path}'")
+    else:
+        with fh:
+            try:
+                return json.load(fh)
+            except json.decoder.JSONDecodeError:
+                raise ConfigException(f"Cannot parse config file '{path}'")
 
 
 def _write_config(path, config):

--- a/substra/sdk/config.py
+++ b/substra/sdk/config.py
@@ -47,16 +47,14 @@ class ProfileNotFoundError(ConfigException):
 
 
 def _read_config(path):
-    try:
-        fh = open(path)
-    except FileNotFoundError:
+    if not os.path.exists(path):
         raise ConfigException(f"Cannot find config file '{path}'")
-    else:
-        with fh:
-            try:
-                return json.load(fh)
-            except json.decoder.JSONDecodeError:
-                raise ConfigException(f"Cannot parse config file '{path}'")
+
+    with open(path) as fh:
+        try:
+            return json.load(fh)
+        except json.decoder.JSONDecodeError:
+            raise ConfigException(f"Cannot parse config file '{path}'")
 
 
 def _write_config(path, config):
@@ -81,7 +79,7 @@ def _add_profile(path, name, url, username, version, insecure):
     # read config file
     try:
         config = _read_config(path)
-    except FileNotFoundError:
+    except ConfigException:
         config = copy.deepcopy(DEFAULT_CONFIG)
 
     # create profile

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -69,7 +69,7 @@ def test_load_profile_fail(tmpdir):
     path = tmpdir / 'substra.cfg'
     manager = configuration.Manager(str(path))
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(configuration.ConfigException):
         manager.load_profile('notfound')
 
     manager.add_profile('default', 'foo', 'bar')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,7 @@ def test_command_add(asset_name, params, workdir, mocker):
 
     res = client_execute(workdir, ['add', asset_name] + params + ['non_existing_file.txt'],
                          exit_code=2)
-    assert re.search(r"File \".*\" does not exist\.", res)
+    assert re.search(r"File '.*' does not exist\.", res)
 
 
 def test_command_add_objective(workdir, mocker):
@@ -184,11 +184,11 @@ def test_command_add_objective(workdir, mocker):
 
     res = client_execute(workdir, ['add', 'objective', 'non_existing_file.txt', '--dataset-key',
                                    'foo', '--data-samples-path', str(json_file)], exit_code=2)
-    assert re.search(r"File \".*\" does not exist\.", res)
+    assert re.search(r"File '.*' does not exist\.", res)
 
     res = client_execute(workdir, ['add', 'objective', str(json_file), '--dataset-key', 'foo',
                                    '--data-samples-path', 'non_existing_file.txt'], exit_code=2)
-    assert re.search(r"File \".*\" does not exist\.", res)
+    assert re.search(r"File '.*' does not exist\.", res)
 
     invalid_json_file = workdir / "invalid_json_file.md"
     invalid_json_file.write_text("test")
@@ -258,7 +258,7 @@ def test_command_add_data_sample(workdir, mocker):
 
     res = client_execute(workdir, ['add', 'data_sample', 'dir', '--dataset-key', 'foo'],
                          exit_code=2)
-    assert re.search(r"Directory \".*\" does not exist\.", res)
+    assert re.search(r"Directory '.*' does not exist\.", res)
 
 
 @pytest.mark.parametrize('asset_name, params', [
@@ -367,7 +367,7 @@ def test_command_update_data_sample(workdir, mocker):
 
     res = client_execute(workdir, ['update', 'data_sample', 'non_existing_file.txt',
                                    '--dataset-key', 'foo'], exit_code=2)
-    assert re.search(r"File \".*\" does not exist\.", res)
+    assert re.search(r"File '.*' does not exist\.", res)
 
 
 @pytest.mark.parametrize('exception', [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,7 +166,7 @@ def test_command_add(asset_name, params, workdir, mocker):
 
     res = client_execute(workdir, ['add', asset_name] + params + ['non_existing_file.txt'],
                          exit_code=2)
-    assert re.search(r"File '.*' does not exist\.", res)
+    assert re.search(r"File \".*\" does not exist\.", res)
 
 
 def test_command_add_objective(workdir, mocker):
@@ -184,11 +184,11 @@ def test_command_add_objective(workdir, mocker):
 
     res = client_execute(workdir, ['add', 'objective', 'non_existing_file.txt', '--dataset-key',
                                    'foo', '--data-samples-path', str(json_file)], exit_code=2)
-    assert re.search(r"File '.*' does not exist\.", res)
+    assert re.search(r"File \".*\" does not exist\.", res)
 
     res = client_execute(workdir, ['add', 'objective', str(json_file), '--dataset-key', 'foo',
                                    '--data-samples-path', 'non_existing_file.txt'], exit_code=2)
-    assert re.search(r"File '.*' does not exist\.", res)
+    assert re.search(r"File \".*\" does not exist\.", res)
 
     invalid_json_file = workdir / "invalid_json_file.md"
     invalid_json_file.write_text("test")
@@ -258,7 +258,7 @@ def test_command_add_data_sample(workdir, mocker):
 
     res = client_execute(workdir, ['add', 'data_sample', 'dir', '--dataset-key', 'foo'],
                          exit_code=2)
-    assert re.search(r"Directory '.*' does not exist\.", res)
+    assert re.search(r"Directory \".*\" does not exist\.", res)
 
 
 @pytest.mark.parametrize('asset_name, params', [
@@ -367,7 +367,7 @@ def test_command_update_data_sample(workdir, mocker):
 
     res = client_execute(workdir, ['update', 'data_sample', 'non_existing_file.txt',
                                    '--dataset-key', 'foo'], exit_code=2)
-    assert re.search(r"File '.*' does not exist\.", res)
+    assert re.search(r"File \".*\" does not exist\.", res)
 
 
 @pytest.mark.parametrize('exception', [


### PR DESCRIPTION
**🔗 This PR is related to the following issue: #117**

As specified in the issue, we get a `FileNotFoundError` when the config file specified in our command doesn't exists.
The goal of this PR is to be able to return instead a `ConfigException` that describes the error.

_The first two examples of the **With or without a .substra file** part have already been fixed in another PR._