### PR TITLE
Prevent from path traversal when extracting archives

### DIFF
--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1033,15 +1033,21 @@ def run_local(algo, train_opener, test_opener, metrics, rank,
         raise click.BadOptionUsage('--train-data-samples',
                                    'Missing option --train-data-samples')
 
-    runner.compute(algo_path=algo,
-                   train_opener_file=train_opener,
-                   test_opener_file=test_opener,
-                   metrics_path=metrics,
-                   train_data_path=train_data_samples,
-                   test_data_path=test_data_samples,
-                   fake_data_samples=fake_data_samples,
-                   rank=rank,
-                   inmodels=inmodels)
+    try:
+        runner.compute(algo_path=algo,
+                       train_opener_file=train_opener,
+                       test_opener_file=test_opener,
+                       metrics_path=metrics,
+                       train_data_path=train_data_samples,
+                       test_data_path=test_data_samples,
+                       fake_data_samples=fake_data_samples,
+                       rank=rank,
+                       inmodels=inmodels)
+    except runner.PathTraversalException as e:
+        raise click.ClickException(
+            f'Archive "{e.archive_path}" includes at least 1 file or folder '
+            f'located outside the archive root folder: "{e.issue_path}"'
+        )
 
 
 @cli.group()

--- a/substra/runner.py
+++ b/substra/runner.py
@@ -201,12 +201,48 @@ def compute_perf(pred_path, opener_file, fake_data_samples, data_path, docker_cl
     return perf['all']
 
 
+def raise_if_path_traversal(requested_paths, to_directory):
+    # Inspired from https://stackoverflow.com/a/45188896
+
+    safe_directory = os.path.join(
+        os.path.realpath(to_directory),
+        ''
+    )
+
+    if not isinstance(requested_paths, list):
+        raise TypeError(f'requested_paths argument should be a list not a {type(requested_paths)}')
+
+    for requested_path in requested_paths:
+        real_requested_path = os.path.realpath(requested_path)
+        path_traversal = os.path.commonprefix([real_requested_path,
+                                               safe_directory]) != safe_directory
+
+        if path_traversal:
+            raise Exception(
+                f'Path Traversal Error : {requested_path} '
+                f'(real : {real_requested_path}) is not safe.'
+            )
+
+
 def _extract_archive(archive_path, to_directory):
     if zipfile.is_zipfile(archive_path):
         with zipfile.ZipFile(archive_path, 'r') as zf:
+
+            # Check no path traversal
+            filenames = [os.path.join(to_directory, filename)
+                         for filename in zf.namelist()]
+            raise_if_path_traversal(filenames, to_directory)
+
             zf.extractall(to_directory)
+
     elif tarfile.is_tarfile(archive_path):
         with tarfile.open(archive_path, 'r:*') as tf:
+
+            # Check no path traversal
+            filenames = [os.path.join(to_directory, filename)
+                         for filename in tf.getnames()]
+            raise_if_path_traversal(filenames, to_directory)
+
             tf.extractall(to_directory)
     else:
         raise ValueError('Archive must be zip or tar.gz')

--- a/substra/runner.py
+++ b/substra/runner.py
@@ -204,6 +204,8 @@ def compute_perf(pred_path, opener_file, fake_data_samples, data_path, docker_cl
 def raise_if_path_traversal(requested_paths, to_directory):
     # Inspired from https://stackoverflow.com/a/45188896
 
+    # Get real path and ensure there is a suffix /
+    # at the end of the path
     safe_directory = os.path.join(
         os.path.realpath(to_directory),
         ''
@@ -214,10 +216,10 @@ def raise_if_path_traversal(requested_paths, to_directory):
 
     for requested_path in requested_paths:
         real_requested_path = os.path.realpath(requested_path)
-        path_traversal = os.path.commonprefix([real_requested_path,
-                                               safe_directory]) != safe_directory
+        is_traversal = os.path.commonprefix([real_requested_path,
+                                             safe_directory]) != safe_directory
 
-        if path_traversal:
+        if is_traversal:
             raise Exception(
                 f'Path Traversal Error : {requested_path} '
                 f'(real : {real_requested_path}) is not safe.'


### PR DESCRIPTION
Filenames should be validated when storing asset to prevent from path/directory traversal.
Companion PR :  https://github.com/SubstraFoundation/substra-backend/pull/192