### PR TITLE
Update the compatibility table before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@ CLI and SDK for interacting with Substra platform.
 
 ## Table of contents
 
-- [Install](#install)
-- [Running the Substra platform locally](#running-the-substra-platform-locally)
-- [Usage](#usage)
-- [Documentation](#documentation)
-- [Compatibility table](#compatibility-table)
-- [Contributing](#contributing)
+- [!Substra](#img-srcsubstra-logosvg-altsubstra)
+  - [Table of contents](#table-of-contents)
+  - [Install](#install)
+  - [Running the Substra platform locally](#running-the-substra-platform-locally)
+  - [Usage](#usage)
+    - [CLI](#cli)
+    - [SDK](#sdk)
+  - [Documentation](#documentation)
+  - [Examples](#examples)
+  - [Compatibility table](#compatibility-table)
+  - [Contributing](#contributing)
+    - [Setup](#setup)
+    - [Documentation](#documentation-1)
+    - [Deploy](#deploy)
 
 ## Install
 
@@ -98,6 +106,7 @@ These sets of versions have been tested for compatilibility:
 | [`0.4.0`](https://github.com/SubstraFoundation/substra/releases/tag/0.4.0) | [`0.0.8`](https://github.com/SubstraFoundation/substra-chaincode/releases/tag/0.0.8) | [`0.0.12`](https://github.com/SubstraFoundation/substra-backend/releases/tag/0.0.12) | [`0.2.0`](https://github.com/SubstraFoundation/substra-tests/releases/tag/0.2.0) | [`0.0.11`](https://github.com/SubstraFoundation/hlf-k8s/releases/tag/0.0.11) | [`0.0.16`](https://github.com/SubstraFoundation/substra-frontend/releases/tag/0.0.16) | |
 | [`0.5.0`](https://github.com/SubstraFoundation/substra/releases/tag/0.5.0) | [`0.0.8`](https://github.com/SubstraFoundation/substra-chaincode/releases/tag/0.0.8) | [`0.0.14`](https://github.com/SubstraFoundation/substra-backend/releases/tag/0.0.14) | [`0.3.0`](https://github.com/SubstraFoundation/substra-tests/releases/tag/0.3.0) | [`0.0.12`](https://github.com/SubstraFoundation/hlf-k8s/releases/tag/0.0.12) | [`0.0.16`](https://github.com/SubstraFoundation/substra-frontend/releases/tag/0.0.16) | [`0.5.0`](https://github.com/SubstraFoundation/substra-tools/releases/tag/0.5.0) |
 | [`0.6.0`](https://github.com/SubstraFoundation/substra/releases/tag/0.6.0) | [`0.0.10`](https://github.com/SubstraFoundation/substra-chaincode/releases/tag/0.0.10) | [`0.0.19`](https://github.com/SubstraFoundation/substra-backend/releases/tag/0.0.19) | [`0.4.0`](https://github.com/SubstraFoundation/substra-tests/releases/tag/0.4.0) | [`0.0.12`](https://github.com/SubstraFoundation/hlf-k8s/releases/tag/0.0.12) | [`0.0.17`](https://github.com/SubstraFoundation/substra-frontend/releases/tag/0.0.17) | [`0.5.0`](https://github.com/SubstraFoundation/substra-tools/releases/tag/0.5.0) |
+| [`0.7.0-alpha.1`](https://github.com/SubstraFoundation/substra/releases/tag/0.7.0-alpha.1) | [`0.0.10`](https://github.com/SubstraFoundation/substra-chaincode/releases/tag/0.0.10) | [`0.0.19`](https://github.com/SubstraFoundation/substra-backend/releases/tag/0.0.19) | [`0.4.0`](https://github.com/SubstraFoundation/substra-tests/releases/tag/0.4.0) | [`0.0.12`](https://github.com/SubstraFoundation/hlf-k8s/releases/tag/0.0.12) | [`0.0.17`](https://github.com/SubstraFoundation/substra-frontend/releases/tag/0.0.17) | [`0.6.0`](https://github.com/SubstraFoundation/substra-tools/releases/tag/0.6.0) |
 
 **Adding entries to the compatibility table**
 


### PR DESCRIPTION
Update the compatibility table: substra-tools 0.6.0 and substra 0.7.0-alpha.1