### PR TITLE
Fix error parsing in CLI

### DIFF
--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -207,10 +207,10 @@ def load_data_samples_keys(data_samples, option="--data-samples-path"):
         raise click.BadParameter('File must contain a "keys" attribute.', param_hint=f'"{option}"')
 
 
-def _error_message(fn, errors):
+def _format_server_errors(fn, errors):
     action = fn.__name__.replace('_', ' ')
 
-    def _error_lines(errors_):
+    def _format_error_lines(errors_):
         lines_ = []
         for field, field_errors in errors_.items():
             for field_error in field_errors:
@@ -219,10 +219,10 @@ def _error_message(fn, errors):
 
     lines = []
     if isinstance(errors, dict):
-        lines += _error_lines(errors)
+        lines += _format_error_lines(errors)
     elif isinstance(errors, list):
         for error in errors:
-            lines += _error_lines(error)
+            lines += _format_error_lines(error)
     else:
         lines.append(f"- {errors}")
 
@@ -251,7 +251,7 @@ def error_printer(fn):
                 errors = e.errors['message']
             except KeyError:
                 errors = e.errors
-            raise click.ClickException(_error_message(fn, errors))
+            raise click.ClickException(_format_server_errors(fn, errors))
         except exceptions.RequestException as e:
             raise click.ClickException(f"Request failed: {e.__class__.__name__}: {e}")
         except (exceptions.ConnectionError,

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -214,7 +214,7 @@ def _format_server_errors(fn, errors):
         lines_ = []
         for field, field_errors in errors_.items():
             for field_error in field_errors:
-                lines_.append(f"- {field}: {field_error}")
+                lines_.append(f"{field}: {field_error}")
         return lines_
 
     lines = []
@@ -224,12 +224,11 @@ def _format_server_errors(fn, errors):
         for error in errors:
             lines += _format_error_lines(error)
     else:
-        lines.append(f"- {errors}")
+        lines.append(errors)
 
+    lines = [f"\n- {line}" for line in lines]
     pluralized_error = 'errors' if len(lines) > 1 else 'error'
-    lines.insert(0, f"Could not {action},"
-                    f"the server returned the following {pluralized_error}:")
-    return "\n".join(lines)
+    return f"Could not {action}, the server returned the following {pluralized_error}:" + lines
 
 
 def error_printer(fn):


### PR DESCRIPTION
Fixes #210 

Errors returned by the backend can take multiple shape:

```json
{"message":[{"metrics":["Cannot handle this file object."]}],"pkhash":"dcb95dfc837ee32f3feaacdf3835fe350d625c47f48bc21aeda41bdcceea6c67"
```
```json
{"message":"error checking associated objective no asset for key foo"}
```
```json
{"permissions":["This field may not be null."]}
```

This update handle all 3 shapes.