### PR TITLE
Prevent aggregatuples with less than 2 inmodels

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -420,7 +420,9 @@ Usage: substra add aggregatetuple [OPTIONS]
 
 Options:
   --algo-key TEXT                 Aggregate algo key.  [required]
-  --in-model-key TEXT             In model traintuple key.
+  --in-model-key TEXT             In model traintuple key (at least 2 keys
+                                  required).  [required]
+
   --worker TEXT                   Node ID for worker execution.  [required]
   --rank INTEGER
   --tag TEXT

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,15 +229,17 @@ def test_command_add_composite_traintuple_missing_model_key(mocker, workdir, par
     assert re.search(message, res)
 
 
-@pytest.mark.parametrize('params', [
-    [],
-    ['--in-model-key', 'bar']
+@pytest.mark.parametrize('params,exit_code', [
+    ([], 2),
+    (['--in-model-key', 'foo'], 2),
+    (['--in-model-key', 'foo', '--in-model-key', 'bar'], 0),
 ])
-def test_command_add_aggregatetuple(mocker, workdir, params):
+def test_command_add_aggregatetuple(mocker, workdir, params, exit_code):
     m = mock_client_call(mocker, 'add_aggregatetuple', response={})
-    client_execute(workdir, ['add', 'aggregatetuple', '--algo-key', 'foo',
-                             '--in-model-key', 'foo'] + params + ['--worker', 'foo'])
-    m.assert_called()
+    command = ['add', 'aggregatetuple', '--algo-key', 'foo', '--worker', 'foo'] + params
+    client_execute(workdir, command, exit_code)
+    if exit_code == 0:
+        m.assert_called()
 
 
 def test_command_add_testtuple_no_data_samples(mocker, workdir):


### PR DESCRIPTION
Companion PR: https://github.com/SubstraFoundation/substra-backend/pull/189

Prevent the creation (from the command line) of aggregatetuples with no in models or just 1 inmodel, since they don't make much sense (no aggregation to do).