### PR TITLE
Add algo type in add aggregatetuple

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -410,7 +410,7 @@ Usage: substra add aggregatetuple [OPTIONS]
   Add aggregatetuple.
 
 Options:
-  --algo-key TEXT                 [required]
+  --algo-key TEXT                 Aggregate algo key.  [required]
   --in-model-key TEXT             In model traintuple key.
   --worker TEXT                   Node ID for worker execution.  [required]
   --rank INTEGER

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -650,7 +650,7 @@ def add_traintuple(ctx, algo_key, dataset_key, data_samples, in_models_keys, tag
 
 
 @add.command('aggregatetuple')
-@click.option('--algo-key', required=True)
+@click.option('--algo-key', required=True, help="Aggregate algo key.")
 @click.option('--in-model-key', 'in_models_keys', type=click.STRING, multiple=True,
               help='In model traintuple key.')
 @click.option('--worker', required=True, help='Node ID for worker execution.')


### PR DESCRIPTION
Currently, when using the following command, the type of the `--algo-key` option isn't specified: 
```sh
substra add aggregatetuple --help
```

Maybe we could add this information in order to make this doc easier to understand?