### PR TITLE
Fix ci (new release of flake8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
     tags: true
 
 script:
-  - pip install flake8==3.8.1
+  - pip install flake8==3.7.9
   - flake8 substra
   - pip install -e .[test]
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
     tags: true
 
 script:
-  - pip install flake8==3.7.9
+  - pip install flake8
   - flake8 substra
   - pip install -e .[test]
   - python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
     tags: true
 
 script:
-  - pip install flake8
+  - pip install flake8==3.8.1
   - flake8 substra
   - pip install -e .[test]
   - python setup.py test

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -191,7 +191,7 @@ def load_data_samples_keys(data_samples, option="--data-samples-path"):
     try:
         return data_samples['keys']
     except KeyError:
-        raise click.BadParameter(f'File must contain a "keys" attribute.', param_hint=f'"{option}"')
+        raise click.BadParameter('File must contain a "keys" attribute.', param_hint=f'"{option}"')
 
 
 def error_printer(fn):


### PR DESCRIPTION
Release of flake8 3.8.0 is triggering a new warning in our code base. 
This PR is fixing it to keep using the latest version of flake8.