### PR TITLE
Remove use of keyring

### DIFF
--- a/docs/local_install_skaffold.md
+++ b/docs/local_install_skaffold.md
@@ -445,9 +445,7 @@ You should find the credentials in the charts: `skaffold.yaml` files or in the `
 
 > Note 1: Substra works on Python 3.6.
 >
-> Note 2: On Ubuntu, if the command `pip3 install substra` fails, you might need to install `keyrings-alt` with `pip3 install keyrings-alt`; you might even have to do `sudo apt-get remove python3-keyrings.alt python-keyrings.alt`.
->
-> Note 3: If you are working inside a virtualized environment, you probably will have execute to `pip3` commands with `sudo`.
+> Note 2: If you are working inside a virtualized environment, you probably will have execute to `pip3` commands with `sudo`.
 
 Install the CLI:
 
@@ -461,10 +459,10 @@ Login with the CLI
 
 ```sh
 # Configuration
-substra config -u "node-1" -p 'p@$swr0d44' http://substra-backend.node-1.com
+substra config http://substra-backend.node-1.com
 
 # Login
-substra login
+substra login -u "node-1" -p 'p@$swr0d44'
 
 # Then you can try
 substra list node

--- a/docs/local_install_skaffold.md
+++ b/docs/local_install_skaffold.md
@@ -445,7 +445,7 @@ You should find the credentials in the charts: `skaffold.yaml` files or in the `
 
 > Note 1: Substra works on Python 3.6.
 >
-> Note 2: If you are working inside a virtualized environment, you probably will have execute to `pip3` commands with `sudo`.
+> Note 2: If you are working inside a virtualized environment, you probably will have to execute `pip3` commands with `sudo`.
 
 Install the CLI:
 

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -15,8 +15,8 @@ In order to run this example, you'll need to:
 * [pull the `substra-tools` docker images](https://github.com/substrafoundation/substra-tools#pull-from-private-docker-registry)
 * create a substra profile to define the substra network to target, for instance:
     ```sh
-    substra config --profile node-1 --username node-1 --password 'p@$swr0d44' http://substra-backend.node-1.com
-    substra login --profile node-1
+    substra config --profile node-1 http://substra-backend.node-1.com
+    substra login --profile node-1 --username node-1 --password 'p@$swr0d44'
     ```
 * checkout this repository
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -35,13 +35,11 @@ Usage: substra config [OPTIONS] URL
   Add profile to config file.
 
 Options:
-  --config PATH        Config path (default ~/.substra).
-  --profile TEXT       Profile name to add
-  -k, --insecure       Do not verify SSL certificates
+  --config PATH       Config path (default ~/.substra).
+  --profile TEXT      Profile name to add
+  -k, --insecure      Do not verify SSL certificates
   -v, --version TEXT
-  -u, --username TEXT  [required]
-  -p, --password TEXT  [required]
-  --help               Show this message and exit.
+  --help              Show this message and exit.
 ```
 
 ## substra login
@@ -60,6 +58,8 @@ Options:
                                   user).
 
   --verbose                       Enable verbose mode.
+  -u, --username TEXT
+  -p, --password TEXT
   --help                          Show this message and exit.
 ```
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -9,15 +9,10 @@ Client(self, config_path=None, profile_name=None, user_path=None, token=None, re
 ```python
 Client.login(self, username, password)
 ```
-Login.
+Login to a remote server.
 
-Allow to login to a remote server.
-
-After setting your configuration with `substra config`, launch `substra login`.
-You will be prompted for your username and password and get a token which will be
-stored by default in `~/.substra-user`
-You can change that thanks to the --user option (works like the --profile option)
-
+Will log into the current profile's server and save the resulting token in the configured
+user_path.
 
 ## set_profile
 ```python

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -2,20 +2,20 @@
 
 # Client
 ```python
-Client(self, config_path=None, profile_name=None, user_path=None, retry_timeout=300)
+Client(self, config_path=None, profile_name=None, user_path=None, token=None, retry_timeout=300)
 ```
 
 ## login
 ```python
-Client.login(self)
+Client.login(self, username, password)
 ```
 Login.
 
 Allow to login to a remote server.
 
-After setting your configuration with `substra config` using `-u` and `-p`
-Launch `substra login`
-You will get a token which will be stored by default in `~/.substra-user`
+After setting your configuration with `substra config`, launch `substra login`.
+You will be prompted for your username and password and get a token which will be
+stored by default in `~/.substra-user`
 You can change that thanks to the --user option (works like the --profile option)
 
 
@@ -30,7 +30,7 @@ from the config file.
 
 ## add_profile
 ```python
-Client.add_profile(self, profile_name, username, password, url, version='0.0', insecure=False)
+Client.add_profile(self, profile_name, url, version='0.0', insecure=False)
 ```
 Add new profile (in-memory only).
 ## add_data_sample

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -10,10 +10,6 @@ Client(self, config_path=None, profile_name=None, user_path=None, token=None, re
 Client.login(self, username, password)
 ```
 Login to a remote server.
-
-Will log into the current profile's server and save the resulting token in the configured
-user_path.
-
 ## set_profile
 ```python
 Client.set_profile(self, profile_name)

--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ setup(
     keywords=['cli', 'substra'],
     packages=find_packages(exclude=['docs', 'tests*']),
     include_package_data=True,
-    install_requires=['click', 'requests', 'docker', 'consolemd', 'pyyaml', 'keyring'],
+    install_requires=['click', 'requests', 'docker', 'consolemd', 'pyyaml'],
     python_requires='>=3.6',
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'pytest-mock', 'keyrings.alt'],
+    tests_require=['pytest', 'pytest-cov', 'pytest-mock'],
     entry_points={
         'console_scripts': [
             'substra=substra.cli.interface:cli',

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -265,14 +265,10 @@ def cli(ctx):
 @click.option('--insecure', '-k', is_flag=True,
               help='Do not verify SSL certificates')
 @click.option('--version', '-v', default=configuration.DEFAULT_VERSION)
-@click.option('--username', '-u', required=True)
-@click.option('--password', '-p', required=True)
-def add_profile_to_config(url, config, profile, insecure, version, username, password):
+def add_profile_to_config(url, config, profile, insecure, version):
     """Add profile to config file."""
     configuration.Manager(config).add_profile(
         profile,
-        username,
-        password,
         url,
         version=version,
         insecure=insecure,
@@ -283,12 +279,14 @@ def add_profile_to_config(url, config, profile, insecure, version, username, pas
 @click_global_conf
 @click.pass_context
 @error_printer
-def login(ctx):
+@click.option('--username', '-u', prompt=True)
+@click.option('--password', '-p', prompt=True, hide_input=True)
+def login(ctx, username, password):
     """Login to the Substra platform."""
     usr.Manager(ctx.obj.user).clear_user()
     client = get_client(ctx.obj)
 
-    token = client.login()
+    token = client.login(username, password)
     # create temporary user data
     usr.Manager(ctx.obj.user).add_user(token)
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -279,8 +279,8 @@ def add_profile_to_config(url, config, profile, insecure, version):
 @click_global_conf
 @click.pass_context
 @error_printer
-@click.option('--username', '-u', prompt=True)
-@click.option('--password', '-p', prompt=True, hide_input=True)
+@click.option('--username', '-u', envvar='SUBSTRA_USERNAME', prompt=True)
+@click.option('--password', '-p', envvar='SUBSTRA_PASSWORD', prompt=True, hide_input=True)
 def login(ctx, username, password):
     """Login to the Substra platform."""
     usr.Manager(ctx.obj.user).clear_user()

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -289,6 +289,7 @@ def login(ctx, username, password):
     token = client.login(username, password)
     # create temporary user data
     usr.Manager(ctx.obj.user).add_user(token)
+    display(f"Token: {token}")
 
 
 @cli.group()

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -19,8 +19,6 @@ import os
 import time
 import json
 
-import keyring
-
 from substra.sdk import utils, assets, rest_client, exceptions
 from substra.sdk import config as cfg
 from substra.sdk import user as usr
@@ -57,7 +55,7 @@ def get_asset_key(data):
 class Client(object):
 
     def __init__(self, config_path=None, profile_name=None, user_path=None,
-                 retry_timeout=DEFAULT_RETRY_TIMEOUT):
+                 token=None, retry_timeout=DEFAULT_RETRY_TIMEOUT):
         self._cfg_manager = cfg.Manager(config_path or cfg.DEFAULT_PATH)
         self._usr_manager = usr.Manager(user_path or usr.DEFAULT_PATH)
         self._current_profile = None
@@ -73,15 +71,18 @@ class Client(object):
         # set current logged user if exists
         self.set_user()
 
+        if token:
+            self.set_token(token)
+
     @logit
-    def login(self):
+    def login(self, username, password):
         """Login.
 
         Allow to login to a remote server.
 
-        After setting your configuration with `substra config` using `-u` and `-p`
-        Launch `substra login`
-        You will get a token which will be stored by default in `~/.substra-user`
+        After setting your configuration with `substra config`, launch `substra login`.
+        You will be prompted for your username and password and get a token which will be
+        stored by default in `~/.substra-user`
         You can change that thanks to the --user option (works like the --profile option)
 
         """
@@ -89,8 +90,15 @@ class Client(object):
         if not self._current_profile:
             raise exceptions.SDKException("No profile defined")
 
-        res = self.client.login()
+        res = self.client.login(username, password)
         token = res.json()['token']
+        self.set_token(token)
+        return token
+
+    def set_token(self, token):
+        if not self._current_profile:
+            raise exceptions.SDKException("No profile defined")
+
         self._current_profile.update({
             'token': token,
         })
@@ -131,15 +139,13 @@ class Client(object):
                 })
                 self.client.set_config(self._current_profile, self._profile_name)
 
-    def add_profile(self, profile_name, username, password, url, version='0.0', insecure=False):
+    def add_profile(self, profile_name, url, version='0.0', insecure=False):
         """Add new profile (in-memory only)."""
         profile = cfg.create_profile(
             url=url,
             version=version,
             insecure=insecure,
-            username=username,
         )
-        keyring.set_password(profile_name, username, password)
         return self._set_current_profile(profile_name, profile)
 
     def _add(self, asset, data, files=None, exist_ok=False):

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -72,19 +72,14 @@ class Client(object):
         self.set_user()
 
         if token:
-            self.set_token(token)
+            self._set_token(token)
 
     @logit
     def login(self, username, password):
-        """Login.
+        """Login to a remote server.
 
-        Allow to login to a remote server.
-
-        After setting your configuration with `substra config`, launch `substra login`.
-        You will be prompted for your username and password and get a token which will be
-        stored by default in `~/.substra-user`
-        You can change that thanks to the --user option (works like the --profile option)
-
+        Will log into the current profile's server and save the resulting token in the configured
+        user_path.
         """
 
         if not self._current_profile:
@@ -92,10 +87,10 @@ class Client(object):
 
         res = self.client.login(username, password)
         token = res.json()['token']
-        self.set_token(token)
+        self._set_token(token)
         return token
 
-    def set_token(self, token):
+    def _set_token(self, token):
         if not self._current_profile:
             raise exceptions.SDKException("No profile defined")
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -76,11 +76,7 @@ class Client(object):
 
     @logit
     def login(self, username, password):
-        """Login to a remote server.
-
-        Will log into the current profile's server and save the resulting token in the configured
-        user_path.
-        """
+        """Login to a remote server. """
 
         if not self._current_profile:
             raise exceptions.SDKException("No profile defined")

--- a/substra/sdk/config.py
+++ b/substra/sdk/config.py
@@ -17,23 +17,19 @@ import json
 import logging
 import os
 
-import keyring
-
 logger = logging.getLogger(__name__)
 
 DEFAULT_PATH = os.path.expanduser('~/.substra')
 DEFAULT_VERSION = '0.0'
 DEFAULT_URL = 'http://127.0.0.1:8000'
 DEFAULT_PROFILE_NAME = 'default'
+DEFAULT_INSECURE = False
 
 DEFAULT_CONFIG = {
-    'default': {
-        'url': 'http://127.0.0.1:8000',
-        'version': '0.0',
-        'auth': {
-            'username': 'foo'
-        },
-        'insecure': False,
+    DEFAULT_PROFILE_NAME: {
+        'url': DEFAULT_URL,
+        'version': DEFAULT_VERSION,
+        'insecure': DEFAULT_INSECURE,
     }
 }
 
@@ -62,19 +58,16 @@ def _write_config(path, config):
         json.dump(config, fh, indent=2, sort_keys=True)
 
 
-def create_profile(url, version, insecure, username):
+def create_profile(url, version, insecure):
     """Create profile object."""
     return {
         'url': url,
         'version': version,
         'insecure': insecure,
-        'auth': {
-            'username': username,
-        },
     }
 
 
-def _add_profile(path, name, url, username, version, insecure):
+def _add_profile(path, name, url, version, insecure):
     """Add profile to config file on disk."""
     # read config file
     try:
@@ -83,7 +76,7 @@ def _add_profile(path, name, url, username, version, insecure):
         config = copy.deepcopy(DEFAULT_CONFIG)
 
     # create profile
-    profile = create_profile(url, version, insecure, username)
+    profile = create_profile(url, version, insecure)
 
     # update config file
     if name in config:
@@ -114,18 +107,16 @@ class Manager():
     def __init__(self, path=DEFAULT_PATH):
         self.path = path
 
-    def add_profile(self, name, username, password, url=DEFAULT_URL,
+    def add_profile(self, name, url=DEFAULT_URL,
                     version=DEFAULT_VERSION, insecure=False):
         """Add profile to config file on disk."""
         config = _add_profile(
             self.path,
             name,
             url,
-            username,
             version=version,
             insecure=insecure,
         )
-        keyring.set_password(name, username, password)
         return config[name]
 
     def load_profile(self, name):

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -155,8 +155,3 @@ class BadConfiguration(SDKException):
 class UserException(SDKException):
     """User Exception"""
     pass
-
-
-class KeyringException(SDKException):
-    """Could not retrieve password from keyring"""
-    pass

--- a/tests/sdk/conftest.py
+++ b/tests/sdk/conftest.py
@@ -21,7 +21,7 @@ import substra
 def client(tmpdir):
     config_path = tmpdir / "substra.cfg"
     c = substra.Client(config_path=str(config_path))
-    c.add_profile('test', 'foo', 'password', url="http://foo.io")
+    c.add_profile('test', url="http://foo.io")
     return c
 
 

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -25,8 +25,6 @@ def test_add_load_profile(tmpdir):
 
     profile_1 = manager.add_profile(
         'owkin',
-        'substra',
-        'p@$swr0d44',
         url='http://substra-backend.owkin.xyz:8000',
         version='0.0')
 
@@ -38,9 +36,6 @@ def test_add_load_profile_from_file(tmpdir):
     path = tmpdir / 'substra.cfg'
     conf = {
        "node-1": {
-           "auth": {
-               "username": "node-1"
-           },
            "insecure": False,
            "url": "http://substra-backend.node-1.com",
            "version": "0.0"
@@ -82,4 +77,28 @@ def test_login_without_profile(tmpdir):
     client = substra.Client()
 
     with pytest.raises(substra.exceptions.SDKException):
-        client.login()
+        client.login('foo', 'bar')
+
+def test_token_without_user_path(tmpdir):
+    config_path = tmpdir / 'substra.json'
+    config_path.write_text(json.dumps(configuration.DEFAULT_CONFIG), "UTF-8")
+
+    client = substra.Client(config_path=config_path, profile_name='default')
+    assert client._current_profile['token'] == ''
+
+    client = substra.Client(config_path=config_path, profile_name='default', token='foo')
+    assert client._current_profile['token'] == 'foo'
+
+
+def test_token_with_user_path(tmpdir):
+    config_path = tmpdir / 'substra.json'
+    config_path.write_text(json.dumps(configuration.DEFAULT_CONFIG), "UTF-8")
+
+    user_path = tmpdir / 'substra-user.json'
+    user_path.write_text(json.dumps({'token': 'foo'}), "UTF-8")
+
+    client = substra.Client(config_path=config_path, profile_name='default', user_path=user_path)
+    assert client._current_profile['token'] == 'foo'
+
+    client = substra.Client(config_path=config_path, profile_name='default', user_path=user_path, token='bar')
+    assert client._current_profile['token'] == 'bar'

--- a/tests/sdk/test_config.py
+++ b/tests/sdk/test_config.py
@@ -79,6 +79,7 @@ def test_login_without_profile(tmpdir):
     with pytest.raises(substra.exceptions.SDKException):
         client.login('foo', 'bar')
 
+
 def test_token_without_user_path(tmpdir):
     config_path = tmpdir / 'substra.json'
     config_path.write_text(json.dumps(configuration.DEFAULT_CONFIG), "UTF-8")
@@ -100,5 +101,6 @@ def test_token_with_user_path(tmpdir):
     client = substra.Client(config_path=config_path, profile_name='default', user_path=user_path)
     assert client._current_profile['token'] == 'foo'
 
-    client = substra.Client(config_path=config_path, profile_name='default', user_path=user_path, token='bar')
+    client = substra.Client(config_path=config_path, profile_name='default', user_path=user_path,
+                            token='bar')
     assert client._current_profile['token'] == 'bar'

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -23,27 +23,18 @@ from .utils import mock_response, mock_requests, mock_requests_responses
 CONFIG = {
     'url': 'http://foo.com',
     'version': '1.0',
-    'auth': {
-        'username': 'foo',
-    },
     'insecure': False,
 }
 
 CONFIG_SECURE = {
     'url': 'http://foo.com',
     'version': '1.0',
-    'auth': {
-        'username': 'foo',
-    },
     'insecure': False,
 }
 
 CONFIG_INSECURE = {
     'url': 'http://foo.com',
     'version': '1.0',
-    'auth': {
-        'username': 'foo',
-    },
     'insecure': True,
 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,8 +52,7 @@ def client_execute(directory, command, exit_code=0):
     # force using a new config file and a new profile
     if '--config' not in command:
         cfgpath = directory / 'substra.cfg'
-        substra.sdk.config.Manager(str(cfgpath)).add_profile(
-            'default', 'username', 'password', url='http://foo')
+        substra.sdk.config.Manager(str(cfgpath)).add_profile('default', url='http://foo')
         command.extend(['--config', str(cfgpath)])
     return execute(command, exit_code=exit_code)
 
@@ -80,8 +79,6 @@ def test_command_config(workdir):
         new_url,
         '--profile', new_profile,
         '--config', str(cfgfile),
-        '-u', 'foo',
-        '-p', 'bar'
     ])
     assert cfgfile.exists()
 
@@ -100,7 +97,7 @@ def mock_client_call(mocker, method_name, response="", side_effect=None):
 
 def test_command_login(workdir, mocker):
     m = mock_client_call(mocker, 'login')
-    client_execute(workdir, ['login'])
+    client_execute(workdir, ['login', '--username', 'foo', '--password', 'bar'])
     m.assert_called()
 
 


### PR DESCRIPTION
This PR removes the storage of user passwords in the keyring. 

The client can now be initialized with an existing token or will use the one from `~/.substra-user`.

## CLI changes

- removed `--username` and `--password` options from the `config` command
- added `--username` and `--password` options to the `login` command. If not provided at call, the command will prompt the user for values and the password won't be displayed at all.

## SDK changes

- the `Client` constructor takes an optional `token` arg instead of the previous `username` and `password`
- `add_profile` doesn't have `username` and `password` anymore
- new `set_token` method

## Companion PRs

Since this introduces a change in our public interface, there are a few companion PRs:
* substra-backend: https://github.com/SubstraFoundation/substra-backend/pull/202
* substra-tests: https://github.com/SubstraFoundation/substra-tests/pull/94
* ~hlf-k8s: https://github.com/SubstraFoundation/hlf-k8s/pull/42~
* substra-documentation: https://github.com/SubstraFoundation/substra-documentation/pull/53

Fixes #97 (makes it irrelevant)
Fixes #165 