### PR TITLE
Do not log "asset not found" at creation - debug mode

### DIFF
--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -861,7 +861,7 @@ class Local(base.BaseBackend):
             # Check if the asset exists, return it if 'exist_ok' is True
             key = self._db.get_local_key(spec.compute_key())
             try:
-                asset = self._db.get(type_=spec.__class__.type_, key=key)
+                asset = self._db.get(type_=spec.__class__.type_, key=key, log=False)
             except exceptions.NotFound:
                 pass
             else:

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -120,9 +120,9 @@ class DataAccess:
             attr.storage_address = asset_path
             return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         if self.is_local(key):
-            return self._db.get(type_, key)
+            return self._db.get(type_, key, log)
         elif self._remote:
             remote_object = self._remote.get(type_, key)
             return self._get_response(type_, remote_object)

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -45,12 +45,13 @@ class InMemoryDb:
 
         return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         """Return asset."""
         try:
             return self._data[type_][key]
         except KeyError:
-            logger.error(f"{type_} with key '{key}' not found.")
+            if log:
+                logger.error(f"{type_} with key '{key}' not found.")
             raise exceptions.NotFound(f"Wrong pk {key}", 404)
 
     def list(self, type_):


### PR DESCRIPTION
In debug mode, when we create an asset, we first test if it exists

- Before: the asset does not exist, log an error 'asset does not exist'
- After: can deactivate this log so no error shown to the user when we create the asset