### PR TITLE
Remove logins from examples

### DIFF
--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -24,7 +24,6 @@ assets_keys_path = os.path.join(current_directory, '../../titanic/assets_keys.js
 compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.json')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')
 with open(assets_keys_path, 'r') as f:

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -22,7 +22,6 @@ current_directory = os.path.dirname(__file__)
 compute_plan_keys_path = os.path.join(current_directory, '../compute_plan_keys.json')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 with open(compute_plan_keys_path, 'r') as f:
     compute_plan_keys = json.load(f)

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -23,7 +23,6 @@ assets_keys_path = os.path.join(current_directory, '../../titanic/assets_keys.js
 folds_keys_path = os.path.join(current_directory, '../folds_keys.json')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 print(f'Loading existing asset keys from {os.path.abspath(assets_keys_path)}...')
 with open(assets_keys_path, 'r') as f:
@@ -68,5 +67,5 @@ with open(folds_keys_path, 'w') as f:
 
 print(f'Tuples keys have been saved to {os.path.abspath(folds_keys_path)}')
 print('\nRun the following commands to track the status of the tuples:')
-print(f'    substra list traintuple -f "traintuple:tag:{tag}"')
-print(f'    substra list testtuple -f "testtuple:tag:{tag}"')
+print(f'    substra list traintuple -f "traintuple:tag:{tag}" --profile node-1')
+print(f'    substra list testtuple -f "testtuple:tag:{tag}" --profile node-1')

--- a/examples/titanic/scripts/add_dataset_objective.py
+++ b/examples/titanic/scripts/add_dataset_objective.py
@@ -47,7 +47,6 @@ current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 DATASET = {
     'name': 'Titanic',

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -22,7 +22,6 @@ current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 ALGO = {
     'name': 'Constant death predictor',
@@ -105,5 +104,5 @@ with open(assets_keys_path, 'w') as f:
 
 print(f'Assets keys have been saved to {os.path.abspath(assets_keys_path)}')
 print('\nRun the following commands to track the status of the tuples:')
-print(f'    substra get traintuple {traintuple_key}')
-print(f'    substra get testtuple {testtuple_key}')
+print(f'    substra get traintuple {traintuple_key} --profile node-1')
+print(f'    substra get testtuple {testtuple_key} --profile node-1')

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -22,7 +22,6 @@ current_directory = os.path.dirname(__file__)
 assets_directory = os.path.join(current_directory, '../assets')
 
 client = substra.Client(profile_name="node-1")
-client.login()
 
 ALGO_KEYS_JSON_FILENAME = 'algo_random_forest_keys.json'
 
@@ -107,5 +106,5 @@ with open(assets_keys_path, 'w') as f:
 
 print(f'Assets keys have been saved to {os.path.abspath(assets_keys_path)}')
 print('\nRun the following commands to track the status of the tuples:')
-print(f'    substra get traintuple {traintuple_key}')
-print(f'    substra get testtuple {testtuple_key}')
+print(f'    substra get traintuple {traintuple_key} --profile node-1')
+print(f'    substra get testtuple {testtuple_key} --profile node-1')


### PR DESCRIPTION
In the examples, we tell the user to login manually through the readme and then login again in each script. These subsequent logins have for consequence to invalidate the token obtained in the first manual login.

This PR removes these unnecessary logins.