### PR TITLE
fix(sdk): client - set default value if manager gives None for path

### DIFF
--- a/substra/sdk/config.py
+++ b/substra/sdk/config.py
@@ -109,13 +109,19 @@ def _from_config_file(path, name):
 
 class Manager:
     def __init__(self, path=DEFAULT_PATH):
-        self.path = path
+        self.path = path or DEFAULT_PATH
 
     def add_profile(
         self, name, url=DEFAULT_URL, version=DEFAULT_VERSION, insecure=False
     ):
         """Add profile to config file on disk."""
-        config = _add_profile(self.path, name, url, version=version, insecure=insecure,)
+        config = _add_profile(
+            self.path,
+            name,
+            url or DEFAULT_URL,
+            version=version or DEFAULT_VERSION,
+            insecure=insecure,
+        )
         return config[name]
 
     def from_config_file(self, name=DEFAULT_PROFILE_NAME):
@@ -125,4 +131,4 @@ class Manager:
             FileNotFoundError: if config file does not exist.
             ProfileNotFoundError: if profile does not exist.
         """
-        return _from_config_file(self.path, name)
+        return _from_config_file(self.path, name or DEFAULT_PROFILE_NAME)

--- a/substra/sdk/user.py
+++ b/substra/sdk/user.py
@@ -16,7 +16,7 @@ def _read_user(path):
 
 class Manager():
     def __init__(self, path=DEFAULT_PATH):
-        self.path = path
+        self.path = path or DEFAULT_PATH
 
     def add_user(self, token):
         # create profile


### PR DESCRIPTION
Fix the bug when trying to run the Titanic example (gave None for config path instead of DEFAULT_CONFIG if the user did not give the argument)

```
Traceback (most recent call last):
  File "./scripts/add_dataset_objective.py", line 49, in <module>
    client = substra.Client.from_config_file(profile_name="node-1")
  File "/media/chrisalexandre/datalinux/dev/substra/substra/examples/titanic/.venv/lib/python3.6/site-packages/substra/sdk/client.py", line 125, in from_config_file
    profile = cfg_manager.from_config_file(name=profile_name)
  File "/media/chrisalexandre/datalinux/dev/substra/substra/examples/titanic/.venv/lib/python3.6/site-packages/substra/sdk/config.py", line 128, in from_config_file
    return _from_config_file(self.path, name)
  File "/media/chrisalexandre/datalinux/dev/substra/substra/examples/titanic/.venv/lib/python3.6/site-packages/substra/sdk/config.py", line 100, in _from_config_file
    config = _read_config(path)
  File "/media/chrisalexandre/datalinux/dev/substra/substra/examples/titanic/.venv/lib/python3.6/site-packages/substra/sdk/config.py", line 46, in _read_config
    if not os.path.exists(path):
  File "/usr/lib/python3.6/genericpath.py", line 19, in exists
    os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```