### PR TITLE
Rewing files before uploading

### DIFF
--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -115,6 +115,11 @@ class Client():
         kwargs = dict(self._default_kwargs)
         kwargs.update(request_kwargs)
 
+        # rewind files so that they are properly sent in retries as well
+        if 'files' in kwargs:
+            for _, file in kwargs['files'].items():
+                file.seek(0)
+
         # do HTTP request and catch generic exceptions
         try:
             r = fn(url, headers=self._headers, **kwargs)

--- a/substra/sdk/rest_client.py
+++ b/substra/sdk/rest_client.py
@@ -117,7 +117,7 @@ class Client():
 
         # rewind files so that they are properly sent in retries as well
         if 'files' in kwargs:
-            for _, file in kwargs['files'].items():
+            for file in kwargs['files'].values():
                 file.seek(0)
 
         # do HTTP request and catch generic exceptions


### PR DESCRIPTION
Fixes #164 

When retrying to send files to the backend, we used the same file-like object without making sure that the offset was 0. As a result, all retries tried to send empty objects.

