### PR TITLE
Local backend - add support for composite and aggregate traintuples

### DIFF
--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -607,7 +607,7 @@ class Local(base.BaseBackend):
         )
         composite_traintuple = self._db.add(composite_traintuple, exist_ok)
         if composite_traintuple.status == models.Status.waiting:
-            self._worker.schedule_composite_traintuple(composite_traintuple)
+            self._worker.schedule_traintuple(composite_traintuple)
         return composite_traintuple
 
     def _add_aggregatetuple(self,

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -598,10 +598,10 @@ class Local(base.BaseBackend):
         for model_key in spec.in_models_keys:
             try:
                 in_tuple = self._db.get(schemas.Type.Traintuple, key=model_key)
-                in_models.append(in_tuple.out_model.dict(by_alias=True))
             except exceptions.NotFound:
-                in_tuple = self._db.get(schemas.Type.CompositeTraintuple, key=model_key)
-                in_models.append(in_tuple.out_head_model.out_model.dict(by_alias=True))
+                composite_traintuple = self._db.get(schemas.Type.CompositeTraintuple, key=model_key)
+                in_tuple = composite_traintuple.out_head_model
+            in_models.append(in_tuple.out_model.dict(by_alias=True))
             in_tuples.append(in_tuple)
 
         # Hash key

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -273,7 +273,8 @@ class Local(base.BaseBackend):
             # Add to the compute plan
             list_keys = getattr(compute_plan, spec.compute_plan_attr_name)
             if list_keys is None:
-                list_keys = [key]
+                list_keys = list()
+            list_keys.append(key)
             setattr(compute_plan, spec.compute_plan_attr_name, list_keys)
 
             compute_plan.tuple_count += 1

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -395,6 +395,7 @@ class Local(base.BaseBackend):
             try:
                 traintuple = self._db.get(tuple_type, spec.traintuple_key)
                 traintuple_type = tuple_type
+                break
             except exceptions.NotFound:
                 pass
         if not traintuple:

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -273,14 +273,7 @@ class Worker:
             # fetch dependencies
             traintuple = self._db.get(traintuple_type, tuple_.traintuple_key)
 
-            if traintuple_type == schemas.Type.Traintuple:
-                algo_type = schemas.Type.Algo
-            elif traintuple_type == schemas.Type.Aggregatetuple:
-                algo_type = schemas.Type.AggregateAlgo
-            elif traintuple_type == schemas.Type.CompositeTraintuple:
-                algo_type = schemas.Type.CompositeAlgo
-
-            algo = self._db.get(algo_type, traintuple.algo_key)
+            algo = self._db.get(traintuple.algo_type, traintuple.algo_key)
             objective = self._db.get(schemas.Type.Objective, tuple_.objective_key)
             dataset = self._db.get(schemas.Type.Dataset, tuple_.dataset.key)
 

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -181,26 +181,15 @@ class Worker:
             )
 
             # save move output models
-            tuple_.out_head_model = models.OutCompositeModel(
-                out_model=self._save_output_model(
-                    tuple_,
-                    'output_head_model',
-                    output_models_volume
-                ),
-                permissions=tuple_.permissions
+            tuple_.out_head_model.out_model = self._save_output_model(
+                tuple_,
+                'output_head_model',
+                output_models_volume
             )
-            tuple_.out_trunk_model = models.OutCompositeModel(
-                out_model=self._save_output_model(
-                    tuple_,
-                    'output_trunk_model',
-                    output_models_volume
-                ),
-                permissions={
-                    "process": {
-                        "public": False,
-                        "authorized_ids": [dataset.owner]
-                    }
-                }
+            tuple_.out_trunk_model.out_model = self._save_output_model(
+                tuple_,
+                'output_trunk_model',
+                output_models_volume
             )
 
             # set logs and status

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -28,7 +28,7 @@ class InMemoryDb:
         # assets stored per type and per key
         self._data = collections.defaultdict(dict)
 
-    def add(self, asset, exist_ok=False):
+    def add(self, asset, exist_ok: bool = False):
         """Add an asset."""
         type_ = asset.__class__.type_
         if type_ == models.ComputePlan.type_:
@@ -48,7 +48,7 @@ class InMemoryDb:
             logger.info(f"{type_} with key '{key}' has been created.")
         return asset
 
-    def get(self, type_, key):
+    def get(self, type_, key: str):
         """Return asset."""
         try:
             return self._data[type_][key]

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -63,11 +63,17 @@ class Permission(pydantic.BaseModel):
     public: bool
     authorized_ids: List[str]
 
+    class Config:
+        extra = 'forbid'
+
 
 class Permissions(pydantic.BaseModel):
     """Permissions structure stored in various asset types."""
 
     process: Permission
+
+    class Config:
+        extra = 'forbid'
 
 
 class _Model(pydantic.BaseModel, abc.ABC):
@@ -76,6 +82,9 @@ class _Model(pydantic.BaseModel, abc.ABC):
     class Meta:
         storage_only_fields = None
         alias_fields = None
+
+    class Config:
+        extra = 'forbid'
 
     def to_response(self):
         """Convert model to backend response object."""
@@ -242,6 +251,7 @@ class Aggregatetuple(_Model):
     algo_key: str
     permissions: Permissions
     tag: str
+    compute_plan_id: str
     rank: Optional[int]
     status: Status
     log: str

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -238,6 +238,7 @@ class Traintuple(_Model):
     metadata: Dict[str, str]
 
     type_: ClassVar[str] = schemas.Type.Traintuple
+    algo_type: ClassVar[schemas.Type] = schemas.Type.Algo
 
     class Meta:
         storage_only_fields = None
@@ -260,6 +261,7 @@ class Aggregatetuple(_Model):
     metadata: Dict[str, str]
 
     type_: ClassVar[str] = schemas.Type.Aggregatetuple
+    algo_type: ClassVar[schemas.Type] = schemas.Type.AggregateAlgo
 
 
 class OutCompositeModel(pydantic.BaseModel):
@@ -287,6 +289,7 @@ class CompositeTraintuple(_Model):
     metadata: Dict[str, str]
 
     type_: ClassVar[str] = schemas.Type.CompositeTraintuple
+    algo_type: ClassVar[schemas.Type] = schemas.Type.CompositeAlgo
 
     class Meta:
         storage_only_fields = None

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -252,18 +252,9 @@ class Aggregatetuple(_Model):
     type_: ClassVar[str] = schemas.Type.Aggregatetuple
 
 
-class OutHeadModel(pydantic.BaseModel):
-    hash_: str = pydantic.Field(..., alias="hash")
-
-
-class OutCompositeTrunkModel(pydantic.BaseModel):
+class OutCompositeModel(pydantic.BaseModel):
     permissions: Permissions
     out_model: Optional[OutModel]
-
-
-class OutCompositeHeadModel(pydantic.BaseModel):
-    permissions: Permissions
-    out_model: Optional[OutHeadModel]
 
 
 class CompositeTraintuple(_Model):
@@ -280,8 +271,10 @@ class CompositeTraintuple(_Model):
     log: str
     in_head_model: Optional[InModel]
     in_trunk_model: Optional[InModel]
-    out_head_model: Optional[OutCompositeHeadModel]
-    out_trunk_model: Optional[OutCompositeTrunkModel]
+    # This is different from the remote backend
+    # We store the out head model storage address directly in the object
+    out_head_model: Optional[OutCompositeModel]
+    out_trunk_model: Optional[OutCompositeModel]
     metadata: Dict[str, str]
 
     type_: ClassVar[str] = schemas.Type.CompositeTraintuple

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -273,7 +273,6 @@ class CompositeTraintuple(_Model):
     worker: str
     algo_key: str
     dataset: _TraintupleDataset
-    permissions: Permissions
     tag: str
     compute_plan_id: str
     rank: Optional[int]
@@ -283,8 +282,8 @@ class CompositeTraintuple(_Model):
     in_trunk_model: Optional[InModel]
     # This is different from the remote backend
     # We store the out head model storage address directly in the object
-    out_head_model: Optional[OutCompositeModel]
-    out_trunk_model: Optional[OutCompositeModel]
+    out_head_model: OutCompositeModel
+    out_trunk_model: OutCompositeModel
     metadata: Dict[str, str]
 
     type_: ClassVar[str] = schemas.Type.CompositeTraintuple

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -194,8 +194,8 @@ class TraintupleSpec(_Spec):
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
 
-    compute_plan_attr_name: str = "traintuple_keys"
-
+    compute_plan_attr_name: typing.ClassVar[str] = "traintuple_keys"
+    algo_type: typing.ClassVar[Type] = Type.Algo
     type_: typing.ClassVar[Type] = Type.Traintuple
 
 
@@ -208,8 +208,8 @@ class AggregatetupleSpec(_Spec):
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
 
-    compute_plan_attr_name: str = "aggregatetuple_keys"
-
+    compute_plan_attr_name: typing.ClassVar[str] = "aggregatetuple_keys"
+    algo_type: typing.ClassVar[Type] = Type.AggregateAlgo
     type_: typing.ClassVar[Type] = Type.Aggregatetuple
 
 
@@ -225,8 +225,7 @@ class CompositeTraintupleSpec(_Spec):
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
 
-    compute_plan_attr_name: str = "composite_traintuple_keys"
-
+    compute_plan_attr_name: typing.ClassVar[str] = "composite_traintuple_keys"
     type_: typing.ClassVar[Type] = Type.CompositeTraintuple
 
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -194,6 +194,8 @@ class TraintupleSpec(_Spec):
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
 
+    compute_plan_attr_name: str = "traintuple_keys"
+
     type_: typing.ClassVar[Type] = Type.Traintuple
 
 
@@ -205,6 +207,8 @@ class AggregatetupleSpec(_Spec):
     compute_plan_id: Optional[str]
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
+
+    compute_plan_attr_name: str = "aggregatetuple_keys"
 
     type_: typing.ClassVar[Type] = Type.Aggregatetuple
 
@@ -220,6 +224,8 @@ class CompositeTraintupleSpec(_Spec):
     out_trunk_model_permissions: PrivatePermissions
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
+
+    compute_plan_attr_name: str = "composite_traintuple_keys"
 
     type_: typing.ClassVar[Type] = Type.CompositeTraintuple
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -15,9 +15,10 @@
 import abc
 import contextlib
 import enum
+import json
 import pathlib
 import typing
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict
 
 import pydantic
 
@@ -73,7 +74,8 @@ class _Spec(pydantic.BaseModel, abc.ABC):
     @contextlib.contextmanager
     def build_request_kwargs(self):
         # TODO should be located in the backends/remote module
-        data = self.dict(exclude_unset=True)
+        # Serialize and deserialize to prevent errors eg with pathlib.Path
+        data = json.loads(self.json(exclude_unset=True))
         if self.Meta.file_attributes:
             with utils.extract_files(data, self.Meta.file_attributes) as (data, files):
                 yield (data, files)
@@ -97,8 +99,8 @@ class PrivatePermissions(pydantic.BaseModel):
 
 
 class DataSampleSpec(_Spec):
-    path: Optional[Union[str, pathlib.Path]]
-    paths: Optional[List[Union[str, pathlib.Path]]]
+    path: Optional[pathlib.Path]
+    paths: Optional[List[pathlib.Path]]
     test_only: bool
     data_manager_keys: typing.List[str]
 
@@ -119,7 +121,8 @@ class DataSampleSpec(_Spec):
     @contextlib.contextmanager
     def build_request_kwargs(self, local):
         # redefine kwargs builder to handle the local paths
-        data = self.dict(exclude_unset=True)
+        # Serialize and deserialize to prevent errors eg with pathlib.Path
+        data = json.loads(self.json(exclude_unset=True))
         if local:
             with utils.extract_data_sample_files(data) as (data, files):
                 yield (data, files)
@@ -129,9 +132,9 @@ class DataSampleSpec(_Spec):
 
 class DatasetSpec(_Spec):
     name: str
-    data_opener: Union[str, pathlib.Path]
+    data_opener: pathlib.Path
     type: str
-    description: Union[str, pathlib.Path]
+    description: pathlib.Path
     permissions: Permissions
     objective_key: Optional[str]
     metadata: Optional[Dict[str, str]]
@@ -144,9 +147,9 @@ class DatasetSpec(_Spec):
 
 class ObjectiveSpec(_Spec):
     name: str
-    description: Union[str, pathlib.Path]
+    description: pathlib.Path
     metrics_name: str
-    metrics: Union[str, pathlib.Path]
+    metrics: pathlib.Path
     test_data_sample_keys: Optional[List[str]]
     test_data_manager_key: Optional[str]
     permissions: Permissions
@@ -160,8 +163,8 @@ class ObjectiveSpec(_Spec):
 
 class _AlgoSpec(_Spec):
     name: str
-    description: Union[str, pathlib.Path]
-    file: Union[str, pathlib.Path]
+    description: pathlib.Path
+    file: pathlib.Path
     permissions: Permissions
     metadata: Optional[Dict[str, str]]
 


### PR DESCRIPTION
## Main changes
- Substra sdk, local backend: add the functions `add_composite_traintuple`, `add_aggregate_traintuple`
- Substra sdk, schemas: update the pydantic typing: pathlib.Path accepts Path and str
- added checks on the metadata, this is not directly related to composite/aggregate but they need the checks too.
  - each key in metadata can be of length 50 max
  - each value in metadata can be of length 100 max and cannot be empty

- [ ] Hybrid debugging: run these on fake data (wait for https://github.com/SubstraFoundation/substra/pull/195)