### PR TITLE
Remove is_complex option

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -556,12 +556,6 @@ Options:
                                   be a JSON array of valid filters).
                                   Incompatible with the --filter option
 
-  --is-complex                    When using filters using 'OR', the server
-                                  will return a list of matching assets for
-                                  each operand. By default these lists are
-                                  merged into a single list. When set, this
-                                  option disables the lists aggregation.
-
   --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                   Enable logging and set log level
   --config PATH                   Config path (default ~/.substra).

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -436,57 +436,57 @@ Client.get_composite_traintuple(self, composite_traintuple_key)
 Get composite traintuple by key.
 ## list_algo
 ```python
-Client.list_algo(self, filters=None, is_complex=False)
+Client.list_algo(self, filters=None)
 ```
 List algos.
 ## list_compute_plan
 ```python
-Client.list_compute_plan(self, filters=None, is_complex=False)
+Client.list_compute_plan(self, filters=None)
 ```
 List compute plans.
 ## list_aggregate_algo
 ```python
-Client.list_aggregate_algo(self, filters=None, is_complex=False)
+Client.list_aggregate_algo(self, filters=None)
 ```
 List aggregate algos.
 ## list_composite_algo
 ```python
-Client.list_composite_algo(self, filters=None, is_complex=False)
+Client.list_composite_algo(self, filters=None)
 ```
 List composite algos.
 ## list_data_sample
 ```python
-Client.list_data_sample(self, filters=None, is_complex=False)
+Client.list_data_sample(self, filters=None)
 ```
 List data samples.
 ## list_dataset
 ```python
-Client.list_dataset(self, filters=None, is_complex=False)
+Client.list_dataset(self, filters=None)
 ```
 List datasets.
 ## list_objective
 ```python
-Client.list_objective(self, filters=None, is_complex=False)
+Client.list_objective(self, filters=None)
 ```
 List objectives.
 ## list_testtuple
 ```python
-Client.list_testtuple(self, filters=None, is_complex=False)
+Client.list_testtuple(self, filters=None)
 ```
 List testtuples.
 ## list_traintuple
 ```python
-Client.list_traintuple(self, filters=None, is_complex=False)
+Client.list_traintuple(self, filters=None)
 ```
 List traintuples.
 ## list_aggregatetuple
 ```python
-Client.list_aggregatetuple(self, filters=None, is_complex=False)
+Client.list_aggregatetuple(self, filters=None)
 ```
 List aggregatetuples.
 ## list_composite_traintuple
 ```python
-Client.list_composite_traintuple(self, filters=None, is_complex=False)
+Client.list_composite_traintuple(self, filters=None)
 ```
 List composite traintuples.
 ## list_node

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -841,18 +841,10 @@ def get(ctx, expand, asset_name, asset_key):
               callback=validate_json,
               help='Filter results using a complex search (must be a JSON array of valid filters). '
                    'Incompatible with the --filter option')
-@click.option(
-    '--is-complex', is_flag=True,
-    help=(
-        "When using filters using 'OR', the server will return a list of matching assets for each "
-        "operand. By default these lists are merged into a single list. When set, this option "
-        "disables the lists aggregation."
-    ),
-)
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def list_(ctx, asset_name, filters, filters_logical_clause, advanced_filters, is_complex):
+def list_(ctx, asset_name, filters, filters_logical_clause, advanced_filters):
     """List assets."""
     client = get_client(ctx.obj)
     # method must exist in sdk
@@ -869,7 +861,7 @@ def list_(ctx, asset_name, filters, filters_logical_clause, advanced_filters, is
                 filters.insert(i + 1, 'OR')
     elif advanced_filters:
         filters = advanced_filters
-    res = method(filters, is_complex)
+    res = method(filters)
     printer = printers.get_asset_printer(asset_name, ctx.obj.output_format)
     printer.print(res, is_list=True)
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -671,57 +671,57 @@ class Client(object):
         return self.client.get(assets.COMPOSITE_TRAINTUPLE, composite_traintuple_key)
 
     @logit
-    def list_algo(self, filters=None, is_complex=False):
+    def list_algo(self, filters=None):
         """List algos."""
         return self.client.list(assets.ALGO, filters=filters)
 
     @logit
-    def list_compute_plan(self, filters=None, is_complex=False):
+    def list_compute_plan(self, filters=None):
         """List compute plans."""
         return self.client.list(assets.COMPUTE_PLAN, filters=filters)
 
     @logit
-    def list_aggregate_algo(self, filters=None, is_complex=False):
+    def list_aggregate_algo(self, filters=None):
         """List aggregate algos."""
         return self.client.list(assets.AGGREGATE_ALGO, filters=filters)
 
     @logit
-    def list_composite_algo(self, filters=None, is_complex=False):
+    def list_composite_algo(self, filters=None):
         """List composite algos."""
         return self.client.list(assets.COMPOSITE_ALGO, filters=filters)
 
     @logit
-    def list_data_sample(self, filters=None, is_complex=False):
+    def list_data_sample(self, filters=None):
         """List data samples."""
         return self.client.list(assets.DATA_SAMPLE, filters=filters)
 
     @logit
-    def list_dataset(self, filters=None, is_complex=False):
+    def list_dataset(self, filters=None):
         """List datasets."""
         return self.client.list(assets.DATASET, filters=filters)
 
     @logit
-    def list_objective(self, filters=None, is_complex=False):
+    def list_objective(self, filters=None):
         """List objectives."""
         return self.client.list(assets.OBJECTIVE, filters=filters)
 
     @logit
-    def list_testtuple(self, filters=None, is_complex=False):
+    def list_testtuple(self, filters=None):
         """List testtuples."""
         return self.client.list(assets.TESTTUPLE, filters=filters)
 
     @logit
-    def list_traintuple(self, filters=None, is_complex=False):
+    def list_traintuple(self, filters=None):
         """List traintuples."""
         return self.client.list(assets.TRAINTUPLE, filters=filters)
 
     @logit
-    def list_aggregatetuple(self, filters=None, is_complex=False):
+    def list_aggregatetuple(self, filters=None):
         """List aggregatetuples."""
         return self.client.list(assets.AGGREGATETUPLE, filters=filters)
 
     @logit
-    def list_composite_traintuple(self, filters=None, is_complex=False):
+    def list_composite_traintuple(self, filters=None):
         """List composite traintuples."""
         return self.client.list(assets.COMPOSITE_TRAINTUPLE, filters=filters)
 

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -216,8 +216,8 @@ class Client():
             **request_kwargs,
         )
 
-        # when filtering 'complex' assets the server responds with a list per filter
-        # item, these list of list must then be flatten
+        # the server always responds with a list of lists (linked to the debug option "is_complex")
+        # which must then be flatten
         if isinstance(items, list) and all([isinstance(i, list) for i in items]):
             items = utils.flatten(items)
 


### PR DESCRIPTION
The is_complex option that the backend exposes for debug purposes was described in both CLI and SDK but never passed to the backend. This PR removes it to make our public interfaces cleaner.