### PR TITLE
Add metadata to compute_plan

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -248,6 +248,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "traintuple_id": str,
           "in_models_ids": list[str],
           "tag": str,
+          "metadata": dict
       }],
       "composite_traintuples": list[{
           "composite_traintuple_id": str,
@@ -260,6 +261,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
               "authorized_ids": list[str],
           },
           "tag": str,
+          "metadata": dict
       }]
       "aggregatetuples": list[{
           "aggregatetuple_id": str,
@@ -267,6 +269,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "worker": str,
           "in_models_ids": list[str],
           "tag": str,
+          "metadata": dict
       }],
       "testtuples": list[{
           "objective_key": str,
@@ -274,6 +277,7 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "test_data_sample_keys": list[str],
           "traintuple_id": str,
           "tag": str,
+          "metadata": dict
       }]
   }
 
@@ -784,6 +788,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "traintuple_id": str,
           "in_models_ids": list[str],
           "tag": str,
+          "metadata": dict,
       }],
       "composite_traintuples": list[{
           "composite_traintuple_id": str,
@@ -796,6 +801,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
               "authorized_ids": list[str],
           },
           "tag": str,
+          "metadata": dict,
       }]
       "aggregatetuples": list[{
           "aggregatetuple_id": str,
@@ -803,6 +809,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "worker": str,
           "in_models_ids": list[str],
           "tag": str,
+          "metadata": dict,
       }],
       "testtuples": list[{
           "objective_key": str,
@@ -810,6 +817,7 @@ Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
           "test_data_sample_keys": list[str],
           "traintuple_id": str,
           "tag": str,
+          "metadata": dict,
       }]
   }
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -234,11 +234,11 @@ Options:
 ## substra add compute_plan
 
 ```bash
-Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
+Usage: substra add compute_plan [OPTIONS] PATH
 
   Add compute plan.
 
-  The tuples path must point to a valid JSON file with the following schema:
+  The path must point to a valid JSON file with the following schema:
 
   {
       "traintuples": list[{
@@ -278,7 +278,10 @@ Usage: substra add compute_plan [OPTIONS] TUPLES_PATH
           "traintuple_id": str,
           "tag": str,
           "metadata": dict
-      }]
+      }],
+      "clean_models": bool,
+      "tag": str,
+      "metadata": dict
   }
 
 Options:

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -349,6 +349,7 @@ Data is a dict object with the following schema:
         "train_data_sample_keys": list[str],
         "in_models_ids": list[str],
         "tag": str,
+        "metadata": dict,
     }],
     "composite_traintuples": list[{
         "composite_traintuple_id": str,
@@ -361,6 +362,7 @@ Data is a dict object with the following schema:
             "authorized_ids": list[str],
         },
         "tag": str,
+        "metadata": dict,
     }]
     "aggregatetuples": list[{
         "aggregatetuple_id": str,
@@ -368,6 +370,7 @@ Data is a dict object with the following schema:
         "worker": str,
         "in_models_ids": list[str],
         "tag": str,
+        "metadata": dict,
     }],
     "testtuples": list[{
         "objective_key": str,
@@ -375,9 +378,11 @@ Data is a dict object with the following schema:
         "test_data_sample_keys": list[str],
         "traintuple_id": str,
         "tag": str,
+        "metadata": dict,
     }],
     "clean_models": bool,
-    "tag": str
+    "tag": str,
+    "metadata": dict
 }
 ```
 
@@ -516,6 +521,7 @@ Data is a dict object with the following schema:
         "train_data_sample_keys": list[str],
         "in_models_ids": list[str],
         "tag": str,
+        "metadata": dict,
     }],
     "composite_traintuples": list[{
         "composite_traintuple_id": str,
@@ -528,6 +534,7 @@ Data is a dict object with the following schema:
             "authorized_ids": list[str],
         },
         "tag": str,
+        "metadata": dict,
     }]
     "aggregatetuples": list[{
         "aggregatetuple_id": str,
@@ -535,6 +542,7 @@ Data is a dict object with the following schema:
         "worker": str,
         "in_models_ids": list[str],
         "tag": str,
+        "metadata": dict,
     }],
     "testtuples": list[{
         "objective_key": str,
@@ -542,6 +550,7 @@ Data is a dict object with the following schema:
         "test_data_sample_keys": list[str],
         "traintuple_id": str,
         "tag": str,
+        "metadata": dict,
     }]
 }
 ```

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -504,6 +504,7 @@ def add_compute_plan(ctx, tuples):
             "traintuple_id": str,
             "in_models_ids": list[str],
             "tag": str,
+            "metadata": dict
         }],
         "composite_traintuples": list[{
             "composite_traintuple_id": str,
@@ -516,6 +517,7 @@ def add_compute_plan(ctx, tuples):
                 "authorized_ids": list[str],
             },
             "tag": str,
+            "metadata": dict
         }]
         "aggregatetuples": list[{
             "aggregatetuple_id": str,
@@ -523,6 +525,7 @@ def add_compute_plan(ctx, tuples):
             "worker": str,
             "in_models_ids": list[str],
             "tag": str,
+            "metadata": dict
         }],
         "testtuples": list[{
             "objective_key": str,
@@ -530,6 +533,7 @@ def add_compute_plan(ctx, tuples):
             "test_data_sample_keys": list[str],
             "traintuple_id": str,
             "tag": str,
+            "metadata": dict
         }]
     }
 
@@ -1160,6 +1164,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "traintuple_id": str,
             "in_models_ids": list[str],
             "tag": str,
+            "metadata": dict,
         }],
         "composite_traintuples": list[{
             "composite_traintuple_id": str,
@@ -1172,6 +1177,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
                 "authorized_ids": list[str],
             },
             "tag": str,
+            "metadata": dict,
         }]
         "aggregatetuples": list[{
             "aggregatetuple_id": str,
@@ -1179,6 +1185,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "worker": str,
             "in_models_ids": list[str],
             "tag": str,
+            "metadata": dict,
         }],
         "testtuples": list[{
             "objective_key": str,
@@ -1186,6 +1193,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples):
             "test_data_sample_keys": list[str],
             "traintuple_id": str,
             "tag": str,
+            "metadata": dict,
         }]
     }
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -485,15 +485,15 @@ def add_algo(ctx, data):
 
 
 @add.command('compute_plan')
-@click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
-                callback=load_json_from_path, metavar="TUPLES_PATH")
+@click.argument('data', type=click.Path(exists=True, dir_okay=False),
+                callback=load_json_from_path, metavar="PATH")
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def add_compute_plan(ctx, tuples):
+def add_compute_plan(ctx, data):
     """Add compute plan.
 
-    The tuples path must point to a valid JSON file with the following schema:
+    The path must point to a valid JSON file with the following schema:
 
     \b
     {
@@ -534,12 +534,15 @@ def add_compute_plan(ctx, tuples):
             "traintuple_id": str,
             "tag": str,
             "metadata": dict
-        }]
+        }],
+        "clean_models": bool,
+        "tag": str,
+        "metadata": dict
     }
 
     """
     client = get_client(ctx.obj)
-    res = client.add_compute_plan(tuples)
+    res = client.add_compute_plan(data)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, is_list=False)
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -560,6 +560,7 @@ class Client(object):
                 "train_data_sample_keys": list[str],
                 "in_models_ids": list[str],
                 "tag": str,
+                "metadata": dict,
             }],
             "composite_traintuples": list[{
                 "composite_traintuple_id": str,
@@ -572,6 +573,7 @@ class Client(object):
                     "authorized_ids": list[str],
                 },
                 "tag": str,
+                "metadata": dict,
             }]
             "aggregatetuples": list[{
                 "aggregatetuple_id": str,
@@ -579,6 +581,7 @@ class Client(object):
                 "worker": str,
                 "in_models_ids": list[str],
                 "tag": str,
+                "metadata": dict,
             }],
             "testtuples": list[{
                 "objective_key": str,
@@ -586,9 +589,11 @@ class Client(object):
                 "test_data_sample_keys": list[str],
                 "traintuple_id": str,
                 "tag": str,
+                "metadata": dict,
             }],
             "clean_models": bool,
-            "tag": str
+            "tag": str,
+            "metadata": dict
         }
 ```
 
@@ -732,6 +737,7 @@ class Client(object):
                 "train_data_sample_keys": list[str],
                 "in_models_ids": list[str],
                 "tag": str,
+                "metadata": dict,
             }],
             "composite_traintuples": list[{
                 "composite_traintuple_id": str,
@@ -744,6 +750,7 @@ class Client(object):
                     "authorized_ids": list[str],
                 },
                 "tag": str,
+                "metadata": dict,
             }]
             "aggregatetuples": list[{
                 "aggregatetuple_id": str,
@@ -751,6 +758,7 @@ class Client(object):
                 "worker": str,
                 "in_models_ids": list[str],
                 "tag": str,
+                "metadata": dict,
             }],
             "testtuples": list[{
                 "objective_key": str,
@@ -758,6 +766,7 @@ class Client(object):
                 "test_data_sample_keys": list[str],
                 "traintuple_id": str,
                 "tag": str,
+                "metadata": dict,
             }]
         }
 ```


### PR DESCRIPTION
:link: **Related Pull Requests :**
• [substra-tests](https://github.com/SubstraFoundation/substra-tests/pull/112)
• [substra-chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/121)
• [substra-backend](https://github.com/SubstraFoundation/substra-backend/pull/273)

This PR aims to add a metadata field to the compute plan asset.