### PR TITLE
Use key instead of pkhash

### DIFF
--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -48,7 +48,7 @@ algo_key = client.add_algo({
         'public': False,
         'authorized_ids': [],
     }
-}, exist_ok=True)['pkhash']
+}, exist_ok=True)['key']
 
 
 print('Generating compute plan...')

--- a/examples/cross_val/scripts/cross_val_algo_random_forest.py
+++ b/examples/cross_val/scripts/cross_val_algo_random_forest.py
@@ -48,7 +48,7 @@ for i, fold in enumerate(folds_keys['folds']):
         'train_data_sample_keys': fold['train_data_sample_keys'],
         'tag': tag,
     }, exist_ok=True)
-    traintuple_key = traintuple.get('key') or traintuple.get('pkhash')
+    traintuple_key = traintuple.get('key')
     fold['traintuple_key'] = traintuple_key
 
     # testtuple
@@ -59,7 +59,7 @@ for i, fold in enumerate(folds_keys['folds']):
         'test_data_sample_keys': fold['test_data_sample_keys'],
         'tag': tag,
     }, exist_ok=True)
-    testtuple_key = testtuple.get('key') or testtuple.get('pkhash')
+    testtuple_key = testtuple.get('key')
     fold['testtuple_key'] = testtuple_key
 
 with open(folds_keys_path, 'w') as f:

--- a/examples/debugging/scripts/debugging.py
+++ b/examples/debugging/scripts/debugging.py
@@ -62,7 +62,7 @@ algo_key = client.add_algo(
         "permissions": ALGO["permissions"],
     },
     exist_ok=True,
-)["pkhash"]
+)["key"]
 print(f"Algo key: {algo_key}")
 
 ##################
@@ -83,7 +83,7 @@ traintuple = client.add_traintuple(
     },
     exist_ok=True,
 )
-traintuple_key = traintuple.get("key") or traintuple.get("pkhash")
+traintuple_key = traintuple.get("key")
 assert traintuple_key, "Missing traintuple key"
 
 print(f"\n--- Logs of the execution of the traintuple --- \n{traintuple['log']}\n")
@@ -100,7 +100,7 @@ testtuple = client.add_testtuple(
         "traintuple_key": traintuple_key
     }, exist_ok=True
 )
-testtuple_key = testtuple.get("key") or testtuple.get("pkhash")
+testtuple_key = testtuple.get("key")
 assert testtuple_key, "Missing testtuple key"
 
 print(f"\n--- Logs of the execution of the testtuple --- \n{testtuple['log']}\n")

--- a/examples/debugging/scripts/local_debugging.py
+++ b/examples/debugging/scripts/local_debugging.py
@@ -108,7 +108,7 @@ with zipfile.ZipFile(ALGO["file"], "w") as z:
 
 # Add the dataset to Substra
 print("Adding dataset...")
-dataset_key = client.add_dataset(DATASET, exist_ok=True)["pkhash"]
+dataset_key = client.add_dataset(DATASET, exist_ok=True)["key"]
 assert dataset_key, "Missing data manager key"
 
 # Add the data samples to Substra
@@ -143,7 +143,7 @@ for conf in data_samples_configs:
                 local=True,
                 exist_ok=True,
             )
-            data_sample_key = data_sample["pkhash"]
+            data_sample_key = data_sample["key"]
             conf["data_sample_keys"].append(data_sample_key)
             progress.update()
     assert len(conf["data_sample_keys"]), conf["missing_message"]
@@ -169,7 +169,7 @@ objective_key = client.add_objective(
         "permissions": OBJECTIVE["permissions"],
     },
     exist_ok=True,
-)["pkhash"]
+)["key"]
 assert objective_key, "Missing objective key"
 
 # Add the algorithm
@@ -182,7 +182,7 @@ algo_key = client.add_algo(
         "permissions": ALGO["permissions"],
     },
     exist_ok=True,
-)["pkhash"]
+)["key"]
 
 #  Add the traintuple
 print("Registering traintuple...")
@@ -194,7 +194,7 @@ traintuple = client.add_traintuple(
     },
     exist_ok=True,
 )
-traintuple_key = traintuple.get("key") or traintuple.get("pkhash")
+traintuple_key = traintuple.get("key")
 assert traintuple_key, "Missing traintuple key"
 
 #  Add the testtuple
@@ -202,7 +202,7 @@ print("Registering testtuple...")
 testtuple = client.add_testtuple(
     {"objective_key": objective_key, "traintuple_key": traintuple_key}, exist_ok=True
 )
-testtuple_key = testtuple.get("key") or testtuple.get("pkhash")
+testtuple_key = testtuple.get("key")
 assert testtuple_key, "Missing testtuple key"
 
 #  Get the performance

--- a/examples/titanic/scripts/add_dataset_objective.py
+++ b/examples/titanic/scripts/add_dataset_objective.py
@@ -91,7 +91,7 @@ with zipfile.ZipFile(archive_path, 'w') as z:
 
 
 print('Adding dataset...')
-dataset_key = client.add_dataset(DATASET, exist_ok=True)['pkhash']
+dataset_key = client.add_dataset(DATASET, exist_ok=True)['key']
 assert dataset_key, 'Missing data manager key'
 
 train_data_sample_keys = []
@@ -121,7 +121,7 @@ for conf in data_samples_configs:
                 'test_only': conf['test_only'],
                 'path': path,
             }, local=True, exist_ok=True)
-            data_sample_key = data_sample['pkhash']
+            data_sample_key = data_sample['key']
             conf['data_sample_keys'].append(data_sample_key)
             progress.update()
     assert len(conf['data_sample_keys']), conf['missing_message']
@@ -141,7 +141,7 @@ objective_key = client.add_objective({
     'test_data_sample_keys': test_data_sample_keys,
     'test_data_manager_key': dataset_key,
     'permissions': OBJECTIVE['permissions'],
-}, exist_ok=True)['pkhash']
+}, exist_ok=True)['key']
 assert objective_key, 'Missing objective key'
 
 # Save assets keys

--- a/examples/titanic/scripts/add_train_algo_constant.py
+++ b/examples/titanic/scripts/add_train_algo_constant.py
@@ -64,7 +64,7 @@ algo_key = client.add_algo({
     'file': ALGO['file'],
     'description': ALGO['description'],
     'permissions': ALGO['permissions'],
-}, exist_ok=True)['pkhash']
+}, exist_ok=True)['key']
 
 ########################################################
 #         Add traintuple
@@ -76,7 +76,7 @@ traintuple = client.add_traintuple({
     'data_manager_key': assets_keys['dataset_key'],
     'train_data_sample_keys': assets_keys['train_data_sample_keys']
 }, exist_ok=True)
-traintuple_key = traintuple.get('key') or traintuple.get('pkhash')
+traintuple_key = traintuple.get('key')
 assert traintuple_key, 'Missing traintuple key'
 
 ########################################################
@@ -87,7 +87,7 @@ testtuple = client.add_testtuple({
     'objective_key': assets_keys['objective_key'],
     'traintuple_key': traintuple_key
 }, exist_ok=True)
-testtuple_key = testtuple.get('key') or testtuple.get('pkhash')
+testtuple_key = testtuple.get('key')
 assert testtuple_key, 'Missing testtuple key'
 
 ########################################################

--- a/examples/titanic/scripts/add_train_algo_random_forest.py
+++ b/examples/titanic/scripts/add_train_algo_random_forest.py
@@ -66,7 +66,7 @@ algo_key = client.add_algo({
     'file': ALGO['file'],
     'description': ALGO['description'],
     'permissions': ALGO['permissions'],
-}, exist_ok=True)['pkhash']
+}, exist_ok=True)['key']
 
 ########################################################
 #         Add traintuple
@@ -78,7 +78,7 @@ traintuple = client.add_traintuple({
     'data_manager_key': assets_keys['dataset_key'],
     'train_data_sample_keys': assets_keys['train_data_sample_keys']
 }, exist_ok=True)
-traintuple_key = traintuple.get('key') or traintuple.get('pkhash')
+traintuple_key = traintuple.get('key')
 assert traintuple_key, 'Missing traintuple key'
 
 ########################################################
@@ -89,7 +89,7 @@ testtuple = client.add_testtuple({
     'objective_key': assets_keys['objective_key'],
     'traintuple_key': traintuple_key
 }, exist_ok=True)
-testtuple_key = testtuple.get('key') or testtuple.get('pkhash')
+testtuple_key = testtuple.get('key')
 assert testtuple_key, 'Missing testtuple key'
 
 ########################################################

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -281,7 +281,6 @@ class Local(base.BaseBackend):
         algo_description_path = self._db.save_file(spec.description, key)
         algo = model_class(
             key=key,
-            pkhash=key,
             name=spec.name,
             owner=_BACKEND_ID,
             permissions={
@@ -327,7 +326,6 @@ class Local(base.BaseBackend):
         dataset_description_path = self._db.save_file(spec.description, key)
         asset = models.Dataset(
             key=key,
-            pkhash=key,
             owner=_BACKEND_ID,
             name=spec.name,
             objective_key=spec.objective_key if spec.objective_key else "",
@@ -366,7 +364,6 @@ class Local(base.BaseBackend):
         data_sample_file_path = self._db.save_file(spec.path, key)
         data_sample = models.DataSample(
             key=key,
-            pkhash=key,
             owner=_BACKEND_ID,
             path=data_sample_file_path,
             data_manager_keys=spec.data_manager_keys,
@@ -435,7 +432,6 @@ class Local(base.BaseBackend):
         # create objective model instance
         objective = models.Objective(
             key=key,
-            pkhash=key,
             name=spec.name,
             owner=_BACKEND_ID,
             test_dataset=test_dataset,
@@ -877,7 +873,7 @@ class Local(base.BaseBackend):
             )
 
         dataset.objective_key = objective_key
-        return {"pkhash": dataset.key}
+        return {"key": dataset.key}
 
     def link_dataset_with_data_samples(self, dataset_key, data_sample_keys):
         dataset = self._db.get(schemas.Type.Dataset, dataset_key)

--- a/substra/sdk/backends/local/models.py
+++ b/substra/sdk/backends/local/models.py
@@ -129,7 +129,6 @@ class _Model(pydantic.BaseModel, abc.ABC):
 class DataSample(_Model):
     key: str
     owner: str
-    pkhash: str = ''
     data_manager_keys: Optional[List[str]]
     path: Optional[DirectoryPath]
     validated: bool = True
@@ -146,7 +145,6 @@ class _File(pydantic.BaseModel):
 
 class Dataset(_Model):
     key: str
-    pkhash: str = ''
     name: str
     owner: str
     objective_key: Optional[str]
@@ -183,7 +181,6 @@ class _Metric(pydantic.BaseModel):
 
 class Objective(_Model):
     key: str
-    pkhash: str = ''
     name: str
     owner: str
     test_dataset: Optional[_ObjectiveDataset]
@@ -202,7 +199,6 @@ class Objective(_Model):
 
 class _Algo(_Model):
     key: str
-    pkhash: str = ''
     name: str
     owner: str
     permissions: Permissions

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -28,7 +28,7 @@ BATCH_SIZE = 'batch_size'
 
 
 def _get_asset_key(data):
-    return data.get('pkhash') or data.get('key') or data.get('computePlanID')
+    return data.get('key') or data.get('computePlanID')
 
 
 def _find_asset_field(data, field):
@@ -91,9 +91,9 @@ class Remote(base.BaseBackend):
             if not exist_ok or spec.is_many():
                 raise
 
-            key = e.pkhash[0]
+            key = e.key[0]
             logger.warning(f"data_sample already exists: key='{key}'")
-            data_samples = [{'pkhash': key}]
+            data_samples = [{'key': key}]
 
         # there is currently a single route in the backend to add a single or many
         # datasamples, this route always returned a list of created data sample keys

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -212,7 +212,7 @@ class Client():
             if not exist_ok:
                 raise
 
-            key = e.pkhash or e.computePlanID
+            key = e.key or e.computePlanID
             is_many = isinstance(key, list)
             if is_many:
                 logger.warning("Many assets not compatible with 'exist_ok' option")
@@ -233,7 +233,7 @@ class Client():
             return self._add(name, exist_ok=exist_ok, **request_kwargs)
 
         except exceptions.RequestTimeout as e:
-            key = e.pkhash
+            key = e.key
             is_many = isinstance(key, list)  # timeout on many objects is not handled
             if not retry_timeout or is_many:
                 raise e

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -212,7 +212,7 @@ class Client():
             if not exist_ok:
                 raise
 
-            key = e.key or e.computePlanID
+            key = e.key
             is_many = isinstance(key, list)
             if is_many:
                 logger.warning("Many assets not compatible with 'exist_ok' option")

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -88,46 +88,46 @@ class NotFound(HTTPError):
 
 
 class RequestTimeout(HTTPError):
-    def __init__(self, pkhash, status_code):
-        self.pkhash = pkhash
-        msg = f"Operation on object with key(s) '{pkhash}' timed out."
+    def __init__(self, key, status_code):
+        self.key = key
+        msg = f"Operation on object with key(s) '{key}' timed out."
         super().__init__(msg, status_code)
 
     @classmethod
     def from_request_exception(cls, request_exception):
-        # parse response and fetch pkhash
+        # parse response and fetch key
         r = request_exception.response.json()
 
         try:
-            pkhash = r.get('computePlanID') or (
-                r['pkhash'] if 'pkhash' in r else r['message'].get('pkhash')
+            key = r.get('computePlanID') or (
+                r['key'] if 'key' in r else r['message'].get('key')
             )
         except (AttributeError, KeyError):
             # XXX this is the case when doing a POST query to update the
             #     data manager for instance
-            pkhash = None
+            key = None
 
-        return cls(pkhash, request_exception.response.status_code)
+        return cls(key, request_exception.response.status_code)
 
 
 class AlreadyExists(HTTPError):
-    def __init__(self, pkhash, status_code):
-        self.pkhash = pkhash
-        msg = f"Object with key(s) '{pkhash}' already exists."
+    def __init__(self, key, status_code):
+        self.key = key
+        msg = f"Object with key(s) '{key}' already exists."
         super().__init__(msg, status_code)
 
     @classmethod
     def from_request_exception(cls, request_exception):
-        # parse response and fetch pkhash
+        # parse response and fetch key
         r = request_exception.response.json()
-        # XXX support list of pkhashes; this could be the case when adding
+        # XXX support list of keyes; this could be the case when adding
         #     a list of data samples through a single POST request
         if isinstance(r, list):
-            pkhash = [x['pkhash'] for x in r]
+            key = [x['key'] for x in r]
         else:
-            pkhash = r['pkhash']
+            key = r['key']
 
-        return cls(pkhash, request_exception.response.status_code)
+        return cls(key, request_exception.response.status_code)
 
 
 class InvalidResponse(SDKException):

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -88,7 +88,7 @@ ALGO = {
             "authorizedIDs": []
         }
     },
-    "pkhash": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+    "key": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
     "metadata": {
         "foo": "bar"
     }
@@ -112,7 +112,7 @@ AGGREGATE_ALGO = {
             "authorizedIDs": []
         }
     },
-    "pkhash": "7c9t9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+    "key": "7c9t9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
     "metadata": {
         "foo": "bar"
     }
@@ -132,7 +132,7 @@ COMPOSITE_ALGO = {
     "owner": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4beade2d62a8b708fdde48fb0edea",
     "permissions_public": False,
     "permissions_authorized_ids": [],
-    "pkhash": "7c9f9br9bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+    "key": "7c9f9br9bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
     "metadata": {
         "foo": "bar"
     }

--- a/tests/sdk/test_add.py
+++ b/tests/sdk/test_add.py
@@ -46,12 +46,12 @@ def test_add_dataset_response_failure_500(client, dataset_query, mocker):
 
 
 def test_add_dataset_response_failure_409(client, dataset_query, mocker):
-    mock_requests(mocker, "post", response={"pkhash": "42"}, status=409)
+    mock_requests(mocker, "post", response={"key": "42"}, status=409)
 
     with pytest.raises(substra.sdk.exceptions.AlreadyExists) as exc_info:
         client.add_dataset(dataset_query)
 
-    assert exc_info.value.pkhash == "42"
+    assert exc_info.value.key == "42"
 
 
 def test_add_objective(client, objective_query, mocker):
@@ -104,10 +104,10 @@ def test_add_data_sample(client, data_sample_query, mocker):
 
 
 def test_add_data_sample_already_exists(client, data_sample_query, mocker):
-    m = mock_requests(mocker, "post", response=[{"pkhash": "42"}], status=409)
+    m = mock_requests(mocker, "post", response=[{"key": "42"}], status=409)
     response = client.add_data_sample(data_sample_query, exist_ok=True)
 
-    assert response == {"pkhash": "42"}
+    assert response == {"key": "42"}
     m.assert_called()
 
 

--- a/tests/sdk/test_rest_client.py
+++ b/tests/sdk/test_rest_client.py
@@ -63,11 +63,11 @@ def test_post_success(mocker, config):
 
     (404, {"message": "Not Found"}, exceptions.NotFound),
 
-    (408, {"pkhash": "a-key"}, exceptions.RequestTimeout),
+    (408, {"key": "a-key"}, exceptions.RequestTimeout),
     (408, {}, exceptions.RequestTimeout),
 
-    (409, {"pkhash": "a-key"}, exceptions.AlreadyExists),
-    (409, {"pkhash": ["a-key", "other-key"]}, exceptions.AlreadyExists),
+    (409, {"key": "a-key"}, exceptions.AlreadyExists),
+    (409, {"key": ["a-key", "other-key"]}, exceptions.AlreadyExists),
 
     (500, "CRASH", exceptions.InternalServerError),
 ])
@@ -88,20 +88,20 @@ def test_request_connection_error(mocker):
 def test_add_timeout_with_retry(mocker):
     asset_name = "traintuple"
     responses = [
-        mock_response(response={"pkhash": "a-key"}, status=408),
-        mock_response(response={"pkhash": "a-key"}),
+        mock_response(response={"key": "a-key"}, status=408),
+        mock_response(response={"key": "a-key"}),
     ]
     m_post = mock_requests_responses(mocker, "post", responses)
     asset = _client_from_config(CONFIG).add(asset_name, retry_timeout=60)
     assert len(m_post.call_args_list) == 2
-    assert asset == {"pkhash": "a-key"}
+    assert asset == {"key": "a-key"}
 
 
 def test_add_exist_ok(mocker):
     asset_name = "traintuple"
-    m_post = mock_requests(mocker, "post", response={"pkhash": "a-key"}, status=409)
-    m_get = mock_requests(mocker, "get", response={"pkhash": "a-key"})
+    m_post = mock_requests(mocker, "post", response={"key": "a-key"}, status=409)
+    m_get = mock_requests(mocker, "get", response={"key": "a-key"})
     asset = _client_from_config(CONFIG).add(asset_name, exist_ok=True)
     assert len(m_post.call_args_list) == 1
     assert len(m_get.call_args_list) == 1
-    assert asset == {"pkhash": "a-key"}
+    assert asset == {"key": "a-key"}


### PR DESCRIPTION
The goal of this multi-repo PRs is to make sure that all the asset creation endpoints returns only the "key" of the asset. 
Indeed, currently `create` and 'get' an asset return, respectively, `pkhash` and `key`. As `pkhash` is only a substra-backend concept, we need to move from `pkhash` to `key` when dealing with substra cli/sdk and frontend.

Consequently, when client create a new asset, the substra-backend will now only return the `key` of the created asset.

There is an exception for compute plan which need to be returned in its complete form because client need to get the ID_to_key mapping and it’s returned only when client create this asset.

The client will take care of doing an extra GET in order to retrieve the complete asset.

PRs :
    https://github.com/SubstraFoundation/substra-backend/pull/312
    https://github.com/SubstraFoundation/substra/pull/220
    https://github.com/SubstraFoundation/substra-tests/pull/140

