### PR TITLE
Document when AlreadyExists exception are raised

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,13 @@ pyclean:
 	find . -type d -name "__pycache__" -delete
 	rm -rf build/ dist/ *.egg-info
 
-doc:
+doc-cli:
 	python bin/generate_cli_documentation.py
+
+doc-sdk:
 	pydocmd simple substra.sdk+ substra.sdk.Client+ > references/sdk.md
+
+doc: doc-cli doc-sdk
 
 test: pyclean
 	python setup.py test

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -173,7 +173,8 @@ Create new algo asset.
 }
 ```
 
-If an algo with the same file already exists, an `AlreadyExists` exception will be raised.
+If an algo with the same archive file already exists, an `AlreadyExists` exception will be
+raised.
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
@@ -195,8 +196,8 @@ Create new aggregate algo asset.
     },
 }
 ```
-If an aggregate algo with the same file already exists, an `AlreadyExists` exception will
-be raised.
+If an aggregate algo with the same archive file already exists, an `AlreadyExists`
+exception will be raised.
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
@@ -218,8 +219,8 @@ Create new composite algo asset.
     },
 }
 ```
-If a composite algo with the same file already exists, an `AlreadyExists` exception will be
-raised.
+If a composite algo with the same archive file already exists, an `AlreadyExists` exception
+will be raised.
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -324,7 +324,8 @@ Create new testtuple asset.
 ```
 
 An `AlreadyExists` exception will be raised if a traintuple already exists that:
-* has the same `traintuple_key`, `data_manager_key` and `test_data_sample_keys`
+* has the same `traintuple_key`, `objective_key`, `data_manager_key` and
+  `test_data_sample_keys`
 * and was created through the same node you are using
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -60,6 +60,9 @@ If `local` is false, `path` must refer to a directory located on the server
 filesystem. This directory must be accessible (readable) by the server.  This
 mode is well suited for all kind of file sizes.
 
+If a data sample with the same content already exists, an `AlreadyExists` exception will be
+raised.
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -90,6 +93,9 @@ This method is well suited for adding multiple small files only. For adding a
 large amount of data it is recommended to add them one by one. It allows a
 better control in case of failures.
 
+If data samples with the same content as any of the paths already exists, an `AlreadyExists`
+exception will be raised.
+
 ## add_dataset
 ```python
 Client.add_dataset(self, data, exist_ok=False)
@@ -111,6 +117,9 @@ Create new dataset asset.
     },
 }
 ```
+
+If a dataset with the same opener already exists, an `AlreadyExists` exception will be
+raised.
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
@@ -138,6 +147,9 @@ Create new objective asset.
 }
 ```
 
+If an objective with the same description already exists, an `AlreadyExists` exception will
+be raised.
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -161,6 +173,8 @@ Create new algo asset.
 }
 ```
 
+If an algo with the same file already exists, an `AlreadyExists` exception will be raised.
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -181,6 +195,9 @@ Create new aggregate algo asset.
     },
 }
 ```
+If an aggregate algo with the same file already exists, an `AlreadyExists` exception will
+be raised.
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -201,6 +218,9 @@ Create new composite algo asset.
     },
 }
 ```
+If a composite algo with the same file already exists, an `AlreadyExists` exception will be
+raised.
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -223,6 +243,9 @@ Create new traintuple asset.
     "compute_plan_id": str,
 }
 ```
+An `AlreadyExists` exception will be raised if a traintuple already exists that:
+* has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
+* and was created through the same node you are using
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
@@ -243,6 +266,10 @@ Create new aggregatetuple asset.
     "worker": str,
 }
 ```
+An `AlreadyExists` exception will be raised if an aggregatetuple already exists that:
+* has the same `algo_key` and `in_models_keys`
+* and was created through the same node you are using
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -270,6 +297,11 @@ Create new composite traintuple asset.
 As specified in the data dict structure, output trunk models cannot be made
 public.
 
+An `AlreadyExists` exception will be raised if a traintuple already exists that:
+* has the same `algo_key`, `data_manager_key`, `train_data_sample_keys`,
+  `in_head_models_key` and `in_trunk_model_key`
+* and was created through the same node you are using
+
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.
 
@@ -290,6 +322,10 @@ Create new testtuple asset.
     "tag": str,
 }
 ```
+
+An `AlreadyExists` exception will be raised if a traintuple already exists that:
+* has the same `traintuple_key`, `data_manager_key` and `test_data_sample_keys`
+* and was created through the same node you are using
 
 If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
 existing asset will be returned.

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -220,6 +220,9 @@ class Client(object):
         filesystem. This directory must be accessible (readable) by the server.  This
         mode is well suited for all kind of file sizes.
 
+        If a data sample with the same content already exists, an `AlreadyExists` exception will be
+        raised.
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
 
@@ -266,6 +269,9 @@ class Client(object):
         This method is well suited for adding multiple small files only. For adding a
         large amount of data it is recommended to add them one by one. It allows a
         better control in case of failures.
+
+        If data samples with the same content as any of the paths already exists, an `AlreadyExists`
+        exception will be raised.
         """
         data = _update_permissions_field(data)
         if 'path' in data:
@@ -293,6 +299,9 @@ class Client(object):
             },
         }
 ```
+
+        If a dataset with the same opener already exists, an `AlreadyExists` exception will be
+        raised.
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
@@ -327,6 +336,9 @@ class Client(object):
         }
 ```
 
+        If an objective with the same description already exists, an `AlreadyExists` exception will
+        be raised.
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -357,6 +369,8 @@ class Client(object):
         }
 ```
 
+        If an algo with the same file already exists, an `AlreadyExists` exception will be raised.
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -384,6 +398,9 @@ class Client(object):
             },
         }
 ```
+        If an aggregate algo with the same file already exists, an `AlreadyExists` exception will
+        be raised.
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -411,6 +428,9 @@ class Client(object):
             },
         }
 ```
+        If a composite algo with the same file already exists, an `AlreadyExists` exception will be
+        raised.
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -440,6 +460,9 @@ class Client(object):
             "compute_plan_id": str,
         }
 ```
+        An `AlreadyExists` exception will be raised if a traintuple already exists that:
+        * has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
+        * and was created through the same node you are using
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
@@ -464,6 +487,10 @@ class Client(object):
             "worker": str,
         }
 ```
+        An `AlreadyExists` exception will be raised if an aggregatetuple already exists that:
+        * has the same `algo_key` and `in_models_keys`
+        * and was created through the same node you are using
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -495,6 +522,11 @@ class Client(object):
         As specified in the data dict structure, output trunk models cannot be made
         public.
 
+        An `AlreadyExists` exception will be raised if a traintuple already exists that:
+        * has the same `algo_key`, `data_manager_key`, `train_data_sample_keys`,
+          `in_head_models_key` and `in_trunk_model_key`
+        * and was created through the same node you are using
+
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
         """
@@ -520,6 +552,10 @@ class Client(object):
             "tag": str,
         }
 ```
+
+        An `AlreadyExists` exception will be raised if a traintuple already exists that:
+        * has the same `traintuple_key`, `data_manager_key` and `test_data_sample_keys`
+        * and was created through the same node you are using
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -369,7 +369,8 @@ class Client(object):
         }
 ```
 
-        If an algo with the same file already exists, an `AlreadyExists` exception will be raised.
+        If an algo with the same archive file already exists, an `AlreadyExists` exception will be
+        raised.
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
@@ -398,8 +399,8 @@ class Client(object):
             },
         }
 ```
-        If an aggregate algo with the same file already exists, an `AlreadyExists` exception will
-        be raised.
+        If an aggregate algo with the same archive file already exists, an `AlreadyExists`
+        exception will be raised.
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.
@@ -428,8 +429,8 @@ class Client(object):
             },
         }
 ```
-        If a composite algo with the same file already exists, an `AlreadyExists` exception will be
-        raised.
+        If a composite algo with the same archive file already exists, an `AlreadyExists` exception
+        will be raised.
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
         existing asset will be returned.

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -554,7 +554,8 @@ class Client(object):
 ```
 
         An `AlreadyExists` exception will be raised if a traintuple already exists that:
-        * has the same `traintuple_key`, `data_manager_key` and `test_data_sample_keys`
+        * has the same `traintuple_key`, `objective_key`, `data_manager_key` and
+          `test_data_sample_keys`
         * and was created through the same node you are using
 
         If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the


### PR DESCRIPTION
This branch adds documentation to `add_` methods in the client specifying when the `AlreadyExists` exception are raised.

To make the generation of documentation a bit faster when testing, I to the makefile two new targets: `doc-cli` and `doc-sdk`.

Fixes #92 