### PR TITLE
Improve error messages in tracebacks

### DIFF
--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -69,7 +69,7 @@ class InvalidRequest(HTTPError):
             error = request_exception.response.json()
         except ValueError:
             error = request_exception.response
-        msg = error.get('message', None)
+        msg = error.get('message', str(error))
         return super().from_request_exception(request_exception, msg)
 
 


### PR DESCRIPTION
Fixes #35 

This make traceback go from:
```sh
➜ python test.py
Traceback (most recent call last):
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 126, in __request
    r.raise_for_status()
  File "/Users/jeremy/.virtualenvs/substra/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/data_manager/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 42, in <module>
    dataset_key = client.add_dataset(DATASET, exist_ok=True)['pkhash']
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 41, in wrapper
    return f(*args, **kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 288, in add_dataset
    res = self._add(assets.DATASET, data, files=files, exist_ok=exist_ok)
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 164, in _add
    **requests_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 261, in add
    return self._add(name, exist_ok=exist_ok, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 237, in _add
    return self.request('post', name, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/utils.py", line 170, in wrapper
    return f(*args, **kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 192, in request
    **request_kwargs,
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 170, in _request
    return self.__request(request_name, url, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 138, in __request
    raise exceptions.InvalidRequest.from_request_exception(e)
substra.sdk.exceptions.InvalidRequest: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/data_manager/
```

To:
```sh
➜ python test.py
Adding dataset...
Traceback (most recent call last):
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 126, in __request
    r.raise_for_status()
  File "/Users/jeremy/.virtualenvs/substra/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/data_manager/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 42, in <module>
    dataset_key = client.add_dataset(DATASET, exist_ok=True)['pkhash']
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 41, in wrapper
    return f(*args, **kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 288, in add_dataset
    res = self._add(assets.DATASET, data, files=files, exist_ok=exist_ok)
  File "/Users/jeremy/substra/substra/substra/sdk/client.py", line 164, in _add
    **requests_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 261, in add
    return self._add(name, exist_ok=exist_ok, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 237, in _add
    return self.request('post', name, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/utils.py", line 170, in wrapper
    return f(*args, **kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 192, in request
    **request_kwargs,
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 170, in _request
    return self.__request(request_name, url, **request_kwargs)
  File "/Users/jeremy/substra/substra/substra/sdk/rest_client.py", line 138, in __request
    raise exceptions.InvalidRequest.from_request_exception(e)
substra.sdk.exceptions.InvalidRequest: 400 Client Error: Bad Request for url: http://substra-backend.node-1.com/data_manager/: {'permissions': ['This field may not be null.']}
```