### PR TITLE
Type hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ sdist/
 .cache
 .coverage
 .pytest_cache/
+.mypy_cache/
 
 # Developer environments
 .idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ deploy:
 script:
   - pip install flake8
   - flake8 substra
+  - pip install mypy
+  - make check-type
   - pip install -e .[test]
   - python setup.py test
   - python bin/generate_cli_documentation.py --output-path references/cli.md.tmp

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ doc:
 
 test: pyclean
 	python setup.py test
+
+check-type:
+	mypy --check-untyped-defs substra/ tests/

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -2,12 +2,12 @@
 
 # Client
 ```python
-Client(self, config_path=None, profile_name=None, user_path=None, retry_timeout=300)
+Client(self, config_path: str = None, profile_name: str = None, user_path: str = None, retry_timeout: int = 300) -> None
 ```
 
 ## login
 ```python
-Client.login(self)
+Client.login(self) -> str
 ```
 Login.
 
@@ -21,7 +21,7 @@ You can change that thanks to the --user option (works like the --profile option
 
 ## set_profile
 ```python
-Client.set_profile(self, profile_name)
+Client.set_profile(self, profile_name: str) -> Dict[str, str]
 ```
 Set profile from profile name.
 
@@ -30,12 +30,12 @@ from the config file.
 
 ## add_profile
 ```python
-Client.add_profile(self, profile_name, username, password, url, version='0.0', insecure=False)
+Client.add_profile(self, profile_name: str, username: str, password: str, url: str, version: str = '0.0', insecure: bool = False) -> Dict[str, str]
 ```
 Add new profile (in-memory only).
 ## add_data_sample
 ```python
-Client.add_data_sample(self, data, local=True, exist_ok=False)
+Client.add_data_sample(self, data: dict, local: bool = True, exist_ok: bool = False) -> dict
 ```
 Create new data sample asset.
 
@@ -66,7 +66,7 @@ existing asset will be returned.
 
 ## add_data_samples
 ```python
-Client.add_data_samples(self, data, local=True)
+Client.add_data_samples(self, data: dict, local: bool = True) -> List[dict]
 ```
 Create many data sample assets.
 
@@ -92,7 +92,7 @@ better control in case of failures.
 
 ## add_dataset
 ```python
-Client.add_dataset(self, data, exist_ok=False)
+Client.add_dataset(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new dataset asset.
 
@@ -117,7 +117,7 @@ existing asset will be returned.
 
 ## add_objective
 ```python
-Client.add_objective(self, data, exist_ok=False)
+Client.add_objective(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new objective asset.
 
@@ -143,7 +143,7 @@ existing asset will be returned.
 
 ## add_algo
 ```python
-Client.add_algo(self, data, exist_ok=False)
+Client.add_algo(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new algo asset.
 
@@ -166,7 +166,7 @@ existing asset will be returned.
 
 ## add_aggregate_algo
 ```python
-Client.add_aggregate_algo(self, data, exist_ok=False)
+Client.add_aggregate_algo(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new aggregate algo asset.
 `data` is a dict object with the following schema:
@@ -186,7 +186,7 @@ existing asset will be returned.
 
 ## add_composite_algo
 ```python
-Client.add_composite_algo(self, data, exist_ok=False)
+Client.add_composite_algo(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new composite algo asset.
 `data` is a dict object with the following schema:
@@ -206,7 +206,7 @@ existing asset will be returned.
 
 ## add_traintuple
 ```python
-Client.add_traintuple(self, data, exist_ok=False)
+Client.add_traintuple(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new traintuple asset.
 
@@ -229,7 +229,7 @@ existing asset will be returned.
 
 ## add_aggregatetuple
 ```python
-Client.add_aggregatetuple(self, data, exist_ok=False)
+Client.add_aggregatetuple(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new aggregatetuple asset.
 `data` is a dict object with the following schema:
@@ -248,7 +248,7 @@ existing asset will be returned.
 
 ## add_composite_traintuple
 ```python
-Client.add_composite_traintuple(self, data, exist_ok=False)
+Client.add_composite_traintuple(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new composite traintuple asset.
 `data` is a dict object with the following schema:
@@ -275,7 +275,7 @@ existing asset will be returned.
 
 ## add_testtuple
 ```python
-Client.add_testtuple(self, data, exist_ok=False)
+Client.add_testtuple(self, data: dict, exist_ok: bool = False) -> dict
 ```
 Create new testtuple asset.
 
@@ -296,7 +296,7 @@ existing asset will be returned.
 
 ## add_compute_plan
 ```python
-Client.add_compute_plan(self, data)
+Client.add_compute_plan(self, data: dict) -> dict
 ```
 Create compute plan.
 
@@ -346,122 +346,122 @@ traintuples cannot be made public.
 
 ## get_algo
 ```python
-Client.get_algo(self, algo_key)
+Client.get_algo(self, algo_key: str) -> dict
 ```
 Get algo by key.
 ## get_compute_plan
 ```python
-Client.get_compute_plan(self, compute_plan_key)
+Client.get_compute_plan(self, compute_plan_key: str) -> dict
 ```
 Get compute plan by key.
 ## get_aggregate_algo
 ```python
-Client.get_aggregate_algo(self, aggregate_algo_key)
+Client.get_aggregate_algo(self, aggregate_algo_key: str) -> dict
 ```
 Get aggregate algo by key.
 ## get_composite_algo
 ```python
-Client.get_composite_algo(self, composite_algo_key)
+Client.get_composite_algo(self, composite_algo_key: str) -> dict
 ```
 Get composite algo by key.
 ## get_dataset
 ```python
-Client.get_dataset(self, dataset_key)
+Client.get_dataset(self, dataset_key: str) -> dict
 ```
 Get dataset by key.
 ## get_objective
 ```python
-Client.get_objective(self, objective_key)
+Client.get_objective(self, objective_key: str) -> dict
 ```
 Get objective by key.
 ## get_testtuple
 ```python
-Client.get_testtuple(self, testtuple_key)
+Client.get_testtuple(self, testtuple_key: str) -> dict
 ```
 Get testtuple by key.
 ## get_traintuple
 ```python
-Client.get_traintuple(self, traintuple_key)
+Client.get_traintuple(self, traintuple_key: str) -> dict
 ```
 Get traintuple by key.
 ## get_aggregatetuple
 ```python
-Client.get_aggregatetuple(self, aggregatetuple_key)
+Client.get_aggregatetuple(self, aggregatetuple_key: str) -> dict
 ```
 Get aggregatetuple by key.
 ## get_composite_traintuple
 ```python
-Client.get_composite_traintuple(self, composite_traintuple_key)
+Client.get_composite_traintuple(self, composite_traintuple_key: str) -> dict
 ```
 Get composite traintuple by key.
 ## list_algo
 ```python
-Client.list_algo(self, filters=None, is_complex=False)
+Client.list_algo(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List algos.
 ## list_compute_plan
 ```python
-Client.list_compute_plan(self, filters=None, is_complex=False)
+Client.list_compute_plan(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List compute plans.
 ## list_aggregate_algo
 ```python
-Client.list_aggregate_algo(self, filters=None, is_complex=False)
+Client.list_aggregate_algo(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List aggregate algos.
 ## list_composite_algo
 ```python
-Client.list_composite_algo(self, filters=None, is_complex=False)
+Client.list_composite_algo(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List composite algos.
 ## list_data_sample
 ```python
-Client.list_data_sample(self, filters=None, is_complex=False)
+Client.list_data_sample(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List data samples.
 ## list_dataset
 ```python
-Client.list_dataset(self, filters=None, is_complex=False)
+Client.list_dataset(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List datasets.
 ## list_objective
 ```python
-Client.list_objective(self, filters=None, is_complex=False)
+Client.list_objective(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List objectives.
 ## list_testtuple
 ```python
-Client.list_testtuple(self, filters=None, is_complex=False)
+Client.list_testtuple(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List testtuples.
 ## list_traintuple
 ```python
-Client.list_traintuple(self, filters=None, is_complex=False)
+Client.list_traintuple(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List traintuples.
 ## list_aggregatetuple
 ```python
-Client.list_aggregatetuple(self, filters=None, is_complex=False)
+Client.list_aggregatetuple(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List aggregatetuples.
 ## list_composite_traintuple
 ```python
-Client.list_composite_traintuple(self, filters=None, is_complex=False)
+Client.list_composite_traintuple(self, filters: Union[List[str], NoneType] = None, is_complex: bool = False) -> List[dict]
 ```
 List composite traintuples.
 ## list_node
 ```python
-Client.list_node(self, *args, **kwargs)
+Client.list_node(self) -> List[dict]
 ```
 List nodes.
 ## update_dataset
 ```python
-Client.update_dataset(self, dataset_key, data)
+Client.update_dataset(self, dataset_key: str, data: dict) -> dict
 ```
 Update dataset.
 ## update_compute_plan
 ```python
-Client.update_compute_plan(self, compute_plan_id, data)
+Client.update_compute_plan(self, compute_plan_id: str, data: dict) -> dict
 ```
 Update compute plan.
 
@@ -512,17 +512,17 @@ traintuples cannot be made public.
 
 ## link_dataset_with_objective
 ```python
-Client.link_dataset_with_objective(self, dataset_key, objective_key)
+Client.link_dataset_with_objective(self, dataset_key: str, objective_key: str) -> dict
 ```
 Link dataset with objective.
 ## link_dataset_with_data_samples
 ```python
-Client.link_dataset_with_data_samples(self, dataset_key, data_sample_keys)
+Client.link_dataset_with_data_samples(self, dataset_key: str, data_sample_keys: List[str]) -> dict
 ```
 Link dataset with data samples.
 ## download_dataset
 ```python
-Client.download_dataset(self, asset_key, destination_folder)
+Client.download_dataset(self, asset_key: str, destination_folder: str) -> None
 ```
 Download data manager resource.
 
@@ -530,7 +530,7 @@ Download opener script in destination folder.
 
 ## download_algo
 ```python
-Client.download_algo(self, asset_key, destination_folder)
+Client.download_algo(self, asset_key: str, destination_folder: str) -> None
 ```
 Download algo resource.
 
@@ -538,7 +538,7 @@ Download algo package in destination folder.
 
 ## download_aggregate_algo
 ```python
-Client.download_aggregate_algo(self, asset_key, destination_folder)
+Client.download_aggregate_algo(self, asset_key: str, destination_folder: str) -> None
 ```
 Download aggregate algo resource.
 
@@ -546,7 +546,7 @@ Download aggregate algo package in destination folder.
 
 ## download_composite_algo
 ```python
-Client.download_composite_algo(self, asset_key, destination_folder)
+Client.download_composite_algo(self, asset_key: str, destination_folder: str) -> None
 ```
 Download composite algo resource.
 
@@ -554,7 +554,7 @@ Download composite algo package in destination folder.
 
 ## download_objective
 ```python
-Client.download_objective(self, asset_key, destination_folder)
+Client.download_objective(self, asset_key: str, destination_folder: str) -> None
 ```
 Download objective resource.
 
@@ -562,36 +562,36 @@ Download metrics script in destination folder.
 
 ## describe_algo
 ```python
-Client.describe_algo(self, asset_key)
+Client.describe_algo(self, asset_key: str) -> str
 ```
 Get algo description.
 ## describe_aggregate_algo
 ```python
-Client.describe_aggregate_algo(self, asset_key)
+Client.describe_aggregate_algo(self, asset_key: str) -> str
 ```
 Get aggregate algo description.
 ## describe_composite_algo
 ```python
-Client.describe_composite_algo(self, asset_key)
+Client.describe_composite_algo(self, asset_key: str) -> str
 ```
 Get composite algo description.
 ## describe_dataset
 ```python
-Client.describe_dataset(self, asset_key)
+Client.describe_dataset(self, asset_key: str) -> str
 ```
 Get dataset description.
 ## describe_objective
 ```python
-Client.describe_objective(self, asset_key)
+Client.describe_objective(self, asset_key: str) -> str
 ```
 Get objective description.
 ## leaderboard
 ```python
-Client.leaderboard(self, objective_key, sort='desc')
+Client.leaderboard(self, objective_key: str, sort: str = 'desc') -> dict
 ```
 Get objective leaderboard
 ## cancel_compute_plan
 ```python
-Client.cancel_compute_plan(self, compute_plan_id)
+Client.cancel_compute_plan(self, compute_plan_id: str) -> dict
 ```
 Cancel execution of compute plan.

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,9 @@ ignore_missing_imports = True
 
 [mypy-consolemd]
 ignore_missing_imports = True
+
+[mypy-substra.sdk.client]
+disallow_untyped_defs = True
+
+[mypy-substra.sdk.exceptions]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,15 @@ test=pytest
 
 [tool:pytest]
 addopts = -v --cov=substra --ignore=tests/unit --ignore=tests/e2e
+
+[mypy-docker]
+ignore_missing_imports = True
+
+[mypy-keyring]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True
+
+[mypy-consolemd]
+ignore_missing_imports = True

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -14,6 +14,7 @@
 
 import json
 import math
+import typing
 
 import yaml
 
@@ -131,6 +132,7 @@ class ProgressField(Field):
 class MappingField(Field):
     def get_value(self, item, expand=False):
         mapping = super().get_value(item) or {}
+        value: typing.Union[str, typing.List[str]]
         if expand:
             value = [f'{k}:{v}' for k, v in mapping.items()]
         else:
@@ -182,13 +184,13 @@ class BasePrinter:
 
 
 class AssetPrinter(BasePrinter):
-    asset_name = None
+    asset_name: str
 
     key_field = Field('key', 'key')
-    list_fields = ()
-    single_fields = ()
+    list_fields: typing.Tuple[Field, ...] = ()
+    single_fields: typing.Tuple[Field, ...] = ()
 
-    download_message = None
+    download_message: typing.Optional[str] = None
     has_description = True
 
     def _get_list_fields(self):

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import time
+import typing
 
 import keyring
 import requests
@@ -104,6 +105,7 @@ class Client():
     def __request(self, request_name, url, **request_kwargs):
         """Base request helper."""
 
+        fn: typing.Callable
         if request_name == 'get':
             fn = requests.get
         elif request_name == 'post':


### PR DESCRIPTION
Fixes #142 

* Adds mypy to the project
* New makefile target: `check-type`
* Adds mypy check to travis config
* Adds type hints to client.py
* Adds type hints to exception.py

I recommend reading https://realpython.com/python-type-checking/ as a good introduction to type hints.

My comments after doing this preliminary work:
* `typing.cast` is needed in quite a few places but feels very wrong as it looks like a cast occurring at runtime but isn't, it's only here for static type checking https://mypy.readthedocs.io/en/stable/casts.html#casts
* understanding how to a add type hints to a decorator was pretty hard and the result is a bit puzzling
* the `exceptions.py` would need a pretty big refactoring if we wanted to remove the `# type: ignore` as the issue is not with the return values but with the number of args and their types.
* exceptions raised by functions can't be documented through type hints, they have to be documented using docstrings.
* the generated doc isn't improved, only more verbose

But the larger issue I have is that these type hints don't solve our documentation issue in any way. We could create very well defined types for each type of asset, but it would be the same amount of work as using pydantic to serialize/deserialize dict into proper objects with none of the added benefits (runtime checks, manipulating objects instead of dicts).

I do feel type hints have a role to play though, but only once we have proper objects that are themselves well documented, and without the strict setup that I tried here.