### PR TITLE
Torch example

### DIFF
--- a/examples/torch/.gitignore
+++ b/examples/torch/.gitignore
@@ -1,0 +1,2 @@
+cifar_net.pth
+data/

--- a/examples/torch/README.md
+++ b/examples/torch/README.md
@@ -1,0 +1,11 @@
+# Torch example
+
+Adapt the CIFAR10 Classifier Torch tutorial to Substra.
+
+## Torch
+
+```
+python reference_tutorial.py
+```
+
+## Substra (requires a network up)

--- a/examples/torch/assets/algo/Dockerfile
+++ b/examples/torch/assets/algo/Dockerfile
@@ -1,0 +1,11 @@
+# this base image works in both CPU and GPU enabled environments
+FROM substrafoundation/substra-tools:0.5.0
+
+# install dependencies
+RUN pip3 install torch torchvision
+
+# add your algorithm script to docker image
+ADD algo.py .
+
+# define how script is run
+ENTRYPOINT ["python3", "algo.py"]

--- a/examples/torch/assets/algo/algo.py
+++ b/examples/torch/assets/algo/algo.py
@@ -1,0 +1,108 @@
+import logging
+
+import substratools as tools
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+
+logger = logging.getLogger(__name__)
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+class TorchClassifier(tools.algo.Algo):
+
+    def _serialize_train_state(self, model, optimizer):
+        """Returns single object with model and optimizer states."""
+        return {
+            'model': model,
+            'optimizer': optimizer,
+        }
+
+    def _deserialize_train_state(self, state):
+        """Returns model and optimizer states from previous ouput model train task."""
+        return state['model'], state['optimizer']
+
+    def train(self, X, y, models, rank):
+        """Training task implementation."""
+        net = Net()
+        optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
+        if rank > 0:
+            model_state, optimizer_state = self._deserialize_train_state(
+                models[0])
+
+            net.load_state_dict(model_state)
+            optimizer.load_state_dict(optimizer_state)
+
+        criterion = nn.CrossEntropyLoss()
+
+        running_loss = 0.0
+        i = 0
+        for inputs, labels in zip(X, y):
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+
+            i += 1
+            if i % 2000 == 1999:    # print every 2000 mini-batches
+                print(f'[{i + 1:5d}] loss: {running_loss / 2000:.3f}')
+                running_loss = 0.0
+
+        return self._serialize_train_state(net.state_dict(), optimizer.state_dict())
+
+    def predict(self, X, model):
+        """Predict task implementation."""
+        y_pred = []
+
+        model_state, _ = self._deserialize_train_state(model)
+
+        net = Net()
+        net.load_state_dict(model_state)
+
+        with torch.no_grad():
+            for images in X:
+                outputs = net(images)
+                _, predicted = torch.max(outputs, 1)
+                y_pred.append(predicted)
+
+        return y_pred
+
+    def save_model(self, model, path):
+        torch.save(model, path)
+
+    def load_model(self, path):
+        return torch.load(path)
+
+
+if __name__ == '__main__':
+    tools.algo.execute(TorchClassifier())

--- a/examples/torch/assets/algo/description.md
+++ b/examples/torch/assets/algo/description.md
@@ -1,0 +1,2 @@
+# Torch Classifier
+

--- a/examples/torch/assets/dataset/description.md
+++ b/examples/torch/assets/dataset/description.md
@@ -1,0 +1,3 @@
+# CIFAR10 Dataset
+
+https://pytorch.org/docs/stable/torchvision/datasets.html#cifar

--- a/examples/torch/assets/dataset/opener.py
+++ b/examples/torch/assets/dataset/opener.py
@@ -1,0 +1,97 @@
+import glob
+import os
+import pickle
+
+import numpy as np
+import PIL
+import substratools as tools
+import torch
+import torchvision.transforms as transforms
+
+
+class TorchDataset(torch.utils.data.Dataset):
+    def __init__(self, X, y, transform=None):
+        self.train = True
+        self.data = X
+        self.targets = y
+        self.transform = transform
+
+    def __getitem__(self, index):
+        img, target = self.data[index], self.targets[index]
+        img = PIL.Image.fromarray(img)
+
+        if self.transform is not None:
+            img = self.transform(img)
+
+        return img, target
+
+    def __len__(self):
+        return len(self.data)
+
+
+class TorchOpener(tools.Opener):
+
+    def __init__(self):
+        self._X = None
+        self._y = None
+
+    def _get_Xy(self, folders):
+        if self._X is not None:
+            return self._X, self._y
+
+        data = []
+        labels = []
+
+        for folder in folders:
+            # code from:
+            # https://pytorch.org/docs/stable/_modules/torchvision/datasets/cifar.html#CIFAR10
+            # each folder should contain a single numpy file
+            filepaths = glob.glob(os.path.join(folder, 'data_batch_*'))
+            assert len(filepaths) == 1
+            with open(filepaths[0], 'rb') as f:
+                entry = pickle.load(f, encoding='latin1')
+
+            data.append(entry['data'])
+            labels.extend(entry['labels'])
+
+        data = np.vstack(data).reshape(-1, 3, 32, 32)
+        data = data.transpose((0, 2, 3, 1))
+
+        transform = transforms.Compose(
+            [transforms.ToTensor(),
+             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+        shuffle = True
+        trainset = TorchDataset(data, labels, transform=transform)
+        trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                                  shuffle=shuffle, num_workers=2)
+
+        # TODO this is very unefficient as it will load all the data in memory.
+        X = []
+        y = []
+        for i, j in trainloader:
+            X.append(i)
+            y.append(j)
+
+        self._X = X
+        self._y = y
+        return self._X, self._y
+
+    def get_X(self, folders):
+        X, _ = self._get_Xy(folders)
+        return X
+
+    def get_y(self, folders):
+        _, y = self._get_Xy(folders)
+        return y
+
+    def save_predictions(self, y_pred, path):
+        torch.save(y_pred, path)
+
+    def get_predictions(self, path):
+        return torch.load(path)
+
+    def fake_X(self):
+        raise NotImplementedError
+
+    def fake_y(self):
+        raise NotImplementedError

--- a/examples/torch/assets/objective/Dockerfile
+++ b/examples/torch/assets/objective/Dockerfile
@@ -1,0 +1,11 @@
+# this base image works in both CPU and GPU enabled environments
+FROM substrafoundation/substra-tools:0.5.0
+
+# install dependencies
+RUN pip3 install torch torchvision
+
+# add your metrics script to docker image
+ADD metrics.py .
+
+# define how script is run
+ENTRYPOINT ["python3", "metrics.py"]

--- a/examples/torch/assets/objective/description.md
+++ b/examples/torch/assets/objective/description.md
@@ -1,0 +1,1 @@
+# Torch Classifier Objective

--- a/examples/torch/assets/objective/metrics.py
+++ b/examples/torch/assets/objective/metrics.py
@@ -1,0 +1,15 @@
+import substratools as tools
+
+
+class ClassifierMetrics(tools.Metrics):
+    def score(self, y_true, y_pred):
+        correct = 0
+        total = 0
+        for predicted, labels in zip(y_pred, y_true):
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+        return correct / total
+
+
+if __name__ == '__main__':
+    tools.metrics.execute(ClassifierMetrics())

--- a/examples/torch/substra-local.py
+++ b/examples/torch/substra-local.py
@@ -1,0 +1,103 @@
+import contextlib
+import importlib
+import logging
+from pathlib import Path
+import shutil
+import tarfile
+import tempfile
+
+import torchvision
+
+DATASET_ROOT = './data'
+CURRENT_DIR = Path(__file__).parent
+_CIFAR10_ARCHIVE_NAME = 'cifar-10-python.tar.gz'
+_OPENER_PATH = Path(CURRENT_DIR, 'assets/dataset/opener.py')
+_ALGO_PATH = Path(CURRENT_DIR, 'assets/algo/algo.py')
+_METRICS_PATH = Path(CURRENT_DIR, 'assets/objective/metrics.py')
+
+
+def _load_module(path, module_name):
+    """Import dynamically a python module."""
+    assert path.exists(), "path '{}' not found".format(path)
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec, "could not load spec from path '{}'".format(path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _untar(archive_path):
+    """Untar archive in its current folder."""
+    with tarfile.open(archive_path) as tar:
+        tar.extractall(archive_path.parent)
+
+
+@contextlib.contextmanager
+def _to_datasamples_tree(filepaths):
+    """Create a temporary data sample folders structure from input files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        folders = []
+        for index, src in enumerate(filepaths):
+            folder = Path(tmpdir, f'data_{index}/')
+            folder.mkdir()
+            # opener requires a filename data_batch_*
+            dst = Path(folder, f'data_batch_{index}')
+            shutil.copy(str(src), str(dst))
+
+            folders.append(str(folder))
+        yield folders
+
+
+def run():
+    """Run workflow in memory."""
+    # download data
+    torchvision.datasets.CIFAR10(root=DATASET_ROOT, download=True)
+    _untar(Path(DATASET_ROOT, _CIFAR10_ARCHIVE_NAME))
+
+    # load opener, algo and metrics from path
+    Opener = _load_module(_OPENER_PATH, 'opener').TorchOpener
+    algo = _load_module(_ALGO_PATH, 'algo').TorchClassifier()
+    metrics = _load_module(_METRICS_PATH, 'algo').ClassifierMetrics()
+
+    num_epochs = 2
+    num_cifar10_batches = 5
+    model = None
+    data_root = Path(DATASET_ROOT, 'cifar-10-batches-py')
+
+    # training
+    rank = 0
+    for epoch in range(num_epochs):  # loop over the dataset multiple times
+        print(f'Epoch {epoch + 1}')
+        datasample_paths = [
+            Path(data_root, f'data_batch_{i + 1}') for i in range(num_cifar10_batches)
+        ]
+        with _to_datasamples_tree(datasample_paths) as tmp_datasamples_folders:
+            # TODO randomize paths
+            # load datasamples
+            opener = Opener()
+            X = opener.get_X(tmp_datasamples_folders)
+            y = opener.get_y(tmp_datasamples_folders)
+
+        # train algo
+        input_models = [model] if model else []
+        print('Executing training task')
+        model = algo.train(X, y, models=input_models, rank=rank)
+        rank += 1
+
+    # testing
+    datasample_path = Path(data_root, 'test_batch')
+    with _to_datasamples_tree([datasample_path]) as test_folders:
+        # load datasamples
+        opener = Opener()
+        X_test = opener.get_X(test_folders)
+        y_test = opener.get_y(test_folders)
+
+    print('Executing testing task')
+    y_pred = algo.predict(X_test, model)
+    score = metrics.score(y_test, y_pred)
+    print(score)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    run()

--- a/examples/torch/substra-network.py
+++ b/examples/torch/substra-network.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import dataclasses
+import os
+import shutil
+import tarfile
+import tempfile
+import uuid
+import zipfile
+
+import substra
+import torchvision
+
+DATASET_ROOT = './data'
+CURRENT_DIR = os.path.dirname(__file__)
+PUBLIC_PERMISSIONS = {'public': True, 'authorized_ids': []}
+
+_CIFAR10_ARCHIVE_NAME = 'cifar-10-python.tar.gz'
+
+# TODO format data to separate X and y?
+# TODO multiple nodes example
+# TODO create a click wrapper around the different commands
+# TODO make this example reliable to run multiple times (could use tag to store ts)
+
+
+@dataclasses.dataclass
+class Context:
+    profile: str = 'node1'
+    assets_root: str = os.path.join(CURRENT_DIR, 'assets')
+
+    _client: substra.Client = None
+
+    @property
+    def client(self):
+        return self._client
+
+    def initialize(self):
+        self._client = substra.Client(profile_name=self.profile)
+        self._client.login()
+        return self
+
+
+def _zip(archive_path, paths):
+    with zipfile.ZipFile(archive_path, 'w') as z:
+        for filepath in paths:
+            z.write(filepath, arcname=os.path.basename(filepath))
+
+
+def _untar(archive_path):
+    destination_path = os.path.dirname(archive_path)
+    with tarfile.open(archive_path) as tar:
+        tar.extractall(destination_path)
+
+
+def register(ctx):
+    # download data
+    torchvision.datasets.CIFAR10(root=DATASET_ROOT, download=True)
+    _untar(os.path.join(DATASET_ROOT, _CIFAR10_ARCHIVE_NAME))
+
+    # register dataset
+    dataset_spec = {
+        'name': 'CIFAR10',
+        'type': 'image',
+        'data_opener': os.path.join(ctx.assets_root, 'dataset/opener.py'),
+        'description': os.path.join(ctx.assets_root, 'dataset/description.md'),
+        'permissions': PUBLIC_PERMISSIONS,
+    }
+    dataset_key = ctx.client.add_dataset(dataset_spec, exist_ok=True)['pkhash']
+    print(f'Dataset added: key={dataset_key}')
+
+    # register train datasamples
+    num_cifar10_batches = 5
+    train_datasample_keys = []
+    for i in range(num_cifar10_batches):
+        datasample_path = os.path.join(
+            DATASET_ROOT, 'cifar-10-batches-py', f'data_batch_{i + 1}')
+        assert os.path.isfile(datasample_path)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            datadir = os.path.join(tmpdir, 'train_{i}/')
+            os.makedirs(datadir)
+            shutil.copy(datasample_path, datadir)
+            datasample_spec = {
+                'data_manager_keys': [dataset_key],
+                'test_only': False,
+                'path': datadir,
+            }
+            datasample_key = ctx.client.add_data_sample(
+                datasample_spec, local=True, exist_ok=True)['pkhash']
+            print(f'Datasample added: key={datasample_key}')
+            train_datasample_keys.append(datasample_key)
+
+    # register test datasample
+    datasample_path = os.path.join(DATASET_ROOT, 'cifar-10-batches-py', 'test_batch')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        datadir = os.path.join(tmpdir, 'test/')
+        os.makedirs(datadir)
+        shutil.copy(datasample_path, datadir)
+        datasample_spec = {
+            'data_manager_keys': [dataset_key],
+            'test_only': True,
+            'path': datadir,
+        }
+        test_datasample_key = ctx.client.add_data_sample(
+            datasample_spec, local=True, exist_ok=True)['pkhash']
+        print(f'Datasample added: key={test_datasample_key}')
+    test_datasample_keys = [test_datasample_key]
+
+    # link datasamples with dataset
+    ctx.client.link_dataset_with_data_samples(
+        dataset_key, train_datasample_keys + test_datasample_keys)
+
+    # register objective
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = os.path.join(tmpdir, 'metrics.zip')
+        objective_spec = {
+            'name': 'CIFAR10',
+            'description': os.path.join(ctx.assets_root, 'objective/description.md'),
+            'metrics_name': 'accuracy',
+            'metrics': archive_path,
+            'test_data_sample_keys': None,  # TODO add test data samples
+            'test_data_manager_key': dataset_key,
+            'permissions': PUBLIC_PERMISSIONS,
+        }
+        _zip(archive_path, paths=[
+            os.path.join(ctx.assets_root, 'objective/metrics.py'),
+            os.path.join(ctx.assets_root, 'objective/Dockerfile'),
+        ])
+        objective_key = ctx.client.add_objective(objective_spec, exist_ok=True)['pkhash']
+        print(f'Objective added: key={objective_key}')
+
+    # register algo
+    with tempfile.TemporaryDirectory() as tmpdir:
+        archive_path = os.path.join(tmpdir, 'algo.zip')
+        algo_spec = {
+            'name': 'CIFAR10',
+            'description': os.path.join(ctx.assets_root, 'algo/description.md'),
+            'file': archive_path,
+            'permissions': PUBLIC_PERMISSIONS,
+        }
+        _zip(archive_path, paths=[
+            os.path.join(ctx.assets_root, 'algo/algo.py'),
+            os.path.join(ctx.assets_root, 'algo/Dockerfile'),
+        ])
+        algo_key = ctx.client.add_algo(algo_spec, exist_ok=True)['pkhash']
+        print(f'Algo added: key={algo_key}')
+
+    previous_traintuple_id = None
+
+    # register compute plan
+    previous_traintuple_id = None
+    traintuples = []
+    num_epochs = 2
+    for _ in range(num_epochs):
+        for key in train_datasample_keys:
+            traintuple_id = uuid.uuid4().hex
+            traintuple_spec = {
+                'algo_key': algo_key,
+                'data_manager_key': dataset_key,
+                'train_data_sample_keys': [key],
+                'traintuple_id': traintuple_id,
+            }
+            if previous_traintuple_id:
+                traintuple_spec['in_models_ids'] = [previous_traintuple_id]
+            traintuples.append(traintuple_spec)
+            previous_traintuple_id = traintuple_id
+
+    testtuple_spec = {
+        'objective_key': objective_key,
+        'traintuple_id': traintuple_id,
+    }
+
+    cp_spec = {
+        'traintuples': traintuples,
+        'testtuples': [testtuple_spec],
+    }
+    cp_id = ctx.client.add_compute_plan(cp_spec)['computePlanID']
+    print(f'CP added: id={cp_id}')
+
+    # TODO wait for the cp to be executed
+
+
+if __name__ == '__main__':
+    ctx = Context().initialize()
+    register(ctx)

--- a/examples/torch/torch-reference.py
+++ b/examples/torch/torch-reference.py
@@ -1,0 +1,110 @@
+"""Pytorch reference turorial script from (CIFAR10 classifier):
+https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html#sphx-glr-beginner-blitz-cifar10-tutorial-py
+"""
+import torch
+import torchvision
+import torchvision.transforms as transforms
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+
+def main():
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+    trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                                            download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                              shuffle=True, num_workers=2)
+
+    testset = torchvision.datasets.CIFAR10(root='./data', train=False,
+                                           download=True, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=4,
+                                             shuffle=False, num_workers=2)
+
+    classes = ('plane', 'car', 'bird', 'cat',
+               'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+
+    # train
+    net = Net()
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+
+    for epoch in range(2):  # loop over the dataset multiple times
+
+        running_loss = 0.0
+        for i, data in enumerate(trainloader, 0):
+            # get the inputs; data is a list of [inputs, labels]
+            inputs, labels = data
+
+            # zero the parameter gradients
+            optimizer.zero_grad()
+
+            # forward + backward + optimize
+            outputs = net(inputs)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+
+            # print statistics
+            running_loss += loss.item()
+            if i % 2000 == 1999:    # print every 2000 mini-batches
+                print('[%d, %5d] loss: %.3f' %
+                      (epoch + 1, i + 1, running_loss / 2000))
+                running_loss = 0.0
+
+    # save the train model
+    path = './cifar_net.pth'
+    torch.save(net.state_dict(), path)
+
+    # test
+    net = Net()
+    net.load_state_dict(torch.load(path))
+
+    dataiter = iter(testloader)
+    images, labels = next(dataiter)
+
+    outputs = net(images)
+    _, predicted = torch.max(outputs, 1)
+
+    print('Predicted: ', ' '.join('%5s' % classes[predicted[j]]
+                                  for j in range(4)))
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for data in testloader:
+            images, labels = data
+            outputs = net(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+
+    print('Accuracy of the network on the 10000 test images: %d %%' % (
+        100 * correct / total))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR contains the following files:

- torch-reference.py: official torch example. This is useful to check the modifications required to run a torch example on substra
- assets/: assets implementation based on the above torch example
- substra-local.py: tooling to execute the substra workflow in a local python environment (it imports the previous assets and execute the training/testing tasks in the current python environment)
- substra-remote.py: single and main script to add all the assets to a Substra platform

The model is trained through two epochs on a set of 5 randomized samples and is tested on a test dataset. 

It has been translated to two traintuples (one per epoch) and a single testtuple.