### PR TITLE
feat: return an actual object as output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
   - cmp --silent references/cli.md references/cli.md.tmp
   - pydocmd simple substra.sdk+ substra.sdk.Client+ substra.sdk.retry_on_exception+ > references/sdk.md.tmp
   - cmp --silent references/sdk.md references/sdk.md.tmp
+  - python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
+  - cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ script:
   - cmp --silent references/sdk.md references/sdk.md.tmp
   - python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
   - cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp
+  - python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md.tmp'
+  - cmp --silent references/sdk_models.md references/sdk_models.md.tmp

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ doc-sdk:
 
 doc-schemas:
 	python bin/generate_sdk_schemas_documentation.py
+	python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md'
 
 doc: doc-cli doc-sdk doc-schemas
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ doc-cli:
 	python bin/generate_cli_documentation.py
 
 doc-sdk:
-	pydocmd simple substra.sdk+ substra.sdk.Client+ > references/sdk.md
+	pydocmd simple substra.sdk+ substra.sdk.Client+ substra.sdk.retry_on_exception+ > references/sdk.md
 
 doc-schemas:
 	python bin/generate_sdk_schemas_documentation.py

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ doc-cli:
 doc-sdk:
 	pydocmd simple substra.sdk+ substra.sdk.Client+ > references/sdk.md
 
-doc: doc-cli doc-sdk
+doc-schemas:
+	python bin/generate_sdk_schemas_documentation.py
+
+doc: doc-cli doc-sdk doc-schemas
 
 test: pyclean
 	python setup.py test

--- a/README.md
+++ b/README.md
@@ -129,19 +129,14 @@ python setup.py test
 
 ### Documentation
 
-To generate the command line interface documentation, run the following command:
+To generate the command line interface documentation, sdk and schemas documentation, the `python` version
+must be 3.7. Run the following command:
 
 ```sh
-python bin/generate_cli_documentation.py
+make doc
 ```
 
-Use the following command to generate the python sdk documentation (with Python 3.7):
-
-```sh
-pydocmd simple substra.sdk+ substra.sdk.Client+ > references/sdk.md
-```
-
-Documentation will be available in *docs/* directory.
+Documentation will be available in the *references/* directory.
 
 ### Deploy
 

--- a/bin/generate_sdk_schemas_documentation.py
+++ b/bin/generate_sdk_schemas_documentation.py
@@ -3,7 +3,7 @@ import inspect
 from pathlib import Path
 import sys
 
-from substra.sdk import schemas
+from substra.sdk import schemas, models
 
 local_dir = Path(__file__).parent
 
@@ -27,42 +27,76 @@ schemas_list = [
     schemas.PrivatePermissions,
 ]
 
+models_list = [
+    models.DataSample,
+    models.Dataset,
+    models.Objective,
+    models.Testtuple,
+    models.Traintuple,
+    models.Aggregatetuple,
+    models.CompositeTraintuple,
+    models.CompositeAlgo,
+    models.AggregateAlgo,
+    models.ComputePlan,
+    models.Node,
+    models.Permissions,
+    models.InModel,
+    models.InHeadModel,
+    models.OutModel,
+    models.OutHeadModel,
+    models.OutCompositeTrunkModel,
+    models.OutCompositeHeadModel,
+    models._File,
+    models._ObjectiveDataset,
+    models._Metric,
+    models._TraintupleAlgo,
+    models._TraintupleDataset,
+    models._TesttupleDataset,
+    models._TesttupleObjective,
+]
+
 
 def _get_field_description(fields):
     desc = [f"{field.name}: {field._type_display()}" for _, field in fields.items()]
     return desc
 
 
-def generate_help(fh):
+def generate_help(fh, models: bool):
+
+    if models:
+        asset_list = models_list
+    else:
+        asset_list = schemas_list
+
     fh.write("# Summary\n\n")
 
     def _create_anchor(schema):
         return "#{}".format(schema.__name__)
 
-    for schema in schemas_list:
-        anchor = _create_anchor(schema)
-        fh.write(f"- [{schema.__name__}]({anchor})\n")
+    for asset in asset_list:
+        anchor = _create_anchor(asset)
+        fh.write(f"- [{asset.__name__}]({anchor})\n")
 
     fh.write("\n\n")
     fh.write("# Schemas\n\n")
 
-    for schema in schemas_list:
-        anchor = _create_anchor(schema)
+    for asset in asset_list:
+        anchor = _create_anchor(asset)
 
-        fh.write(f"## {schema.__name__}\n")
+        fh.write(f"## {asset.__name__}\n")
         # Write the docstring
-        fh.write(f"{inspect.getdoc(schema)}\n")
+        fh.write(f"{inspect.getdoc(asset)}\n")
         # List the fields and their types
-        description = _get_field_description(schema.__fields__)
+        description = _get_field_description(asset.__fields__)
         fh.write("```python\n")
         fh.write("- " + "\n- ".join(description))
         fh.write("\n```")
         fh.write("\n\n")
 
 
-def write_help(path):
+def write_help(path, models: bool):
     with path.open('w') as fh:
-        generate_help(fh)
+        generate_help(fh, models)
 
 
 if __name__ == '__main__':
@@ -71,6 +105,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--output-path', type=str, default=str(default_path.resolve()), required=False)
+    parser.add_argument('--models', action='store_true', help='Generate the doc for the models. Default: generate for the schemas')
 
     args = parser.parse_args(sys.argv[1:])
-    write_help(Path(args.output_path))
+    write_help(Path(args.output_path), models=args.models)

--- a/bin/generate_sdk_schemas_documentation.py
+++ b/bin/generate_sdk_schemas_documentation.py
@@ -1,0 +1,78 @@
+import argparse
+import inspect
+from pathlib import Path
+import sys
+import yaml
+
+from substra.sdk import schemas
+
+local_dir = Path(__file__).parent
+
+schemas_list = [
+    schemas.DataSampleSpec,
+    schemas.DatasetSpec,
+    schemas.ObjectiveSpec,
+    schemas.TesttupleSpec,
+    schemas.TraintupleSpec,
+    schemas.AggregatetupleSpec,
+    schemas.CompositeTraintupleSpec,
+    schemas.CompositeAlgoSpec,
+    schemas.AggregateAlgoSpec,
+    schemas.ComputePlanSpec,
+    schemas.UpdateComputePlanSpec,
+    schemas.ComputePlanTesttupleSpec,
+    schemas.ComputePlanAggregatetupleSpec,
+    schemas.ComputePlanCompositeTraintupleSpec,
+    schemas.ComputePlanTraintupleSpec,
+    schemas.Permissions,
+    schemas.PrivatePermissions,
+]
+
+
+def _get_field_description(fields):
+    desc = [f"{field.name}: {field._type_display()}" for _, field in fields.items()]
+    return desc
+
+
+def generate_help(fh):
+    fh.write("# Summary\n\n")
+
+    def _create_anchor(schema):
+        return "#{}".format(schema.__name__)
+
+    for schema in schemas_list:
+        anchor = _create_anchor(schema)
+        fh.write(f"- [{schema.__name__}]({anchor})\n")
+
+    fh.write("\n\n")
+    fh.write("# Schemas\n\n")
+
+    for schema in schemas_list:
+        anchor = _create_anchor(schema)
+
+        fh.write(f"## {schema.__name__}\n")
+        # Write the docstring
+        fh.write(f"{inspect.getdoc(schema)}\n")
+        # List the fields and their types
+        description = _get_field_description(schema.__fields__)
+        desc_text = yaml.dump(description).replace('\'', ''),
+        fh.write("```python\n")
+        fh.writelines(desc_text)
+        fh.write("\n```")
+        fh.write("\n\n")
+
+
+def write_help(path):
+    with path.open('w') as fh:
+        generate_help(fh)
+
+
+if __name__ == '__main__':
+    doc_dir = local_dir.parent / "references"
+    default_path = doc_dir / "sdk_schemas.md"
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output-path', type=str, default=str(default_path.resolve()), required=False)
+
+    args = parser.parse_args(sys.argv[1:])
+    write_help(Path(args.output_path))

--- a/bin/generate_sdk_schemas_documentation.py
+++ b/bin/generate_sdk_schemas_documentation.py
@@ -65,8 +65,10 @@ def generate_help(fh, models: bool):
 
     if models:
         asset_list = models_list
+        title = "Models"
     else:
         asset_list = schemas_list
+        title = "Schemas"
 
     fh.write("# Summary\n\n")
 
@@ -78,7 +80,7 @@ def generate_help(fh, models: bool):
         fh.write(f"- [{asset.__name__}]({anchor})\n")
 
     fh.write("\n\n")
-    fh.write("# Schemas\n\n")
+    fh.write(f"# {title}\n\n")
 
     for asset in asset_list:
         anchor = _create_anchor(asset)

--- a/bin/generate_sdk_schemas_documentation.py
+++ b/bin/generate_sdk_schemas_documentation.py
@@ -2,7 +2,6 @@ import argparse
 import inspect
 from pathlib import Path
 import sys
-import yaml
 
 from substra.sdk import schemas
 
@@ -55,9 +54,8 @@ def generate_help(fh):
         fh.write(f"{inspect.getdoc(schema)}\n")
         # List the fields and their types
         description = _get_field_description(schema.__fields__)
-        desc_text = yaml.dump(description).replace('\'', ''),
         fh.write("```python\n")
-        fh.writelines(desc_text)
+        fh.write("- " + "\n- ".join(description))
         fh.write("\n```")
         fh.write("\n\n")
 

--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -79,9 +79,9 @@ compute_plan = client.add_compute_plan({
     'composite_traintuples': [],
     'aggregatetuples': [],
 })
-compute_plan_id = compute_plan.get('compute_plan_id')
+compute_plan_id = compute_plan.compute_plan_id
 
 with open(compute_plan_keys_path, 'w') as f:
-    json.dump(compute_plan, f, indent=2)
+    json.dump(compute_plan.dict(exclude_none=False, by_alias=True), f, indent=2)
 
 print(f'Compute plan keys have been saved to {os.path.abspath(compute_plan_keys_path)}')

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -36,7 +36,7 @@ columns = [
 ]
 for i, testtuple_key in enumerate(testtuple_keys):
     testtuple = client.get_testtuple(testtuple_key)
-    score = testtuple.dataset.perf if testtuple.status.value == 'done' else testtuple.status.value
+    score = testtuple.dataset.perf if testtuple.status == 'done' else testtuple.status
     columns[0].append(str(i+1))
     columns[1].append(str(score))
     columns[2].append(testtuple.traintuple_key)

--- a/examples/compute_plan/scripts/display_scores.py
+++ b/examples/compute_plan/scripts/display_scores.py
@@ -36,11 +36,11 @@ columns = [
 ]
 for i, testtuple_key in enumerate(testtuple_keys):
     testtuple = client.get_testtuple(testtuple_key)
-    score = testtuple['dataset']['perf'] if testtuple['status'] == 'done' else testtuple['status']
+    score = testtuple.dataset.perf if testtuple.status.value == 'done' else testtuple.status.value
     columns[0].append(str(i+1))
     columns[1].append(str(score))
-    columns[2].append(testtuple['traintuple_key'])
-    columns[3].append(testtuple['key'])
+    columns[2].append(testtuple.traintuple_key)
+    columns[3].append(testtuple.key)
 
 # display data
 column_widths = []

--- a/examples/debugging/scripts/debugging.py
+++ b/examples/debugging/scripts/debugging.py
@@ -86,7 +86,7 @@ traintuple_key = client.add_traintuple(
 assert traintuple_key, "Missing traintuple key"
 
 traintuple = client.get_traintuple(traintuple_key)
-print(f"\n--- Logs of the execution of the traintuple --- \n{traintuple['log']}\n")
+print(f"\n--- Logs of the execution of the traintuple --- \n{traintuple.log}\n")
 
 #################
 #   Testtuple   #
@@ -103,7 +103,7 @@ testtuple_key = client.add_testtuple(
 assert testtuple_key, "Missing testtuple key"
 
 testtuple = client.get_testtuple(testtuple_key)
-print(f"\n--- Logs of the execution of the testtuple --- \n{testtuple['log']}\n")
+print(f"\n--- Logs of the execution of the testtuple --- \n{testtuple.log}\n")
 
 ###################
 #   Performance   #
@@ -111,4 +111,4 @@ print(f"\n--- Logs of the execution of the testtuple --- \n{testtuple['log']}\n"
 
 #  Get the performance
 testtuple = client.get_testtuple(key=testtuple_key)
-print(f"The performance on the fake test data is {testtuple['dataset']['perf']:.4f}")
+print(f"The performance on the fake test data is {testtuple.dataset.perf:.4f}")

--- a/examples/debugging/scripts/local_debugging.py
+++ b/examples/debugging/scripts/local_debugging.py
@@ -204,4 +204,4 @@ assert testtuple_key, "Missing testtuple key"
 
 #  Get the performance
 testtuple = client.get_testtuple(key=testtuple_key)
-print(f"The performance on the test set is {testtuple['dataset']['perf']:.4f}")
+print(f"The performance on the test set is {testtuple.dataset.perf:.4f}")

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -351,112 +351,134 @@ Returns:
 ```python
 Client.get_algo(self, key: str) -> substra.sdk.models.Algo
 ```
-Get algo by key.
+Get algo by key, the returned object is described
+in the [models.Algo](sdk_models.md#Algo) model
 ## get_compute_plan
 ```python
 Client.get_compute_plan(self, key: str) -> substra.sdk.models.ComputePlan
 ```
-Get compute plan by key.
+Get compute plan by key, the returned object is described
+in the [models.ComputePlan](sdk_models.md#ComputePlan) model
 ## get_aggregate_algo
 ```python
 Client.get_aggregate_algo(self, key: str) -> substra.sdk.models.AggregateAlgo
 ```
-Get aggregate algo by key.
+Get aggregate algo by key, the returned object is described
+in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model
 ## get_composite_algo
 ```python
 Client.get_composite_algo(self, key: str) -> substra.sdk.models.CompositeAlgo
 ```
-Get composite algo by key.
+Get composite algo by key, the returned object is described
+in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model
 ## get_dataset
 ```python
 Client.get_dataset(self, key: str) -> substra.sdk.models.Dataset
 ```
-Get dataset by key.
+Get dataset by key, the returned object is described
+in the [models.Dataset](sdk_models.md#Dataset) model
 ## get_objective
 ```python
 Client.get_objective(self, key: str) -> substra.sdk.models.Objective
 ```
-Get objective by key.
+Get objective by key, the returned object is described
+in the [models.Objective](sdk_models.md#Objective) model
 ## get_testtuple
 ```python
 Client.get_testtuple(self, key: str) -> substra.sdk.models.Testtuple
 ```
-Get testtuple by key.
+Get testtuple by key, the returned object is described
+in the [models.Testtuple](sdk_models.md#Testtuple) model
 ## get_traintuple
 ```python
 Client.get_traintuple(self, key: str) -> substra.sdk.models.Traintuple
 ```
-Get traintuple by key.
+Get traintuple by key, the returned object is described
+in the [models.Traintuple](sdk_models.md#Traintuple) model
 ## get_aggregatetuple
 ```python
 Client.get_aggregatetuple(self, key: str) -> substra.sdk.models.Aggregatetuple
 ```
-Get aggregatetuple by key.
+Get aggregatetuple by key, the returned object is described
+in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
 ## get_composite_traintuple
 ```python
 Client.get_composite_traintuple(self, key: str) -> substra.sdk.models.CompositeTraintuple
 ```
-Get composite traintuple by key.
+Get composite traintuple by key, the returned object is described
+in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
 ## list_algo
 ```python
 Client.list_algo(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
-List algos.
+List algos, the returned object is described
+in the [models.Algo](sdk_models.md#Algo) model
 ## list_compute_plan
 ```python
 Client.list_compute_plan(self, filters=None) -> List[substra.sdk.models.ComputePlan]
 ```
-List compute plans.
+List compute plans, the returned object is described
+in the [models.ComputePlan](sdk_models.md#ComputePlan) model
 ## list_aggregate_algo
 ```python
 Client.list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.AggregateAlgo]
 ```
-List aggregate algos.
+List aggregate algos, the returned object is described
+in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model
 ## list_composite_algo
 ```python
 Client.list_composite_algo(self, filters=None) -> List[substra.sdk.models.CompositeAlgo]
 ```
-List composite algos.
+List composite algos, the returned object is described
+in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model
 ## list_data_sample
 ```python
 Client.list_data_sample(self, filters=None) -> List[substra.sdk.models.DataSample]
 ```
-List data samples.
+List data samples, the returned object is described
+in the [models.DataSample](sdk_models.md#DataSample) model
 ## list_dataset
 ```python
 Client.list_dataset(self, filters=None) -> List[substra.sdk.models.Dataset]
 ```
-List datasets.
+List datasets, the returned object is described
+in the [models.Dataset](sdk_models.md#Dataset) model
 ## list_objective
 ```python
 Client.list_objective(self, filters=None) -> List[substra.sdk.models.Objective]
 ```
-List objectives.
+List objectives, the returned object is described
+in the [models.Objective](sdk_models.md#Objective) model
 ## list_testtuple
 ```python
 Client.list_testtuple(self, filters=None) -> List[substra.sdk.models.Testtuple]
 ```
-List testtuples.
+List testtuples, the returned object is described
+in the [models.Testtuple](sdk_models.md#Testtuple) model
 ## list_traintuple
 ```python
 Client.list_traintuple(self, filters=None) -> List[substra.sdk.models.Traintuple]
 ```
-List traintuples.
+List traintuples, the returned object is described
+in the [models.Traintuple](sdk_models.md#Traintuple) model
 ## list_aggregatetuple
 ```python
 Client.list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Aggregatetuple]
 ```
-List aggregatetuples.
+List aggregatetuples, the returned object is described
+in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
 ## list_composite_traintuple
 ```python
 Client.list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.CompositeTraintuple]
 ```
-List composite traintuples.
+List composite traintuples, the returned object is described
+in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
 ## list_node
 ```python
 Client.list_node(self, *args, **kwargs) -> List[substra.sdk.models.Node]
 ```
-List nodes.
+List nodes, the returned object is described
+in the [models.Node](sdk_models.md#Node) model
 ## update_compute_plan
 ```python
 Client.update_compute_plan(self, compute_plan_id: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
@@ -481,7 +503,8 @@ Args:
         to define the number of tuples uploaded in each batch (default 20).
 
 Returns:
-    models.ComputePlan: updated compute plan
+    models.ComputePlan: updated compute plan, as described in the
+    [models.ComputePlan](sdk_models.md#ComputePlan) model
 
 ## link_dataset_with_objective
 ```python
@@ -567,7 +590,8 @@ Get objective leaderboard
 ```python
 Client.cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
 ```
-Cancel execution of compute plan.
+Cancel execution of compute plan, the returned object is described
+in the [models.ComputePlan](sdk_models.md#ComputePlan) model
 # retry_on_exception
 ```python
 retry_on_exception(exceptions, timeout=300)

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -354,47 +354,47 @@ Client.get_algo(self, key: str) -> substra.sdk.models.Algo
 Get algo by key.
 ## get_compute_plan
 ```python
-Client.get_compute_plan(self, key: str) -> substra.sdk.models.Algo
+Client.get_compute_plan(self, key: str) -> substra.sdk.models.ComputePlan
 ```
 Get compute plan by key.
 ## get_aggregate_algo
 ```python
-Client.get_aggregate_algo(self, key: str) -> substra.sdk.models.Algo
+Client.get_aggregate_algo(self, key: str) -> substra.sdk.models.AggregateAlgo
 ```
 Get aggregate algo by key.
 ## get_composite_algo
 ```python
-Client.get_composite_algo(self, key: str) -> substra.sdk.models.Algo
+Client.get_composite_algo(self, key: str) -> substra.sdk.models.CompositeAlgo
 ```
 Get composite algo by key.
 ## get_dataset
 ```python
-Client.get_dataset(self, key: str) -> substra.sdk.models.Algo
+Client.get_dataset(self, key: str) -> substra.sdk.models.Dataset
 ```
 Get dataset by key.
 ## get_objective
 ```python
-Client.get_objective(self, key: str) -> substra.sdk.models.Algo
+Client.get_objective(self, key: str) -> substra.sdk.models.Objective
 ```
 Get objective by key.
 ## get_testtuple
 ```python
-Client.get_testtuple(self, key: str) -> substra.sdk.models.Algo
+Client.get_testtuple(self, key: str) -> substra.sdk.models.Testtuple
 ```
 Get testtuple by key.
 ## get_traintuple
 ```python
-Client.get_traintuple(self, key: str) -> substra.sdk.models.Algo
+Client.get_traintuple(self, key: str) -> substra.sdk.models.Traintuple
 ```
 Get traintuple by key.
 ## get_aggregatetuple
 ```python
-Client.get_aggregatetuple(self, key: str) -> substra.sdk.models.Algo
+Client.get_aggregatetuple(self, key: str) -> substra.sdk.models.Aggregatetuple
 ```
 Get aggregatetuple by key.
 ## get_composite_traintuple
 ```python
-Client.get_composite_traintuple(self, key: str) -> substra.sdk.models.Algo
+Client.get_composite_traintuple(self, key: str) -> substra.sdk.models.CompositeTraintuple
 ```
 Get composite traintuple by key.
 ## list_algo
@@ -404,57 +404,57 @@ Client.list_algo(self, filters=None) -> List[substra.sdk.models.Algo]
 List algos.
 ## list_compute_plan
 ```python
-Client.list_compute_plan(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_compute_plan(self, filters=None) -> List[substra.sdk.models.ComputePlan]
 ```
 List compute plans.
 ## list_aggregate_algo
 ```python
-Client.list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.AggregateAlgo]
 ```
 List aggregate algos.
 ## list_composite_algo
 ```python
-Client.list_composite_algo(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_composite_algo(self, filters=None) -> List[substra.sdk.models.CompositeAlgo]
 ```
 List composite algos.
 ## list_data_sample
 ```python
-Client.list_data_sample(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_data_sample(self, filters=None) -> List[substra.sdk.models.DataSample]
 ```
 List data samples.
 ## list_dataset
 ```python
-Client.list_dataset(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_dataset(self, filters=None) -> List[substra.sdk.models.Dataset]
 ```
 List datasets.
 ## list_objective
 ```python
-Client.list_objective(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_objective(self, filters=None) -> List[substra.sdk.models.Objective]
 ```
 List objectives.
 ## list_testtuple
 ```python
-Client.list_testtuple(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_testtuple(self, filters=None) -> List[substra.sdk.models.Testtuple]
 ```
 List testtuples.
 ## list_traintuple
 ```python
-Client.list_traintuple(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_traintuple(self, filters=None) -> List[substra.sdk.models.Traintuple]
 ```
 List traintuples.
 ## list_aggregatetuple
 ```python
-Client.list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Aggregatetuple]
 ```
 List aggregatetuples.
 ## list_composite_traintuple
 ```python
-Client.list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.Algo]
+Client.list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.CompositeTraintuple]
 ```
 List composite traintuples.
 ## list_node
 ```python
-Client.list_node(self, *args, **kwargs) -> List[substra.sdk.models.Algo]
+Client.list_node(self, *args, **kwargs) -> List[substra.sdk.models.Node]
 ```
 List nodes.
 ## update_compute_plan
@@ -568,28 +568,3 @@ Get objective leaderboard
 Client.cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
 ```
 Cancel execution of compute plan.
-# retry_on_exception
-```python
-retry_on_exception(exceptions, timeout=300)
-```
-Retry function in case of exception(s).
-
-Arguments:
-    exceptions: list of exception types that trigger a retry
-    timeout (int): timeout in seconds
-
-Example:
-
-```python
-from substra.sdk import exceptions, retry_on_exception
-
-def my_function(arg1, arg2):
-    pass
-
-retry = retry_on_exception(
-            exceptions=(exceptions.RequestTimeout),
-            timeout=300,
-        )
-retry(my_function)(arg1, arg2)
-```
-

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -568,3 +568,28 @@ Get objective leaderboard
 Client.cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
 ```
 Cancel execution of compute plan.
+# retry_on_exception
+```python
+retry_on_exception(exceptions, timeout=300)
+```
+Retry function in case of exception(s).
+
+Arguments:
+    exceptions: list of exception types that trigger a retry
+    timeout (int): timeout in seconds
+
+Example:
+
+```python
+from substra.sdk import exceptions, retry_on_exception
+
+def my_function(arg1, arg2):
+    pass
+
+retry = retry_on_exception(
+            exceptions=(exceptions.RequestTimeout),
+            timeout=300,
+        )
+retry(my_function)(arg1, arg2)
+```
+

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -46,11 +46,11 @@ Args:
     profile_name (str, optional): Name of the profile to load.
         Defaults to 'default'.
 
-    config_path (typing.Union[str, pathlib.Path], optional): Path to the
+    config_path (Union[str, pathlib.Path], optional): Path to the
         configuration file.
         Defaults to '~/.substra'.
 
-    tokens_path (typing.Union[str, pathlib.Path], optional): Path to the tokens file.
+    tokens_path (Union[str, pathlib.Path], optional): Path to the tokens file.
         Defaults to '~/.substra-tokens'.
 
     token (str, optional): Token to use for authentication (will be used
@@ -69,59 +69,41 @@ Returns:
 
 ## add_data_sample
 ```python
-Client.add_data_sample(self, data, local=True, exist_ok=False)
+Client.add_data_sample(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True, exist_ok: bool = False) -> str
 ```
-Create new data sample asset.
-
-`data` is a dict object with the following schema:
-
-```
-{
-    "path": str,
-    "data_manager_keys": list[str],
-    "test_only": bool,
-}
-```
-The `path` in the data dictionary must point to a directory representing the
-data sample content. Note that the directory can contain multiple files, all the
-directory content will be added to the platform.
-
-If `local` is true, `path` must refer to a directory located on the local
-filesystem. The file content will be transferred to the server through an
-HTTP query, so this mode should be used for relatively small files (<10mo).
-
-If `local` is false, `path` must refer to a directory located on the server
-filesystem. This directory must be accessible (readable) by the server.  This
-mode is well suited for all kind of file sizes.
+Create a new data sample asset and return its key.
 
 If a data sample with the same content already exists, an `AlreadyExists` exception will be
 raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
+
+    data (Union[dict, schemas.DataSampleSpec]): data sample to add. If it is a dict,
+    it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+
+    local (bool, optional):
+        If `local` is true, `path` must refer to a directory located on the local
+        filesystem. The file content will be transferred to the server through an
+        HTTP query, so this mode should be used for relatively small files (<10mo).
+
+        If `local` is false, `path` must refer to a directory located on the server
+        filesystem. This directory must be accessible (readable) by the server.  This
+        mode is well suited for all kind of file sizes. Defaults to True.
+
+    exist_ok (bool, optional):
+        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
+        existing asset key will be returned. Defaults to False.
+
+Returns:
+    str: key of the data sample
 
 ## add_data_samples
 ```python
-Client.add_data_samples(self, data, local=True)
+Client.add_data_samples(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True) -> List[str]
 ```
-Create many data sample assets.
+Create many data sample assets and return  a list of keys.
 
-`data` is a dict object with the following schema:
-
-```
-{
-    "paths": list[str],
-    "data_manager_keys": list[str],
-    "test_only": bool,
-}
-```
 Create multiple data samples through a single HTTP request.
-
-The `paths` in the data dictionary must be a list of paths where each path
-points to a directory representing one data sample.
-
-For the `local` argument, please refer to the method `Client.add_data_sample`.
-
 This method is well suited for adding multiple small files only. For adding a
 large amount of data it is recommended to add them one by one. It allows a
 better control in case of failures.
@@ -129,228 +111,176 @@ better control in case of failures.
 If data samples with the same content as any of the paths already exists, an `AlreadyExists`
 exception will be raised.
 
+Args:
+
+    data (Union[dict, schemas.DataSampleSpec]): data samples to add. If it is a dict,
+        it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+
+        The `paths` in the data dictionary must be a list of paths where each path
+        points to a directory representing one data sample.
+
+    local (bool, optional):  Please refer to the method `Client.add_data_sample`.
+        Defaults to True.
+
+Returns:
+    List[str]: List of the data sample keys
+
 ## add_dataset
 ```python
-Client.add_dataset(self, data, exist_ok=False)
+Client.add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec], exist_ok: bool = False)
 ```
-Create new dataset asset.
-
-`data` is a dict object with the following schema:
-
-```
-{
-    "name": str,
-    "description": str,
-    "type": str,
-    "data_opener": str,
-    "objective_key": str,
-    "permissions": {
-        "public": bool,
-        "authorized_ids": list[str],
-    },
-    "metadata": dict
-}
-```
+Create new dataset asset and return its key.
 
 If a dataset with the same opener already exists, an `AlreadyExists` exception will be
 raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
+        keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+        will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+Returns:
+    str: Key of the dataset
 
 ## add_objective
 ```python
-Client.add_objective(self, data, exist_ok=False)
+Client.add_objective(self, data: Union[dict, substra.sdk.schemas.ObjectiveSpec], exist_ok: bool = False) -> str
 ```
 Create new objective asset.
-
-`data` is a dict object with the following schema:
-
-```
-{
-    "name": str,
-    "description": str,
-    "metrics_name": str,
-    "metrics": str,
-    "test_data_manager_key": str,
-    "test_data_sample_keys": list[str],
-    "permissions": {
-        "public": bool,
-        "authorized_ids": list[str],
-    },
-    "metadata": dict
-}
-```
 
 If an objective with the same description already exists, an `AlreadyExists` exception will
 be raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.ObjectiveSpec]): If it is a dict, it must have the same keys
+        as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+        will be ignored and the existing asset key will be returned. Defaults to False.
+
+Returns:
+    str: Key of the objective
 
 ## add_algo
 ```python
-Client.add_algo(self, data, exist_ok=False)
+Client.add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec], exist_ok: bool = False) -> str
 ```
 Create new algo asset.
-
-`data` is a dict object with the following schema:
-
-```
-{
-    "name": str,
-    "description": str,
-    "file": str,
-    "permissions": {
-        "public": bool,
-        "authorized_ids": list[str],
-    },
-    "metadata": dict
-}
-```
 
 If an algo with the same archive file already exists, an `AlreadyExists` exception will be
 raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
+        as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
+        ignored and the existing asset key will be returned. Defaults to False.
+
+Returns:
+    str: Key of the algo
 
 ## add_aggregate_algo
 ```python
-Client.add_aggregate_algo(self, data, exist_ok=False)
+Client.add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec], exist_ok: bool = False) -> str
 ```
 Create new aggregate algo asset.
-`data` is a dict object with the following schema:
-```
-{
-    "name": str,
-    "description": str,
-    "file": str,
-    "permissions": {
-        "public": bool,
-        "authorized_ids": list[str],
-    },
-    "metadata": dict
-}
-```
+
 If an aggregate algo with the same archive file already exists, an `AlreadyExists`
 exception will be raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
+        it must have the same keys as specified in
+        [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_composite_algo
 ```python
-Client.add_composite_algo(self, data, exist_ok=False)
+Client.add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec], exist_ok: bool = False) -> str
 ```
 Create new composite algo asset.
-`data` is a dict object with the following schema:
-```
-{
-    "name": str,
-    "description": str,
-    "file": str,
-    "permissions": {
-        "public": bool,
-        "authorized_ids": list[str],
-    },
-    "metadata": dict
-}
-```
-If a composite algo with the same archive file already exists, an `AlreadyExists` exception
-will be raised.
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+If a composite algo with the same archive file already exists, an `AlreadyExists`
+exception will be raised.
 
-This returns the key of the created asset.
+Args:
+
+    data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
+        keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_traintuple
 ```python
-Client.add_traintuple(self, data, exist_ok=False)
+Client.add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec], exist_ok: bool = False) -> str
 ```
 Create new traintuple asset.
 
-`data` is a dict object with the following schema:
-
-```
-{
-    "algo_key": str,
-    "data_manager_key": str,
-    "train_data_sample_keys": list[str],
-    "in_models_keys": list[str],
-    "tag": str,
-    "metadata": dict,
-    "rank": int,
-    "compute_plan_id": str,
-}
-```
 An `AlreadyExists` exception will be raised if a traintuple already exists that:
 * has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
 * and was created through the same node you are using
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
+        keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_aggregatetuple
 ```python
-Client.add_aggregatetuple(self, data, exist_ok=False)
+Client.add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpec], exist_ok: bool = False) -> str
 ```
-Create new aggregatetuple asset.
-`data` is a dict object with the following schema:
-```
-{
-    "algo_key": str,
-    "in_models_keys": list[str],
-    "tag": str,
-    "metadata": dict,
-    "compute_plan_id": str,
-    "rank": int,
-    "worker": str,
-}
-```
+Create a new aggregate tuple asset.
+
 An `AlreadyExists` exception will be raised if an aggregatetuple already exists that:
 * has the same `algo_key` and `in_models_keys`
 * and was created through the same node you are using
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
+        keys as specified in
+        [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_composite_traintuple
 ```python
-Client.add_composite_traintuple(self, data, exist_ok=False)
+Client.add_composite_traintuple(self, data: Union[dict, substra.sdk.schemas.CompositeTraintupleSpec], exist_ok: bool = False) -> str
 ```
 Create new composite traintuple asset.
-`data` is a dict object with the following schema:
-```
-{
-    "algo_key": str,
-    "data_manager_key": str,
-    "in_head_model_key": str,
-    "in_trunk_model_key": str,
-    "out_trunk_model_permissions": {
-        "authorized_ids": list[str],
-    },
-    "tag": str,
-    "metadata": dict,
-    "rank": int,
-    "compute_plan_id": str,
-}
-```
 
-As specified in the data dict structure, output trunk models cannot be made
+As specified in the data structure, output trunk models cannot be made
 public.
 
 An `AlreadyExists` exception will be raised if a traintuple already exists that:
@@ -358,280 +288,214 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
   `in_head_models_key` and `in_trunk_model_key`
 * and was created through the same node you are using
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
+        same keys as specified in
+        [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_testtuple
 ```python
-Client.add_testtuple(self, data, exist_ok=False)
+Client.add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec], exist_ok: bool = False) -> str
 ```
 Create new testtuple asset.
-
-`data` is a dict object with the following schema:
-
-```
-{
-    "objective_key": str,
-    "data_manager_key": str,
-    "traintuple_key": str,
-    "test_data_sample_keys": list[str],
-    "tag": str,
-    "metadata": dict
-}
-```
 
 An `AlreadyExists` exception will be raised if a testtuple already exists that:
 * has the same `traintuple_key`, `objective_key`, `data_manager_key` and
   `test_data_sample_keys`
 * and was created through the same node you are using
 
-If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-existing asset key will be returned.
+Args:
 
-This returns the key of the created asset.
+    data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same
+        keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
+
+    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+        exceptions will be ignored and the existing asset key will be returned.
+        Defaults to False.
+
+ Returns:
+    str: Key of the asset
 
 ## add_compute_plan
 ```python
-Client.add_compute_plan(self, data, auto_batching: bool = True, batch_size: int = 20)
+Client.add_compute_plan(self, data: Union[dict, substra.sdk.schemas.ComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
 ```
-Create compute plan.
-
-Data is a dict object with the following schema:
-```
-{
-    "traintuples": list[{
-        "traintuple_id": str,
-        "algo_key": str,
-        "data_manager_key": str,
-        "train_data_sample_keys": list[str],
-        "in_models_ids": list[str],
-        "tag": str,
-        "metadata": dict,
-    }],
-    "composite_traintuples": list[{
-        "composite_traintuple_id": str,
-        "algo_key": str,
-        "data_manager_key": str,
-        "train_data_sample_keys": list[str],
-        "in_head_model_id": str,
-        "in_trunk_model_id": str,
-        "out_trunk_model_permissions": {
-            "authorized_ids": list[str],
-        },
-        "tag": str,
-        "metadata": dict,
-    }]
-    "aggregatetuples": list[{
-        "aggregatetuple_id": str,
-        "algo_key": str,
-        "worker": str,
-        "in_models_ids": list[str],
-        "tag": str,
-        "metadata": dict,
-    }],
-    "testtuples": list[{
-        "objective_key": str,
-        "data_manager_key": str,
-        "test_data_sample_keys": list[str],
-        "traintuple_id": str,
-        "tag": str,
-        "metadata": dict,
-    }],
-    "clean_models": bool,
-    "tag": str,
-    "metadata": dict
-}
-```
+Create new compute plan asset.
 
 As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
-Set 'auto_batching' to False to upload all the tuples of the
-compute plan at once.
-If 'auto_batching' is True, change `batch_size` to define the number of
-tuples uploaded in each batch (default 20).
+
+Args:
+
+    data (Union[dict, schemas.ComputePlanSpec]): If it is a dict, it must have the same
+        keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
+
+    auto_batching (bool, optional): Set 'auto_batching' to False to upload all the tuples of
+        the compute plan at once. Defaults to True.
+
+    batch_size (int, optional): If 'auto_batching' is True, change `batch_size` to define
+        the number oftuples uploaded in each batch (default 20).
+
+Returns:
+    models.ComputePlan: Created compute plan
 
 ## get_algo
 ```python
-Client.get_algo(self, key)
+Client.get_algo(self, key: str) -> substra.sdk.models.Algo
 ```
 Get algo by key.
 ## get_compute_plan
 ```python
-Client.get_compute_plan(self, key)
+Client.get_compute_plan(self, key: str) -> substra.sdk.models.Algo
 ```
 Get compute plan by key.
 ## get_aggregate_algo
 ```python
-Client.get_aggregate_algo(self, key)
+Client.get_aggregate_algo(self, key: str) -> substra.sdk.models.Algo
 ```
 Get aggregate algo by key.
 ## get_composite_algo
 ```python
-Client.get_composite_algo(self, key)
+Client.get_composite_algo(self, key: str) -> substra.sdk.models.Algo
 ```
 Get composite algo by key.
 ## get_dataset
 ```python
-Client.get_dataset(self, key)
+Client.get_dataset(self, key: str) -> substra.sdk.models.Algo
 ```
 Get dataset by key.
 ## get_objective
 ```python
-Client.get_objective(self, key)
+Client.get_objective(self, key: str) -> substra.sdk.models.Algo
 ```
 Get objective by key.
 ## get_testtuple
 ```python
-Client.get_testtuple(self, key)
+Client.get_testtuple(self, key: str) -> substra.sdk.models.Algo
 ```
 Get testtuple by key.
 ## get_traintuple
 ```python
-Client.get_traintuple(self, key)
+Client.get_traintuple(self, key: str) -> substra.sdk.models.Algo
 ```
 Get traintuple by key.
 ## get_aggregatetuple
 ```python
-Client.get_aggregatetuple(self, key)
+Client.get_aggregatetuple(self, key: str) -> substra.sdk.models.Algo
 ```
 Get aggregatetuple by key.
 ## get_composite_traintuple
 ```python
-Client.get_composite_traintuple(self, key)
+Client.get_composite_traintuple(self, key: str) -> substra.sdk.models.Algo
 ```
 Get composite traintuple by key.
 ## list_algo
 ```python
-Client.list_algo(self, filters=None)
+Client.list_algo(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List algos.
 ## list_compute_plan
 ```python
-Client.list_compute_plan(self, filters=None)
+Client.list_compute_plan(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List compute plans.
 ## list_aggregate_algo
 ```python
-Client.list_aggregate_algo(self, filters=None)
+Client.list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List aggregate algos.
 ## list_composite_algo
 ```python
-Client.list_composite_algo(self, filters=None)
+Client.list_composite_algo(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List composite algos.
 ## list_data_sample
 ```python
-Client.list_data_sample(self, filters=None)
+Client.list_data_sample(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List data samples.
 ## list_dataset
 ```python
-Client.list_dataset(self, filters=None)
+Client.list_dataset(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List datasets.
 ## list_objective
 ```python
-Client.list_objective(self, filters=None)
+Client.list_objective(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List objectives.
 ## list_testtuple
 ```python
-Client.list_testtuple(self, filters=None)
+Client.list_testtuple(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List testtuples.
 ## list_traintuple
 ```python
-Client.list_traintuple(self, filters=None)
+Client.list_traintuple(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List traintuples.
 ## list_aggregatetuple
 ```python
-Client.list_aggregatetuple(self, filters=None)
+Client.list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List aggregatetuples.
 ## list_composite_traintuple
 ```python
-Client.list_composite_traintuple(self, filters=None)
+Client.list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.Algo]
 ```
 List composite traintuples.
 ## list_node
 ```python
-Client.list_node(self, *args, **kwargs)
+Client.list_node(self, *args, **kwargs) -> List[substra.sdk.models.Algo]
 ```
 List nodes.
 ## update_compute_plan
 ```python
-Client.update_compute_plan(self, compute_plan_id, data, auto_batching: bool = True, batch_size: int = 20)
+Client.update_compute_plan(self, compute_plan_id: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
 ```
 Update compute plan.
 
-Data is a dict object with the following schema:
-```
-{
-    "traintuples": list[{
-        "traintuple_id": str,
-        "algo_key": str,
-        "data_manager_key": str,
-        "train_data_sample_keys": list[str],
-        "in_models_ids": list[str],
-        "tag": str,
-        "metadata": dict,
-    }],
-    "composite_traintuples": list[{
-        "composite_traintuple_id": str,
-        "algo_key": str,
-        "data_manager_key": str,
-        "train_data_sample_keys": list[str],
-        "in_head_model_id": str,
-        "in_trunk_model_id": str,
-        "out_trunk_model_permissions": {
-            "authorized_ids": list[str],
-        },
-        "tag": str,
-        "metadata": dict,
-    }]
-    "aggregatetuples": list[{
-        "aggregatetuple_id": str,
-        "algo_key": str,
-        "worker": str,
-        "in_models_ids": list[str],
-        "tag": str,
-        "metadata": dict,
-    }],
-    "testtuples": list[{
-        "objective_key": str,
-        "data_manager_key": str,
-        "test_data_sample_keys": list[str],
-        "traintuple_id": str,
-        "tag": str,
-        "metadata": dict,
-    }]
-}
-```
-
 As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
-Set 'auto_batching' to False to upload all the tuples of the
-compute plan at once.
-If 'auto_batching' is True, change `batch_size` to define the number of
-tuples uploaded in each batch (default 20).
+
+Args:
+
+    compute_plan_id (str): Id of the compute plan
+
+    data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
+        it must have the same keys as specified in
+        [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
+
+    auto_batching (bool, optional): Set 'auto_batching' to False to upload all
+        the tuples of the compute plan at once. Defaults to True.
+
+    batch_size (int, optional): If 'auto_batching' is True, change `batch_size`
+        to define the number of tuples uploaded in each batch (default 20).
+
+Returns:
+    models.ComputePlan: updated compute plan
 
 ## link_dataset_with_objective
 ```python
-Client.link_dataset_with_objective(self, dataset_key, objective_key)
+Client.link_dataset_with_objective(self, dataset_key: str, objective_key: str) -> str
 ```
 Link dataset with objective.
 ## link_dataset_with_data_samples
 ```python
-Client.link_dataset_with_data_samples(self, dataset_key, data_sample_keys)
+Client.link_dataset_with_data_samples(self, dataset_key: str, data_sample_keys: str) -> List[str]
 ```
 Link dataset with data samples.
 ## download_dataset
 ```python
-Client.download_dataset(self, key, destination_folder)
+Client.download_dataset(self, key: str, destination_folder: str) -> None
 ```
 Download data manager resource.
 
@@ -639,7 +503,7 @@ Download opener script in destination folder.
 
 ## download_algo
 ```python
-Client.download_algo(self, key, destination_folder)
+Client.download_algo(self, key: str, destination_folder: str) -> None
 ```
 Download algo resource.
 
@@ -647,7 +511,7 @@ Download algo package in destination folder.
 
 ## download_aggregate_algo
 ```python
-Client.download_aggregate_algo(self, key, destination_folder)
+Client.download_aggregate_algo(self, key: str, destination_folder: str) -> None
 ```
 Download aggregate algo resource.
 
@@ -655,7 +519,7 @@ Download aggregate algo package in destination folder.
 
 ## download_composite_algo
 ```python
-Client.download_composite_algo(self, key, destination_folder)
+Client.download_composite_algo(self, key: str, destination_folder: str) -> None
 ```
 Download composite algo resource.
 
@@ -663,7 +527,7 @@ Download composite algo package in destination folder.
 
 ## download_objective
 ```python
-Client.download_objective(self, key, destination_folder)
+Client.download_objective(self, key: str, destination_folder: str) -> None
 ```
 Download objective resource.
 
@@ -671,37 +535,37 @@ Download metrics script in destination folder.
 
 ## describe_algo
 ```python
-Client.describe_algo(self, key)
+Client.describe_algo(self, key: str) -> str
 ```
 Get algo description.
 ## describe_aggregate_algo
 ```python
-Client.describe_aggregate_algo(self, key)
+Client.describe_aggregate_algo(self, key: str) -> str
 ```
 Get aggregate algo description.
 ## describe_composite_algo
 ```python
-Client.describe_composite_algo(self, key)
+Client.describe_composite_algo(self, key: str) -> str
 ```
 Get composite algo description.
 ## describe_dataset
 ```python
-Client.describe_dataset(self, key)
+Client.describe_dataset(self, key: str) -> str
 ```
 Get dataset description.
 ## describe_objective
 ```python
-Client.describe_objective(self, key)
+Client.describe_objective(self, key: str) -> str
 ```
 Get objective description.
 ## leaderboard
 ```python
-Client.leaderboard(self, objective_key, sort='desc')
+Client.leaderboard(self, objective_key: str, sort: str = 'desc') -> str
 ```
 Get objective leaderboard
 ## cancel_compute_plan
 ```python
-Client.cancel_compute_plan(self, compute_plan_id)
+Client.cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
 ```
 Cancel execution of compute plan.
 # retry_on_exception
@@ -715,16 +579,17 @@ Arguments:
     timeout (int): timeout in seconds
 
 Example:
-    ```python
-    from substra.sdk import exceptions, retry_on_exception
 
-    def my_function(arg1, arg2):
-        pass
+```python
+from substra.sdk import exceptions, retry_on_exception
 
-    retry = retry_on_exception(
-                exceptions=(exceptions.RequestTimeout),
-                timeout=300,
-            )
-    retry(my_function)(arg1, arg2)
-    ```
+def my_function(arg1, arg2):
+    pass
+
+retry = retry_on_exception(
+            exceptions=(exceptions.RequestTimeout),
+            timeout=300,
+        )
+retry(my_function)(arg1, arg2)
+```
 

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -1,0 +1,302 @@
+# Summary
+
+- [DataSample](#DataSample)
+- [Dataset](#Dataset)
+- [Objective](#Objective)
+- [Testtuple](#Testtuple)
+- [Traintuple](#Traintuple)
+- [Aggregatetuple](#Aggregatetuple)
+- [CompositeTraintuple](#CompositeTraintuple)
+- [CompositeAlgo](#CompositeAlgo)
+- [AggregateAlgo](#AggregateAlgo)
+- [ComputePlan](#ComputePlan)
+- [Node](#Node)
+- [Permissions](#Permissions)
+- [InModel](#InModel)
+- [InHeadModel](#InHeadModel)
+- [OutModel](#OutModel)
+- [OutHeadModel](#OutHeadModel)
+- [OutCompositeTrunkModel](#OutCompositeTrunkModel)
+- [OutCompositeHeadModel](#OutCompositeHeadModel)
+- [_File](#_File)
+- [_ObjectiveDataset](#_ObjectiveDataset)
+- [_Metric](#_Metric)
+- [_TraintupleAlgo](#_TraintupleAlgo)
+- [_TraintupleDataset](#_TraintupleDataset)
+- [_TesttupleDataset](#_TesttupleDataset)
+- [_TesttupleObjective](#_TesttupleObjective)
+
+
+# Schemas
+
+## DataSample
+Data sample
+```python
+- key: str
+- owner: str
+- data_manager_keys: Optional[List[str]]
+- path: Optional[DirectoryPath]
+- validated: bool
+- test_only: bool
+```
+
+## Dataset
+Dataset asset
+```python
+- key: str
+- name: str
+- owner: str
+- objective_key: Optional[str]
+- permissions: Permissions
+- type: str
+- train_data_sample_keys: List[str]
+- test_data_sample_keys: List[str]
+- opener: _File
+- description: _File
+- metadata: Mapping[str, str]
+```
+
+## Objective
+Asset creation specification base class.
+```python
+- key: str
+- name: str
+- owner: str
+- test_dataset: Optional[_ObjectiveDataset]
+- metadata: Mapping[str, str]
+- permissions: Permissions
+- description: _File
+- metrics: _Metric
+```
+
+## Testtuple
+Asset creation specification base class.
+```python
+- key: str
+- creator: str
+- algo: _TraintupleAlgo
+- objective: _TesttupleObjective
+- traintuple_key: str
+- certified: bool
+- dataset: _TesttupleDataset
+- tag: Optional[str]
+- log: str
+- status: str
+- compute_plan_id: str
+- rank: int
+- traintuple_type: enum
+- metadata: Mapping[str, str]
+```
+
+## Traintuple
+Asset creation specification base class.
+```python
+- key: str
+- creator: str
+- algo: _TraintupleAlgo
+- dataset: _TraintupleDataset
+- permissions: Permissions
+- tag: str
+- compute_plan_id: str
+- rank: int
+- status: str
+- log: str
+- in_models: Optional[List[InModel]]
+- out_model: Optional[OutModel]
+- metadata: Mapping[str, str]
+```
+
+## Aggregatetuple
+Asset creation specification base class.
+```python
+- key: str
+- creator: str
+- worker: str
+- algo: _TraintupleAlgo
+- permissions: Permissions
+- tag: str
+- compute_plan_id: str
+- rank: Optional[int]
+- status: str
+- log: str
+- in_models: List[InModel]
+- out_model: Optional[OutModel]
+- metadata: Mapping[str, str]
+```
+
+## CompositeTraintuple
+Asset creation specification base class.
+```python
+- key: str
+- creator: str
+- algo: _TraintupleAlgo
+- dataset: _TraintupleDataset
+- tag: str
+- compute_plan_id: str
+- rank: Optional[int]
+- status: str
+- log: str
+- in_head_model: Optional[InHeadModel]
+- in_trunk_model: Optional[InModel]
+- out_head_model: OutCompositeHeadModel
+- out_trunk_model: OutCompositeTrunkModel
+- metadata: Mapping[str, str]
+```
+
+## CompositeAlgo
+Asset creation specification base class.
+```python
+- key: str
+- name: str
+- owner: str
+- permissions: Permissions
+- metadata: Mapping[str, str]
+- description: _File
+- content: _File
+```
+
+## AggregateAlgo
+Asset creation specification base class.
+```python
+- key: str
+- name: str
+- owner: str
+- permissions: Permissions
+- metadata: Mapping[str, str]
+- description: _File
+- content: _File
+```
+
+## ComputePlan
+Asset creation specification base class.
+```python
+- compute_plan_id: str
+- status: str
+- traintuple_keys: Optional[List[str]]
+- composite_traintuple_keys: Optional[List[str]]
+- aggregatetuple_keys: Optional[List[str]]
+- testtuple_keys: Optional[List[str]]
+- id_to_key: Mapping[str, str]
+- tag: str
+- tuple_count: int
+- done_count: int
+- metadata: Mapping[str, str]
+- clean_models: bool
+```
+
+## Node
+Shared configuration for all schemas here
+```python
+- id: str
+- is_current: bool
+```
+
+## Permissions
+Permissions structure stored in various asset types.
+```python
+- process: Permission
+```
+
+## InModel
+In model of a traintuple, aggregate tuple or in trunk
+model of a composite traintuple
+```python
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
+- traintuple_key: Optional[str]
+```
+
+## InHeadModel
+In head model of a composite traintuple
+```python
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str, NoneType]
+- traintuple_key: Optional[str]
+```
+
+## OutModel
+Out model of a traintuple, aggregate tuple or out trunk
+model of a composite traintuple
+```python
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
+```
+
+## OutHeadModel
+Out head model of a composite traintuple
+```python
+- hash_: str
+- storage_address: Optional[FilePath]
+```
+
+## OutCompositeTrunkModel
+Out trunk model of a composite traintuple with permissions
+```python
+- permissions: Permissions
+- out_model: Optional[OutModel]
+```
+
+## OutCompositeHeadModel
+Out head model of a composite traintuple with permissions
+```python
+- permissions: Permissions
+- out_model: Optional[OutHeadModel]
+```
+
+## _File
+File as stored in the models
+```python
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
+```
+
+## _ObjectiveDataset
+Dataset as stored in the Objective asset
+```python
+- data_manager_key: str
+- data_sample_keys: List[str]
+- metadata: Mapping[str, str]
+- worker: Optional[str]
+```
+
+## _Metric
+Metric associated to a testtuple or objective
+```python
+- name: Optional[str]
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
+```
+
+## _TraintupleAlgo
+Algo associated to a traintuple
+```python
+- hash_: str
+- storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
+- name: str
+```
+
+## _TraintupleDataset
+Dataset as stored in a traintuple or composite traintuple
+```python
+- opener_hash: str
+- keys: List[str]
+- worker: str
+- metadata: Optional[Mapping[str, str]]
+```
+
+## _TesttupleDataset
+Dataset of a testtuple
+```python
+- opener_hash: str
+- perf: float
+- keys: List[str]
+- worker: str
+```
+
+## _TesttupleObjective
+Objective of a testtuple
+```python
+- hash_: str
+- metrics: _Metric
+```
+

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -27,7 +27,7 @@
 - [_TesttupleObjective](#_TesttupleObjective)
 
 
-# Schemas
+# Models
 
 ## DataSample
 Data sample
@@ -57,7 +57,7 @@ Dataset asset
 ```
 
 ## Objective
-Asset creation specification base class.
+Objective
 ```python
 - key: str
 - name: str
@@ -70,7 +70,7 @@ Asset creation specification base class.
 ```
 
 ## Testtuple
-Asset creation specification base class.
+Testtuple
 ```python
 - key: str
 - creator: str
@@ -89,7 +89,7 @@ Asset creation specification base class.
 ```
 
 ## Traintuple
-Asset creation specification base class.
+Traintuple
 ```python
 - key: str
 - creator: str
@@ -107,7 +107,7 @@ Asset creation specification base class.
 ```
 
 ## Aggregatetuple
-Asset creation specification base class.
+Aggregatetuple
 ```python
 - key: str
 - creator: str
@@ -125,7 +125,7 @@ Asset creation specification base class.
 ```
 
 ## CompositeTraintuple
-Asset creation specification base class.
+CompositeTraintuple
 ```python
 - key: str
 - creator: str
@@ -144,7 +144,7 @@ Asset creation specification base class.
 ```
 
 ## CompositeAlgo
-Asset creation specification base class.
+CompositeAlgo
 ```python
 - key: str
 - name: str
@@ -156,7 +156,7 @@ Asset creation specification base class.
 ```
 
 ## AggregateAlgo
-Asset creation specification base class.
+AggregateAlgo
 ```python
 - key: str
 - name: str
@@ -168,7 +168,7 @@ Asset creation specification base class.
 ```
 
 ## ComputePlan
-Asset creation specification base class.
+ComputePlan
 ```python
 - compute_plan_id: str
 - status: str
@@ -185,7 +185,7 @@ Asset creation specification base class.
 ```
 
 ## Node
-Shared configuration for all schemas here
+Node
 ```python
 - id: str
 - is_current: bool

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -1,0 +1,235 @@
+# Summary
+
+- [DataSampleSpec](#DataSampleSpec)
+- [DatasetSpec](#DatasetSpec)
+- [ObjectiveSpec](#ObjectiveSpec)
+- [TesttupleSpec](#TesttupleSpec)
+- [TraintupleSpec](#TraintupleSpec)
+- [AggregatetupleSpec](#AggregatetupleSpec)
+- [CompositeTraintupleSpec](#CompositeTraintupleSpec)
+- [CompositeAlgoSpec](#CompositeAlgoSpec)
+- [AggregateAlgoSpec](#AggregateAlgoSpec)
+- [ComputePlanSpec](#ComputePlanSpec)
+- [UpdateComputePlanSpec](#UpdateComputePlanSpec)
+- [ComputePlanTesttupleSpec](#ComputePlanTesttupleSpec)
+- [ComputePlanAggregatetupleSpec](#ComputePlanAggregatetupleSpec)
+- [ComputePlanCompositeTraintupleSpec](#ComputePlanCompositeTraintupleSpec)
+- [ComputePlanTraintupleSpec](#ComputePlanTraintupleSpec)
+- [Permissions](#Permissions)
+- [PrivatePermissions](#PrivatePermissions)
+
+
+# Schemas
+
+## DataSampleSpec
+Specification to create one or many data samples
+To create one data sample, use the 'path' field, otherwise use
+the 'paths' field.
+```python
+- path: Optional[Path]
+- paths: Optional[List[Path]]
+- test_only: bool
+- data_manager_keys: List[str]
+
+```
+
+## DatasetSpec
+Specification for creating a dataset
+```python
+- name: str
+- data_opener: Path
+- type: str
+- description: Path
+- permissions: Permissions
+- objective_key: Optional[str]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## ObjectiveSpec
+Specification for creating an objective
+```python
+- name: str
+- description: Path
+- metrics_name: str
+- metrics: Path
+- test_data_sample_keys: Optional[List[str]]
+- test_data_manager_key: Optional[str]
+- permissions: Permissions
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## TesttupleSpec
+Specification for creating a testtuple
+```python
+- objective_key: str
+- traintuple_key: str
+- tag: Optional[str]
+- data_manager_key: Optional[str]
+- test_data_sample_keys: Optional[List[str]]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## TraintupleSpec
+Specification for creating a traintuple
+```python
+- algo_key: str
+- data_manager_key: str
+- train_data_sample_keys: List[str]
+- in_models_keys: Optional[List[str]]
+- tag: Optional[str]
+- compute_plan_id: Optional[str]
+- rank: Optional[int]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## AggregatetupleSpec
+Specification for creating an aggregate tuple
+```python
+- algo_key: str
+- worker: str
+- in_models_keys: List[str]
+- tag: Optional[str]
+- compute_plan_id: Optional[str]
+- rank: Optional[int]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## CompositeTraintupleSpec
+Specification for creating a composite traintuple
+```python
+- algo_key: str
+- data_manager_key: str
+- train_data_sample_keys: List[str]
+- in_head_model_key: Optional[str]
+- in_trunk_model_key: Optional[str]
+- tag: Optional[str]
+- compute_plan_id: Optional[str]
+- out_trunk_model_permissions: PrivatePermissions
+- rank: Optional[int]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## CompositeAlgoSpec
+Specification for creating a composite algo
+```python
+- name: str
+- description: Path
+- file: Path
+- permissions: Permissions
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## AggregateAlgoSpec
+Specification for creating an aggregate algo
+```python
+- name: str
+- description: Path
+- file: Path
+- permissions: Permissions
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## ComputePlanSpec
+Specification for creating a compute plan
+```python
+- traintuples: Optional[List[ComputePlanTraintupleSpec]]
+- composite_traintuples: Optional[List[ComputePlanCompositeTraintupleSpec]]
+- aggregatetuples: Optional[List[ComputePlanAggregatetupleSpec]]
+- testtuples: Optional[List[ComputePlanTesttupleSpec]]
+- tag: Optional[str]
+- clean_models: Optional[bool]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## UpdateComputePlanSpec
+Specification for updating a compute plan
+```python
+- traintuples: Optional[List[ComputePlanTraintupleSpec]]
+- composite_traintuples: Optional[List[ComputePlanCompositeTraintupleSpec]]
+- aggregatetuples: Optional[List[ComputePlanAggregatetupleSpec]]
+- testtuples: Optional[List[ComputePlanTesttupleSpec]]
+
+```
+
+## ComputePlanTesttupleSpec
+Specification of a testtuple inside a compute
+plan specification
+```python
+- objective_key: str
+- traintuple_id: str
+- tag: Optional[str]
+- data_manager_key: Optional[str]
+- test_data_sample_keys: Optional[List[str]]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## ComputePlanAggregatetupleSpec
+Specification of an aggregate tuple inside a compute
+plan specification
+```python
+- aggregatetuple_id: str
+- algo_key: str
+- worker: str
+- in_models_ids: Optional[List[str]]
+- tag: Optional[str]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## ComputePlanCompositeTraintupleSpec
+Specification of a composite traintuple inside a compute
+plan specification
+```python
+- composite_traintuple_id: str
+- algo_key: str
+- data_manager_key: str
+- train_data_sample_keys: List[str]
+- in_head_model_id: Optional[str]
+- in_trunk_model_id: Optional[str]
+- tag: Optional[str]
+- out_trunk_model_permissions: Permissions
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## ComputePlanTraintupleSpec
+Specification of a traintuple inside a compute
+plan specification
+```python
+- algo_key: str
+- data_manager_key: str
+- train_data_sample_keys: List[str]
+- traintuple_id: str
+- in_models_ids: Optional[List[str]]
+- tag: Optional[str]
+- metadata: Optional[Mapping[str, str]]
+
+```
+
+## Permissions
+Specification for permissions. If public is False,
+give the list of authorized ids.
+```python
+- public: bool
+- authorized_ids: List[str]
+
+```
+
+## PrivatePermissions
+Specification for private permissions. Only the nodes whose
+ids are in authorized_ids can access the asset.
+```python
+- authorized_ids: List[str]
+
+```
+

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -30,7 +30,6 @@ the 'paths' field.
 - paths: Optional[List[Path]]
 - test_only: bool
 - data_manager_keys: List[str]
-
 ```
 
 ## DatasetSpec
@@ -43,7 +42,6 @@ Specification for creating a dataset
 - permissions: Permissions
 - objective_key: Optional[str]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## ObjectiveSpec
@@ -57,7 +55,6 @@ Specification for creating an objective
 - test_data_manager_key: Optional[str]
 - permissions: Permissions
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## TesttupleSpec
@@ -69,7 +66,6 @@ Specification for creating a testtuple
 - data_manager_key: Optional[str]
 - test_data_sample_keys: Optional[List[str]]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## TraintupleSpec
@@ -83,7 +79,6 @@ Specification for creating a traintuple
 - compute_plan_id: Optional[str]
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## AggregatetupleSpec
@@ -96,7 +91,6 @@ Specification for creating an aggregate tuple
 - compute_plan_id: Optional[str]
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## CompositeTraintupleSpec
@@ -112,7 +106,6 @@ Specification for creating a composite traintuple
 - out_trunk_model_permissions: PrivatePermissions
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## CompositeAlgoSpec
@@ -123,7 +116,6 @@ Specification for creating a composite algo
 - file: Path
 - permissions: Permissions
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## AggregateAlgoSpec
@@ -134,7 +126,6 @@ Specification for creating an aggregate algo
 - file: Path
 - permissions: Permissions
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## ComputePlanSpec
@@ -147,7 +138,6 @@ Specification for creating a compute plan
 - tag: Optional[str]
 - clean_models: Optional[bool]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## UpdateComputePlanSpec
@@ -157,7 +147,6 @@ Specification for updating a compute plan
 - composite_traintuples: Optional[List[ComputePlanCompositeTraintupleSpec]]
 - aggregatetuples: Optional[List[ComputePlanAggregatetupleSpec]]
 - testtuples: Optional[List[ComputePlanTesttupleSpec]]
-
 ```
 
 ## ComputePlanTesttupleSpec
@@ -170,7 +159,6 @@ plan specification
 - data_manager_key: Optional[str]
 - test_data_sample_keys: Optional[List[str]]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## ComputePlanAggregatetupleSpec
@@ -183,7 +171,6 @@ plan specification
 - in_models_ids: Optional[List[str]]
 - tag: Optional[str]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## ComputePlanCompositeTraintupleSpec
@@ -199,7 +186,6 @@ plan specification
 - tag: Optional[str]
 - out_trunk_model_permissions: Permissions
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## ComputePlanTraintupleSpec
@@ -213,7 +199,6 @@ plan specification
 - in_models_ids: Optional[List[str]]
 - tag: Optional[str]
 - metadata: Optional[Mapping[str, str]]
-
 ```
 
 ## Permissions
@@ -222,7 +207,6 @@ give the list of authorized ids.
 ```python
 - public: bool
 - authorized_ids: List[str]
-
 ```
 
 ## PrivatePermissions
@@ -230,6 +214,5 @@ Specification for private permissions. Only the nodes whose
 ids are in authorized_ids can access the asset.
 ```python
 - authorized_ids: List[str]
-
 ```
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -248,9 +248,9 @@ def _format_server_errors(fn, errors):
     else:
         lines.append(errors)
 
-    lines = [f"\n- {line}" for line in lines]
     pluralized_error = 'errors' if len(lines) > 1 else 'error'
-    return f"Could not {action}, the server returned the following {pluralized_error}:" + lines
+    return f"Could not {action}, the server returned the following \
+        {pluralized_error}:\n- " + '\n- '.join(lines)
 
 
 def error_printer(fn):
@@ -990,7 +990,8 @@ def list_(ctx, asset_name, filters, filters_logical_clause, advanced_filters):
         filters = advanced_filters
     res = method(filters)
     printer = printers.get_asset_printer(asset_name, ctx.obj.output_format)
-    printer.print(res, is_list=True)
+    dict_res = [result.dict(exclude_none=False, by_alias=True) for result in res]
+    printer.print(dict_res, is_list=True)
 
 
 @cli.command()

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -14,6 +14,7 @@
 
 import json
 import math
+import pydantic
 
 import yaml
 
@@ -178,6 +179,8 @@ class BasePrinter:
         return length
 
     def print_details(self, item, fields, expand):
+        if isinstance(item, pydantic.BaseModel):
+            item = item.dict(exclude_none=False, by_alias=True)
         field_length = self._get_field_name_length(fields)
         for field in fields:
             field.print_details(item, field_length, expand)
@@ -223,6 +226,8 @@ class AssetPrinter(BasePrinter):
         self.print_description_message(item, profile)
 
     def print(self, data, profile=None, expand=False, is_list=False):
+        if isinstance(data, pydantic.BaseModel):
+            data = data.dict(exclude_none=False, by_alias=True)
         if is_list:
             self.print_table(data, self._get_list_fields())
         else:

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -17,10 +17,9 @@ import os
 import pathlib
 import shutil
 
-from substra.sdk import schemas, fs
+from substra.sdk import schemas, fs, models
 from substra.runner import METRICS_FAKE_Y, METRICS_NO_FAKE_Y, DOCKER_METRICS_TAG
 from substra.sdk.backends.local import dal
-from substra.sdk.backends.local import models
 from substra.sdk.backends.local.compute import spawner
 
 _CONTAINER_MODEL_PATH = "/sandbox/model"

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -15,8 +15,7 @@
 import collections
 import logging
 
-from substra.sdk import exceptions
-from substra.sdk.backends.local import models
+from substra.sdk import exceptions, models
 
 logger = logging.getLogger(__name__)
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -17,12 +17,12 @@ import logging
 import os
 import pathlib
 import time
-import typing
+from typing import Union, Optional, List
 
 from substra.sdk import exceptions
 from substra.sdk import config as cfg
 from substra.sdk import backends
-from substra.sdk import schemas
+from substra.sdk import schemas, models
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +82,8 @@ class Client(object):
 
     def __init__(
         self,
-        url: typing.Optional[str] = None,
-        token: typing.Optional[str] = None,
+        url: Optional[str] = None,
+        token: Optional[str] = None,
         retry_timeout: int = DEFAULT_RETRY_TIMEOUT,
         insecure: bool = False,
         debug: bool = False,
@@ -138,9 +138,9 @@ class Client(object):
     def from_config_file(
         cls,
         profile_name: str = cfg.DEFAULT_PROFILE_NAME,
-        config_path: typing.Union[str, pathlib.Path] = cfg.DEFAULT_PATH,
-        tokens_path: typing.Union[str, pathlib.Path] = cfg.DEFAULT_TOKENS_PATH,
-        token: typing.Optional[str] = None,
+        config_path: Union[str, pathlib.Path] = cfg.DEFAULT_PATH,
+        tokens_path: Union[str, pathlib.Path] = cfg.DEFAULT_TOKENS_PATH,
+        token: Optional[str] = None,
         retry_timeout: int = DEFAULT_RETRY_TIMEOUT,
         debug: bool = False
     ):
@@ -151,11 +151,11 @@ class Client(object):
             profile_name (str, optional): Name of the profile to load.
                 Defaults to 'default'.
 
-            config_path (typing.Union[str, pathlib.Path], optional): Path to the
+            config_path (Union[str, pathlib.Path], optional): Path to the
                 configuration file.
                 Defaults to '~/.substra'.
 
-            tokens_path (typing.Union[str, pathlib.Path], optional): Path to the tokens file.
+            tokens_path (Union[str, pathlib.Path], optional): Path to the tokens file.
                 Defaults to '~/.substra-tokens'.
 
             token (str, optional): Token to use for authentication (will be used
@@ -189,35 +189,37 @@ class Client(object):
         )
 
     @logit
-    def add_data_sample(self, data, local=True, exist_ok=False):
-        """Create new data sample asset.
-
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "path": str,
-            "data_manager_keys": list[str],
-            "test_only": bool,
-        }
-```
-        The `path` in the data dictionary must point to a directory representing the
-        data sample content. Note that the directory can contain multiple files, all the
-        directory content will be added to the platform.
-
-        If `local` is true, `path` must refer to a directory located on the local
-        filesystem. The file content will be transferred to the server through an
-        HTTP query, so this mode should be used for relatively small files (<10mo).
-
-        If `local` is false, `path` must refer to a directory located on the server
-        filesystem. This directory must be accessible (readable) by the server.  This
-        mode is well suited for all kind of file sizes.
+    def add_data_sample(
+        self,
+        data: Union[dict, schemas.DataSampleSpec],
+        local: bool = True,
+        exist_ok: bool = False
+    ) -> str:
+        """Create a new data sample asset and return its key.
 
         If a data sample with the same content already exists, an `AlreadyExists` exception will be
         raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
+
+            data (Union[dict, schemas.DataSampleSpec]): data sample to add. If it is a dict,
+            it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+
+            local (bool, optional):
+                If `local` is true, `path` must refer to a directory located on the local
+                filesystem. The file content will be transferred to the server through an
+                HTTP query, so this mode should be used for relatively small files (<10mo).
+
+                If `local` is false, `path` must refer to a directory located on the server
+                filesystem. This directory must be accessible (readable) by the server.  This
+                mode is well suited for all kind of file sizes. Defaults to True.
+
+            exist_ok (bool, optional):
+                If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
+                existing asset key will be returned. Defaults to False.
+
+        Returns:
+            str: key of the data sample
         """
         spec = self._get_spec(schemas.DataSampleSpec, data)
         if spec.paths:
@@ -234,31 +236,34 @@ class Client(object):
         )
 
     @logit
-    def add_data_samples(self, data, local=True):
-        """Create many data sample assets.
+    def add_data_samples(
+        self,
+        data: Union[dict, schemas.DataSampleSpec],
+        local: bool = True,
+    ) -> List[str]:
+        """Create many data sample assets and return  a list of keys.
 
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "paths": list[str],
-            "data_manager_keys": list[str],
-            "test_only": bool,
-        }
-```
         Create multiple data samples through a single HTTP request.
-
-        The `paths` in the data dictionary must be a list of paths where each path
-        points to a directory representing one data sample.
-
-        For the `local` argument, please refer to the method `Client.add_data_sample`.
-
         This method is well suited for adding multiple small files only. For adding a
         large amount of data it is recommended to add them one by one. It allows a
         better control in case of failures.
 
         If data samples with the same content as any of the paths already exists, an `AlreadyExists`
         exception will be raised.
+
+        Args:
+
+            data (Union[dict, schemas.DataSampleSpec]): data samples to add. If it is a dict,
+                it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+
+                The `paths` in the data dictionary must be a list of paths where each path
+                points to a directory representing one data sample.
+
+            local (bool, optional):  Please refer to the method `Client.add_data_sample`.
+                Defaults to True.
+
+        Returns:
+            List[str]: List of the data sample keys
         """
         spec = self._get_spec(schemas.DataSampleSpec, data)
         if spec.path:
@@ -275,232 +280,190 @@ class Client(object):
         )
 
     @logit
-    def add_dataset(self, data, exist_ok=False):
-        """Create new dataset asset.
-
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "name": str,
-            "description": str,
-            "type": str,
-            "data_opener": str,
-            "objective_key": str,
-            "permissions": {
-                "public": bool,
-                "authorized_ids": list[str],
-            },
-            "metadata": dict
-        }
-```
+    def add_dataset(self, data: Union[dict, schemas.DatasetSpec], exist_ok: bool = False):
+        """Create new dataset asset and return its key.
 
         If a dataset with the same opener already exists, an `AlreadyExists` exception will be
         raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
+                keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+                will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+        Returns:
+            str: Key of the dataset
         """
         spec = self._get_spec(schemas.DatasetSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_objective(self, data, exist_ok=False):
+    def add_objective(
+        self,
+        data: Union[dict, schemas.ObjectiveSpec],
+        exist_ok: bool = False,
+    ) -> str:
         """Create new objective asset.
-
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "name": str,
-            "description": str,
-            "metrics_name": str,
-            "metrics": str,
-            "test_data_manager_key": str,
-            "test_data_sample_keys": list[str],
-            "permissions": {
-                "public": bool,
-                "authorized_ids": list[str],
-            },
-            "metadata": dict
-        }
-```
 
         If an objective with the same description already exists, an `AlreadyExists` exception will
         be raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.ObjectiveSpec]): If it is a dict, it must have the same keys
+                as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+                will be ignored and the existing asset key will be returned. Defaults to False.
+
+        Returns:
+            str: Key of the objective
         """
         spec = self._get_spec(schemas.ObjectiveSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_algo(self, data, exist_ok=False):
+    def add_algo(self, data: Union[dict, schemas.AlgoSpec], exist_ok: bool = False) -> str:
         """Create new algo asset.
-
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "name": str,
-            "description": str,
-            "file": str,
-            "permissions": {
-                "public": bool,
-                "authorized_ids": list[str],
-            },
-            "metadata": dict
-        }
-```
 
         If an algo with the same archive file already exists, an `AlreadyExists` exception will be
         raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
+                as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
+                ignored and the existing asset key will be returned. Defaults to False.
+
+        Returns:
+            str: Key of the algo
         """
         spec = self._get_spec(schemas.AlgoSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_aggregate_algo(self, data, exist_ok=False):
+    def add_aggregate_algo(
+        self,
+        data: Union[dict, schemas.AggregateAlgoSpec],
+        exist_ok: bool = False,
+    ) -> str:
         """Create new aggregate algo asset.
-        `data` is a dict object with the following schema:
-```
-        {
-            "name": str,
-            "description": str,
-            "file": str,
-            "permissions": {
-                "public": bool,
-                "authorized_ids": list[str],
-            },
-            "metadata": dict
-        }
-```
+
         If an aggregate algo with the same archive file already exists, an `AlreadyExists`
         exception will be raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
+                it must have the same keys as specified in
+                [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.AggregateAlgoSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_composite_algo(self, data, exist_ok=False):
+    def add_composite_algo(
+        self,
+        data: Union[dict, schemas.CompositeAlgoSpec],
+        exist_ok: bool = False
+    ) -> str:
         """Create new composite algo asset.
-        `data` is a dict object with the following schema:
-```
-        {
-            "name": str,
-            "description": str,
-            "file": str,
-            "permissions": {
-                "public": bool,
-                "authorized_ids": list[str],
-            },
-            "metadata": dict
-        }
-```
-        If a composite algo with the same archive file already exists, an `AlreadyExists` exception
-        will be raised.
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        If a composite algo with the same archive file already exists, an `AlreadyExists`
+        exception will be raised.
 
-        This returns the key of the created asset.
+        Args:
+
+            data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
+                keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.CompositeAlgoSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_traintuple(self, data, exist_ok=False):
+    def add_traintuple(
+        self,
+        data: Union[dict, schemas.TraintupleSpec],
+        exist_ok: bool = False
+    ) -> str:
         """Create new traintuple asset.
 
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "algo_key": str,
-            "data_manager_key": str,
-            "train_data_sample_keys": list[str],
-            "in_models_keys": list[str],
-            "tag": str,
-            "metadata": dict,
-            "rank": int,
-            "compute_plan_id": str,
-        }
-```
         An `AlreadyExists` exception will be raised if a traintuple already exists that:
         * has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
         * and was created through the same node you are using
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
+                keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.TraintupleSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_aggregatetuple(self, data, exist_ok=False):
-        """Create new aggregatetuple asset.
-        `data` is a dict object with the following schema:
-```
-        {
-            "algo_key": str,
-            "in_models_keys": list[str],
-            "tag": str,
-            "metadata": dict,
-            "compute_plan_id": str,
-            "rank": int,
-            "worker": str,
-        }
-```
+    def add_aggregatetuple(
+        self,
+        data: Union[dict, schemas.AggregatetupleSpec],
+        exist_ok: bool = False
+    ) -> str:
+        """Create a new aggregate tuple asset.
+
         An `AlreadyExists` exception will be raised if an aggregatetuple already exists that:
         * has the same `algo_key` and `in_models_keys`
         * and was created through the same node you are using
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
+                keys as specified in
+                [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.AggregatetupleSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_composite_traintuple(self, data, exist_ok=False):
+    def add_composite_traintuple(
+        self,
+        data: Union[dict, schemas.CompositeTraintupleSpec],
+        exist_ok: bool = False
+    ) -> str:
         """Create new composite traintuple asset.
-        `data` is a dict object with the following schema:
-```
-        {
-            "algo_key": str,
-            "data_manager_key": str,
-            "in_head_model_key": str,
-            "in_trunk_model_key": str,
-            "out_trunk_model_permissions": {
-                "authorized_ids": list[str],
-            },
-            "tag": str,
-            "metadata": dict,
-            "rank": int,
-            "compute_plan_id": str,
-        }
-```
 
-        As specified in the data dict structure, output trunk models cannot be made
+        As specified in the data structure, output trunk models cannot be made
         public.
 
         An `AlreadyExists` exception will be raised if a traintuple already exists that:
@@ -508,40 +471,46 @@ class Client(object):
           `in_head_models_key` and `in_trunk_model_key`
         * and was created through the same node you are using
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
+                same keys as specified in
+                [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.CompositeTraintupleSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
 
     @logit
-    def add_testtuple(self, data, exist_ok=False):
+    def add_testtuple(
+        self,
+        data: Union[dict, schemas.TesttupleSpec],
+        exist_ok: bool = False
+    ) -> str:
         """Create new testtuple asset.
-
-        `data` is a dict object with the following schema:
-
-```
-        {
-            "objective_key": str,
-            "data_manager_key": str,
-            "traintuple_key": str,
-            "test_data_sample_keys": list[str],
-            "tag": str,
-            "metadata": dict
-        }
-```
 
         An `AlreadyExists` exception will be raised if a testtuple already exists that:
         * has the same `traintuple_key`, `objective_key`, `data_manager_key` and
           `test_data_sample_keys`
         * and was created through the same node you are using
 
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned.
+        Args:
 
-        This returns the key of the created asset.
+            data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same
+                keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
+
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
+                exceptions will be ignored and the existing asset key will be returned.
+                Defaults to False.
+
+         Returns:
+            str: Key of the asset
         """
         spec = self._get_spec(schemas.TesttupleSpec, data)
         return self._backend.add(spec, exist_ok=exist_ok)
@@ -549,65 +518,28 @@ class Client(object):
     @logit
     def add_compute_plan(
         self,
-        data,
+        data: Union[dict, schemas.ComputePlanSpec],
         auto_batching: bool = True,
-        batch_size: int = DEFAULT_BATCH_SIZE
-    ):
-        """Create compute plan.
-
-        Data is a dict object with the following schema:
-```
-        {
-            "traintuples": list[{
-                "traintuple_id": str,
-                "algo_key": str,
-                "data_manager_key": str,
-                "train_data_sample_keys": list[str],
-                "in_models_ids": list[str],
-                "tag": str,
-                "metadata": dict,
-            }],
-            "composite_traintuples": list[{
-                "composite_traintuple_id": str,
-                "algo_key": str,
-                "data_manager_key": str,
-                "train_data_sample_keys": list[str],
-                "in_head_model_id": str,
-                "in_trunk_model_id": str,
-                "out_trunk_model_permissions": {
-                    "authorized_ids": list[str],
-                },
-                "tag": str,
-                "metadata": dict,
-            }]
-            "aggregatetuples": list[{
-                "aggregatetuple_id": str,
-                "algo_key": str,
-                "worker": str,
-                "in_models_ids": list[str],
-                "tag": str,
-                "metadata": dict,
-            }],
-            "testtuples": list[{
-                "objective_key": str,
-                "data_manager_key": str,
-                "test_data_sample_keys": list[str],
-                "traintuple_id": str,
-                "tag": str,
-                "metadata": dict,
-            }],
-            "clean_models": bool,
-            "tag": str,
-            "metadata": dict
-        }
-```
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> models.ComputePlan:
+        """Create new compute plan asset.
 
         As specified in the data dict structure, output trunk models of composite
         traintuples cannot be made public.
-        Set 'auto_batching' to False to upload all the tuples of the
-        compute plan at once.
-        If 'auto_batching' is True, change `batch_size` to define the number of
-        tuples uploaded in each batch (default 20).
+
+        Args:
+
+            data (Union[dict, schemas.ComputePlanSpec]): If it is a dict, it must have the same
+                keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
+
+            auto_batching (bool, optional): Set 'auto_batching' to False to upload all the tuples of
+                the compute plan at once. Defaults to True.
+
+            batch_size (int, optional): If 'auto_batching' is True, change `batch_size` to define
+                the number oftuples uploaded in each batch (default 20).
+
+        Returns:
+            models.ComputePlan: Created compute plan
         """
         spec = self._get_spec(schemas.ComputePlanSpec, data)
         spec_options = {
@@ -617,197 +549,173 @@ class Client(object):
         return self._backend.add(spec, exist_ok=False, spec_options=spec_options)
 
     @logit
-    def get_algo(self, key):
+    def get_algo(self, key: str) -> models.Algo:
         """Get algo by key."""
         return self._backend.get(schemas.Type.Algo, key)
 
     @logit
-    def get_compute_plan(self, key):
+    def get_compute_plan(self, key: str) -> models.Algo:
         """Get compute plan by key."""
         return self._backend.get(schemas.Type.ComputePlan, key)
 
     @logit
-    def get_aggregate_algo(self, key):
+    def get_aggregate_algo(self, key: str) -> models.Algo:
         """Get aggregate algo by key."""
         return self._backend.get(schemas.Type.AggregateAlgo, key)
 
     @logit
-    def get_composite_algo(self, key):
+    def get_composite_algo(self, key: str) -> models.Algo:
         """Get composite algo by key."""
         return self._backend.get(schemas.Type.CompositeAlgo, key)
 
     @logit
-    def get_dataset(self, key):
+    def get_dataset(self, key: str) -> models.Algo:
         """Get dataset by key."""
         return self._backend.get(schemas.Type.Dataset, key)
 
     @logit
-    def get_objective(self, key):
+    def get_objective(self, key: str) -> models.Algo:
         """Get objective by key."""
         return self._backend.get(schemas.Type.Objective, key)
 
     @logit
-    def get_testtuple(self, key):
+    def get_testtuple(self, key: str) -> models.Algo:
         """Get testtuple by key."""
         return self._backend.get(schemas.Type.Testtuple, key)
 
     @logit
-    def get_traintuple(self, key):
+    def get_traintuple(self, key: str) -> models.Algo:
         """Get traintuple by key."""
         return self._backend.get(schemas.Type.Traintuple, key)
 
     @logit
-    def get_aggregatetuple(self, key):
+    def get_aggregatetuple(self, key: str) -> models.Algo:
         """Get aggregatetuple by key."""
         return self._backend.get(schemas.Type.Aggregatetuple, key)
 
     @logit
-    def get_composite_traintuple(self, key):
+    def get_composite_traintuple(self, key: str) -> models.Algo:
         """Get composite traintuple by key."""
         return self._backend.get(schemas.Type.CompositeTraintuple, key)
 
     @logit
-    def list_algo(self, filters=None):
+    def list_algo(self, filters=None) -> List[models.Algo]:
         """List algos."""
         return self._backend.list(schemas.Type.Algo, filters)
 
     @logit
-    def list_compute_plan(self, filters=None):
+    def list_compute_plan(self, filters=None) -> List[models.Algo]:
         """List compute plans."""
         return self._backend.list(schemas.Type.ComputePlan, filters)
 
     @logit
-    def list_aggregate_algo(self, filters=None):
+    def list_aggregate_algo(self, filters=None) -> List[models.Algo]:
         """List aggregate algos."""
         return self._backend.list(schemas.Type.AggregateAlgo, filters)
 
     @logit
-    def list_composite_algo(self, filters=None):
+    def list_composite_algo(self, filters=None) -> List[models.Algo]:
         """List composite algos."""
         return self._backend.list(schemas.Type.CompositeAlgo, filters)
 
     @logit
-    def list_data_sample(self, filters=None):
+    def list_data_sample(self, filters=None) -> List[models.Algo]:
         """List data samples."""
         return self._backend.list(schemas.Type.DataSample, filters)
 
     @logit
-    def list_dataset(self, filters=None):
+    def list_dataset(self, filters=None) -> List[models.Algo]:
         """List datasets."""
         return self._backend.list(schemas.Type.Dataset, filters)
 
     @logit
-    def list_objective(self, filters=None):
+    def list_objective(self, filters=None) -> List[models.Algo]:
         """List objectives."""
         return self._backend.list(schemas.Type.Objective, filters)
 
     @logit
-    def list_testtuple(self, filters=None):
+    def list_testtuple(self, filters=None) -> List[models.Algo]:
         """List testtuples."""
         return self._backend.list(schemas.Type.Testtuple, filters)
 
     @logit
-    def list_traintuple(self, filters=None):
+    def list_traintuple(self, filters=None) -> List[models.Algo]:
         """List traintuples."""
         return self._backend.list(schemas.Type.Traintuple, filters)
 
     @logit
-    def list_aggregatetuple(self, filters=None):
+    def list_aggregatetuple(self, filters=None) -> List[models.Algo]:
         """List aggregatetuples."""
         return self._backend.list(schemas.Type.Aggregatetuple, filters)
 
     @logit
-    def list_composite_traintuple(self, filters=None):
+    def list_composite_traintuple(self, filters=None) -> List[models.Algo]:
         """List composite traintuples."""
         return self._backend.list(schemas.Type.CompositeTraintuple, filters)
 
     @logit
-    def list_node(self, *args, **kwargs):
+    def list_node(self, *args, **kwargs) -> List[models.Algo]:
         """List nodes."""
         return self._backend.list(schemas.Type.Node)
 
     @logit
     def update_compute_plan(
         self,
-        compute_plan_id,
-        data,
+        compute_plan_id: str,
+        data: Union[dict, schemas.UpdateComputePlanSpec],
         auto_batching: bool = True,
         batch_size: int = DEFAULT_BATCH_SIZE
-    ):
+    ) -> models.ComputePlan:
         """Update compute plan.
-
-        Data is a dict object with the following schema:
-```
-        {
-            "traintuples": list[{
-                "traintuple_id": str,
-                "algo_key": str,
-                "data_manager_key": str,
-                "train_data_sample_keys": list[str],
-                "in_models_ids": list[str],
-                "tag": str,
-                "metadata": dict,
-            }],
-            "composite_traintuples": list[{
-                "composite_traintuple_id": str,
-                "algo_key": str,
-                "data_manager_key": str,
-                "train_data_sample_keys": list[str],
-                "in_head_model_id": str,
-                "in_trunk_model_id": str,
-                "out_trunk_model_permissions": {
-                    "authorized_ids": list[str],
-                },
-                "tag": str,
-                "metadata": dict,
-            }]
-            "aggregatetuples": list[{
-                "aggregatetuple_id": str,
-                "algo_key": str,
-                "worker": str,
-                "in_models_ids": list[str],
-                "tag": str,
-                "metadata": dict,
-            }],
-            "testtuples": list[{
-                "objective_key": str,
-                "data_manager_key": str,
-                "test_data_sample_keys": list[str],
-                "traintuple_id": str,
-                "tag": str,
-                "metadata": dict,
-            }]
-        }
-```
 
         As specified in the data dict structure, output trunk models of composite
         traintuples cannot be made public.
-        Set 'auto_batching' to False to upload all the tuples of the
-        compute plan at once.
-        If 'auto_batching' is True, change `batch_size` to define the number of
-        tuples uploaded in each batch (default 20).
+
+        Args:
+
+            compute_plan_id (str): Id of the compute plan
+
+            data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
+                it must have the same keys as specified in
+                [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
+
+            auto_batching (bool, optional): Set 'auto_batching' to False to upload all
+                the tuples of the compute plan at once. Defaults to True.
+
+            batch_size (int, optional): If 'auto_batching' is True, change `batch_size`
+                to define the number of tuples uploaded in each batch (default 20).
+
+        Returns:
+            models.ComputePlan: updated compute plan
         """
         spec = schemas.UpdateComputePlanSpec(**data)
         spec_options = {
             "auto_batching": auto_batching,
             "batch_size": batch_size,
         }
-        return self._backend.update_compute_plan(compute_plan_id, spec, spec_options=spec_options)
+        return self._backend.update_compute_plan(
+            compute_plan_id,
+            spec,
+            spec_options=spec_options
+        )
 
     @logit
-    def link_dataset_with_objective(self, dataset_key, objective_key):
+    def link_dataset_with_objective(self, dataset_key: str, objective_key: str) -> str:
         """Link dataset with objective."""
         return self._backend.link_dataset_with_objective(dataset_key, objective_key)
 
     @logit
-    def link_dataset_with_data_samples(self, dataset_key, data_sample_keys):
+    def link_dataset_with_data_samples(
+        self, dataset_key: str,
+        data_sample_keys: str,
+    ) -> List[str]:
         """Link dataset with data samples."""
         return self._backend.link_dataset_with_data_samples(
             dataset_key, data_sample_keys
         )
 
     @logit
-    def download_dataset(self, key, destination_folder):
+    def download_dataset(self, key: str, destination_folder: str) -> None:
         """Download data manager resource.
 
         Download opener script in destination folder.
@@ -820,7 +728,7 @@ class Client(object):
         )
 
     @logit
-    def download_algo(self, key, destination_folder):
+    def download_algo(self, key: str, destination_folder: str) -> None:
         """Download algo resource.
 
         Download algo package in destination folder.
@@ -833,7 +741,7 @@ class Client(object):
         )
 
     @logit
-    def download_aggregate_algo(self, key, destination_folder):
+    def download_aggregate_algo(self, key: str, destination_folder: str) -> None:
         """Download aggregate algo resource.
 
         Download aggregate algo package in destination folder.
@@ -846,7 +754,7 @@ class Client(object):
         )
 
     @logit
-    def download_composite_algo(self, key, destination_folder):
+    def download_composite_algo(self, key: str, destination_folder: str) -> None:
         """Download composite algo resource.
 
         Download composite algo package in destination folder.
@@ -859,7 +767,7 @@ class Client(object):
         )
 
     @logit
-    def download_objective(self, key, destination_folder):
+    def download_objective(self, key: str, destination_folder: str) -> None:
         """Download objective resource.
 
         Download metrics script in destination folder.
@@ -872,36 +780,36 @@ class Client(object):
         )
 
     @logit
-    def describe_algo(self, key):
+    def describe_algo(self, key: str) -> str:
         """Get algo description."""
         return self._backend.describe(schemas.Type.Algo, key)
 
     @logit
-    def describe_aggregate_algo(self, key):
+    def describe_aggregate_algo(self, key: str) -> str:
         """Get aggregate algo description."""
         return self._backend.describe(schemas.Type.AggregateAlgo, key)
 
     @logit
-    def describe_composite_algo(self, key):
+    def describe_composite_algo(self, key: str) -> str:
         """Get composite algo description."""
         return self._backend.describe(schemas.Type.CompositeAlgo, key)
 
     @logit
-    def describe_dataset(self, key):
+    def describe_dataset(self, key: str) -> str:
         """Get dataset description."""
         return self._backend.describe(schemas.Type.Dataset, key)
 
     @logit
-    def describe_objective(self, key):
+    def describe_objective(self, key: str) -> str:
         """Get objective description."""
         return self._backend.describe(schemas.Type.Objective, key)
 
     @logit
-    def leaderboard(self, objective_key, sort='desc'):
+    def leaderboard(self, objective_key: str, sort: str = 'desc') -> str:
         """Get objective leaderboard"""
         return self._backend.leaderboard(objective_key, sort='desc')
 
     @logit
-    def cancel_compute_plan(self, compute_plan_id):
+    def cancel_compute_plan(self, compute_plan_id: str) -> models.ComputePlan:
         """Cancel execution of compute plan."""
         return self._backend.cancel_compute_plan(compute_plan_id)

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -550,112 +550,134 @@ class Client(object):
 
     @logit
     def get_algo(self, key: str) -> models.Algo:
-        """Get algo by key."""
+        """Get algo by key, the returned object is described
+        in the [models.Algo](sdk_models.md#Algo) model"""
         return self._backend.get(schemas.Type.Algo, key)
 
     @logit
     def get_compute_plan(self, key: str) -> models.ComputePlan:
-        """Get compute plan by key."""
+        """Get compute plan by key, the returned object is described
+        in the [models.ComputePlan](sdk_models.md#ComputePlan) model"""
         return self._backend.get(schemas.Type.ComputePlan, key)
 
     @logit
     def get_aggregate_algo(self, key: str) -> models.AggregateAlgo:
-        """Get aggregate algo by key."""
+        """Get aggregate algo by key, the returned object is described
+        in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model"""
         return self._backend.get(schemas.Type.AggregateAlgo, key)
 
     @logit
     def get_composite_algo(self, key: str) -> models.CompositeAlgo:
-        """Get composite algo by key."""
+        """Get composite algo by key, the returned object is described
+        in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model"""
         return self._backend.get(schemas.Type.CompositeAlgo, key)
 
     @logit
     def get_dataset(self, key: str) -> models.Dataset:
-        """Get dataset by key."""
+        """Get dataset by key, the returned object is described
+        in the [models.Dataset](sdk_models.md#Dataset) model"""
         return self._backend.get(schemas.Type.Dataset, key)
 
     @logit
     def get_objective(self, key: str) -> models.Objective:
-        """Get objective by key."""
+        """Get objective by key, the returned object is described
+        in the [models.Objective](sdk_models.md#Objective) model"""
         return self._backend.get(schemas.Type.Objective, key)
 
     @logit
     def get_testtuple(self, key: str) -> models.Testtuple:
-        """Get testtuple by key."""
+        """Get testtuple by key, the returned object is described
+        in the [models.Testtuple](sdk_models.md#Testtuple) model"""
         return self._backend.get(schemas.Type.Testtuple, key)
 
     @logit
     def get_traintuple(self, key: str) -> models.Traintuple:
-        """Get traintuple by key."""
+        """Get traintuple by key, the returned object is described
+        in the [models.Traintuple](sdk_models.md#Traintuple) model"""
         return self._backend.get(schemas.Type.Traintuple, key)
 
     @logit
     def get_aggregatetuple(self, key: str) -> models.Aggregatetuple:
-        """Get aggregatetuple by key."""
+        """Get aggregatetuple by key, the returned object is described
+        in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model"""
         return self._backend.get(schemas.Type.Aggregatetuple, key)
 
     @logit
     def get_composite_traintuple(self, key: str) -> models.CompositeTraintuple:
-        """Get composite traintuple by key."""
+        """Get composite traintuple by key, the returned object is described
+        in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model"""
         return self._backend.get(schemas.Type.CompositeTraintuple, key)
 
     @logit
     def list_algo(self, filters=None) -> List[models.Algo]:
-        """List algos."""
+        """List algos, the returned object is described
+        in the [models.Algo](sdk_models.md#Algo) model"""
         return self._backend.list(schemas.Type.Algo, filters)
 
     @logit
     def list_compute_plan(self, filters=None) -> List[models.ComputePlan]:
-        """List compute plans."""
+        """List compute plans, the returned object is described
+        in the [models.ComputePlan](sdk_models.md#ComputePlan) model"""
         return self._backend.list(schemas.Type.ComputePlan, filters)
 
     @logit
     def list_aggregate_algo(self, filters=None) -> List[models.AggregateAlgo]:
-        """List aggregate algos."""
+        """List aggregate algos, the returned object is described
+        in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model"""
         return self._backend.list(schemas.Type.AggregateAlgo, filters)
 
     @logit
     def list_composite_algo(self, filters=None) -> List[models.CompositeAlgo]:
-        """List composite algos."""
+        """List composite algos, the returned object is described
+        in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model"""
         return self._backend.list(schemas.Type.CompositeAlgo, filters)
 
     @logit
     def list_data_sample(self, filters=None) -> List[models.DataSample]:
-        """List data samples."""
+        """List data samples, the returned object is described
+        in the [models.DataSample](sdk_models.md#DataSample) model"""
         return self._backend.list(schemas.Type.DataSample, filters)
 
     @logit
     def list_dataset(self, filters=None) -> List[models.Dataset]:
-        """List datasets."""
+        """List datasets, the returned object is described
+        in the [models.Dataset](sdk_models.md#Dataset) model"""
         return self._backend.list(schemas.Type.Dataset, filters)
 
     @logit
     def list_objective(self, filters=None) -> List[models.Objective]:
-        """List objectives."""
+        """List objectives, the returned object is described
+        in the [models.Objective](sdk_models.md#Objective) model"""
         return self._backend.list(schemas.Type.Objective, filters)
 
     @logit
     def list_testtuple(self, filters=None) -> List[models.Testtuple]:
-        """List testtuples."""
+        """List testtuples, the returned object is described
+        in the [models.Testtuple](sdk_models.md#Testtuple) model"""
         return self._backend.list(schemas.Type.Testtuple, filters)
 
     @logit
     def list_traintuple(self, filters=None) -> List[models.Traintuple]:
-        """List traintuples."""
+        """List traintuples, the returned object is described
+        in the [models.Traintuple](sdk_models.md#Traintuple) model"""
         return self._backend.list(schemas.Type.Traintuple, filters)
 
     @logit
     def list_aggregatetuple(self, filters=None) -> List[models.Aggregatetuple]:
-        """List aggregatetuples."""
+        """List aggregatetuples, the returned object is described
+        in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model"""
         return self._backend.list(schemas.Type.Aggregatetuple, filters)
 
     @logit
     def list_composite_traintuple(self, filters=None) -> List[models.CompositeTraintuple]:
-        """List composite traintuples."""
+        """List composite traintuples, the returned object is described
+        in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model"""
         return self._backend.list(schemas.Type.CompositeTraintuple, filters)
 
     @logit
     def list_node(self, *args, **kwargs) -> List[models.Node]:
-        """List nodes."""
+        """List nodes, the returned object is described
+        in the [models.Node](sdk_models.md#Node) model"""
         return self._backend.list(schemas.Type.Node)
 
     @logit
@@ -686,7 +708,8 @@ class Client(object):
                 to define the number of tuples uploaded in each batch (default 20).
 
         Returns:
-            models.ComputePlan: updated compute plan
+            models.ComputePlan: updated compute plan, as described in the
+            [models.ComputePlan](sdk_models.md#ComputePlan) model
         """
         spec = schemas.UpdateComputePlanSpec(**data)
         spec_options = {
@@ -811,5 +834,6 @@ class Client(object):
 
     @logit
     def cancel_compute_plan(self, compute_plan_id: str) -> models.ComputePlan:
-        """Cancel execution of compute plan."""
+        """Cancel execution of compute plan, the returned object is described
+        in the [models.ComputePlan](sdk_models.md#ComputePlan) model"""
         return self._backend.cancel_compute_plan(compute_plan_id)

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -554,47 +554,47 @@ class Client(object):
         return self._backend.get(schemas.Type.Algo, key)
 
     @logit
-    def get_compute_plan(self, key: str) -> models.Algo:
+    def get_compute_plan(self, key: str) -> models.ComputePlan:
         """Get compute plan by key."""
         return self._backend.get(schemas.Type.ComputePlan, key)
 
     @logit
-    def get_aggregate_algo(self, key: str) -> models.Algo:
+    def get_aggregate_algo(self, key: str) -> models.AggregateAlgo:
         """Get aggregate algo by key."""
         return self._backend.get(schemas.Type.AggregateAlgo, key)
 
     @logit
-    def get_composite_algo(self, key: str) -> models.Algo:
+    def get_composite_algo(self, key: str) -> models.CompositeAlgo:
         """Get composite algo by key."""
         return self._backend.get(schemas.Type.CompositeAlgo, key)
 
     @logit
-    def get_dataset(self, key: str) -> models.Algo:
+    def get_dataset(self, key: str) -> models.Dataset:
         """Get dataset by key."""
         return self._backend.get(schemas.Type.Dataset, key)
 
     @logit
-    def get_objective(self, key: str) -> models.Algo:
+    def get_objective(self, key: str) -> models.Objective:
         """Get objective by key."""
         return self._backend.get(schemas.Type.Objective, key)
 
     @logit
-    def get_testtuple(self, key: str) -> models.Algo:
+    def get_testtuple(self, key: str) -> models.Testtuple:
         """Get testtuple by key."""
         return self._backend.get(schemas.Type.Testtuple, key)
 
     @logit
-    def get_traintuple(self, key: str) -> models.Algo:
+    def get_traintuple(self, key: str) -> models.Traintuple:
         """Get traintuple by key."""
         return self._backend.get(schemas.Type.Traintuple, key)
 
     @logit
-    def get_aggregatetuple(self, key: str) -> models.Algo:
+    def get_aggregatetuple(self, key: str) -> models.Aggregatetuple:
         """Get aggregatetuple by key."""
         return self._backend.get(schemas.Type.Aggregatetuple, key)
 
     @logit
-    def get_composite_traintuple(self, key: str) -> models.Algo:
+    def get_composite_traintuple(self, key: str) -> models.CompositeTraintuple:
         """Get composite traintuple by key."""
         return self._backend.get(schemas.Type.CompositeTraintuple, key)
 
@@ -604,57 +604,57 @@ class Client(object):
         return self._backend.list(schemas.Type.Algo, filters)
 
     @logit
-    def list_compute_plan(self, filters=None) -> List[models.Algo]:
+    def list_compute_plan(self, filters=None) -> List[models.ComputePlan]:
         """List compute plans."""
         return self._backend.list(schemas.Type.ComputePlan, filters)
 
     @logit
-    def list_aggregate_algo(self, filters=None) -> List[models.Algo]:
+    def list_aggregate_algo(self, filters=None) -> List[models.AggregateAlgo]:
         """List aggregate algos."""
         return self._backend.list(schemas.Type.AggregateAlgo, filters)
 
     @logit
-    def list_composite_algo(self, filters=None) -> List[models.Algo]:
+    def list_composite_algo(self, filters=None) -> List[models.CompositeAlgo]:
         """List composite algos."""
         return self._backend.list(schemas.Type.CompositeAlgo, filters)
 
     @logit
-    def list_data_sample(self, filters=None) -> List[models.Algo]:
+    def list_data_sample(self, filters=None) -> List[models.DataSample]:
         """List data samples."""
         return self._backend.list(schemas.Type.DataSample, filters)
 
     @logit
-    def list_dataset(self, filters=None) -> List[models.Algo]:
+    def list_dataset(self, filters=None) -> List[models.Dataset]:
         """List datasets."""
         return self._backend.list(schemas.Type.Dataset, filters)
 
     @logit
-    def list_objective(self, filters=None) -> List[models.Algo]:
+    def list_objective(self, filters=None) -> List[models.Objective]:
         """List objectives."""
         return self._backend.list(schemas.Type.Objective, filters)
 
     @logit
-    def list_testtuple(self, filters=None) -> List[models.Algo]:
+    def list_testtuple(self, filters=None) -> List[models.Testtuple]:
         """List testtuples."""
         return self._backend.list(schemas.Type.Testtuple, filters)
 
     @logit
-    def list_traintuple(self, filters=None) -> List[models.Algo]:
+    def list_traintuple(self, filters=None) -> List[models.Traintuple]:
         """List traintuples."""
         return self._backend.list(schemas.Type.Traintuple, filters)
 
     @logit
-    def list_aggregatetuple(self, filters=None) -> List[models.Algo]:
+    def list_aggregatetuple(self, filters=None) -> List[models.Aggregatetuple]:
         """List aggregatetuples."""
         return self._backend.list(schemas.Type.Aggregatetuple, filters)
 
     @logit
-    def list_composite_traintuple(self, filters=None) -> List[models.Algo]:
+    def list_composite_traintuple(self, filters=None) -> List[models.CompositeTraintuple]:
         """List composite traintuples."""
         return self._backend.list(schemas.Type.CompositeTraintuple, filters)
 
     @logit
-    def list_node(self, *args, **kwargs) -> List[models.Algo]:
+    def list_node(self, *args, **kwargs) -> List[models.Node]:
         """List nodes."""
         return self._backend.list(schemas.Type.Node)
 

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -120,12 +120,16 @@ class AlreadyExists(HTTPError):
     def from_request_exception(cls, request_exception):
         # parse response and fetch key
         r = request_exception.response.json()
-        # XXX support list of keyes; this could be the case when adding
+        # XXX support list of keys; this could be the case when adding
         #     a list of data samples through a single POST request
         if isinstance(r, list):
             key = [x['key'] for x in r]
+        elif isinstance(r, dict):
+            key = r.get('key', None)
+            if not key:
+                key = r['pkhash']
         else:
-            key = r['key']
+            key = r
 
         return cls(key, request_exception.response.status_code)
 

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -196,7 +196,7 @@ class Traintuple(_Model):
     tag: str
     compute_plan_id: str
     rank: int
-    status: Status
+    status: str
     log: str
     in_models: Optional[List[InModel]]
     out_model: Optional[OutModel]
@@ -215,7 +215,7 @@ class Aggregatetuple(_Model):
     tag: str
     compute_plan_id: str
     rank: Optional[int]
-    status: Status
+    status: str
     log: str
     in_models: List[InModel]
     out_model: Optional[OutModel]
@@ -262,7 +262,7 @@ class CompositeTraintuple(_Model):
     tag: str
     compute_plan_id: str
     rank: Optional[int]
-    status: Status
+    status: str
     log: str
     in_head_model: Optional[InHeadModel]
     in_trunk_model: Optional[InModel]
@@ -306,7 +306,7 @@ class Testtuple(_Model):
     dataset: _TesttupleDataset
     tag: Optional[str]
     log: str
-    status: Status
+    status: str
     compute_plan_id: str
     rank: int
     traintuple_type: schemas.Type
@@ -321,7 +321,7 @@ class Testtuple(_Model):
 
 class ComputePlan(_Model):
     compute_plan_id: str
-    status: Status
+    status: str
     traintuple_keys: Optional[List[str]]
     composite_traintuple_keys: Optional[List[str]]
     aggregatetuple_keys: Optional[List[str]]

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -35,6 +35,7 @@ def _to_snake_case(camel_str):
 
 
 class Status(str, enum.Enum):
+    """Status of the task"""
     doing = "doing"
     done = "done"
     failed = "failed"
@@ -44,6 +45,7 @@ class Status(str, enum.Enum):
 
 
 class Permission(schemas._PydanticConfig):
+    """Permissions of a task"""
     public: bool
     authorized_ids: List[str]
 
@@ -61,6 +63,7 @@ class _Model(schemas._PydanticConfig, abc.ABC):
 
 
 class DataSample(_Model):
+    """Data sample"""
     key: str
     owner: str
     data_manager_keys: Optional[List[str]]
@@ -73,11 +76,13 @@ class DataSample(_Model):
 
 
 class _File(schemas._PydanticConfig):
+    """File as stored in the models"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: UriPath
 
 
 class Dataset(_Model):
+    """Dataset asset"""
     key: str
     name: str
     owner: str
@@ -94,6 +99,7 @@ class Dataset(_Model):
 
 
 class _ObjectiveDataset(schemas._PydanticConfig):
+    """Dataset as stored in the Objective asset"""
     data_manager_key: str
     data_sample_keys: List[str]
     metadata: Dict[str, str]
@@ -101,6 +107,7 @@ class _ObjectiveDataset(schemas._PydanticConfig):
 
 
 class _Metric(schemas._PydanticConfig):
+    """Metric associated to a testtuple or objective"""
     name: Optional[str]
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: UriPath
@@ -148,6 +155,7 @@ class CompositeAlgo(_Algo):
 
 
 class _TraintupleDataset(schemas._PydanticConfig):
+    """Dataset as stored in a traintuple or composite traintuple"""
     opener_hash: str
     keys: List[str]
     worker: str
@@ -159,6 +167,8 @@ class _TraintupleDataset(schemas._PydanticConfig):
 
 
 class InModel(schemas._PydanticConfig):
+    """In model of a traintuple, aggregate tuple or in trunk
+    model of a composite traintuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: UriPath
     traintuple_key: Optional[str]
@@ -169,6 +179,8 @@ class InModel(schemas._PydanticConfig):
 
 
 class OutModel(schemas._PydanticConfig):
+    """Out model of a traintuple, aggregate tuple or out trunk
+    model of a composite traintuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: UriPath
 
@@ -178,6 +190,7 @@ class OutModel(schemas._PydanticConfig):
 
 
 class _TraintupleAlgo(schemas._PydanticConfig):
+    """Algo associated to a traintuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: UriPath
     name: str
@@ -226,6 +239,7 @@ class Aggregatetuple(_Model):
 
 
 class InHeadModel(schemas._PydanticConfig):
+    """In head model of a composite traintuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: Optional[UriPath]  # Defined for local assets but not remote ones
     traintuple_key: Optional[str]
@@ -236,6 +250,7 @@ class InHeadModel(schemas._PydanticConfig):
 
 
 class OutHeadModel(schemas._PydanticConfig):
+    """Out head model of a composite traintuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     storage_address: Optional[FilePath]  # Defined for local assets but not remote ones
 
@@ -245,11 +260,13 @@ class OutHeadModel(schemas._PydanticConfig):
 
 
 class OutCompositeHeadModel(schemas._PydanticConfig):
+    """Out head model of a composite traintuple with permissions"""
     permissions: Permissions
     out_model: Optional[OutHeadModel]
 
 
 class OutCompositeTrunkModel(schemas._PydanticConfig):
+    """Out trunk model of a composite traintuple with permissions"""
     permissions: Permissions
     out_model: Optional[OutModel]
 
@@ -277,6 +294,7 @@ class CompositeTraintuple(_Model):
 
 
 class _TesttupleDataset(schemas._PydanticConfig):
+    """Dataset of a testtuple"""
     opener_hash: str
     perf: float
     keys: List[str]
@@ -288,6 +306,7 @@ class _TesttupleDataset(schemas._PydanticConfig):
 
 
 class _TesttupleObjective(schemas._PydanticConfig):
+    """Objective of a testtuple"""
     hash_: str = pydantic.Field(..., alias="hash")
     metrics: _Metric
 

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -118,6 +118,7 @@ class _Metric(schemas._PydanticConfig):
 
 
 class Objective(_Model):
+    """Objective"""
     key: str
     name: str
     owner: str
@@ -143,14 +144,17 @@ class _Algo(_Model):
 
 
 class Algo(_Algo):
+    """Algo"""
     type_: ClassVar[str] = schemas.Type.Algo
 
 
 class AggregateAlgo(_Algo):
+    """AggregateAlgo"""
     type_: ClassVar[str] = schemas.Type.AggregateAlgo
 
 
 class CompositeAlgo(_Algo):
+    """CompositeAlgo"""
     type_: ClassVar[str] = schemas.Type.CompositeAlgo
 
 
@@ -201,6 +205,7 @@ class _TraintupleAlgo(schemas._PydanticConfig):
 
 
 class Traintuple(_Model):
+    """Traintuple"""
     key: str
     creator: str
     algo: _TraintupleAlgo
@@ -220,6 +225,7 @@ class Traintuple(_Model):
 
 
 class Aggregatetuple(_Model):
+    """Aggregatetuple"""
     key: str
     creator: str
     worker: str
@@ -272,6 +278,7 @@ class OutCompositeTrunkModel(schemas._PydanticConfig):
 
 
 class CompositeTraintuple(_Model):
+    """CompositeTraintuple"""
     key: str
     creator: str
     algo: _TraintupleAlgo
@@ -316,6 +323,7 @@ class _TesttupleObjective(schemas._PydanticConfig):
 
 
 class Testtuple(_Model):
+    """Testtuple"""
     key: str
     creator: str
     algo: _TraintupleAlgo
@@ -339,6 +347,7 @@ class Testtuple(_Model):
 
 
 class ComputePlan(_Model):
+    """ComputePlan"""
     compute_plan_id: str
     status: str
     traintuple_keys: Optional[List[str]]
@@ -359,6 +368,7 @@ class ComputePlan(_Model):
 
 
 class Node(schemas._PydanticConfig):
+    """Node"""
     id: str
     is_current: bool
 

--- a/substra/sdk/utils.py
+++ b/substra/sdk/utils.py
@@ -156,18 +156,19 @@ def retry_on_exception(exceptions, timeout=300):
         timeout (int): timeout in seconds
 
     Example:
-        ```python
-        from substra.sdk import exceptions, retry_on_exception
 
-        def my_function(arg1, arg2):
-            pass
+    ```python
+    from substra.sdk import exceptions, retry_on_exception
 
-        retry = retry_on_exception(
-                    exceptions=(exceptions.RequestTimeout),
-                    timeout=300,
-                )
-        retry(my_function)(arg1, arg2)
-        ```
+    def my_function(arg1, arg2):
+        pass
+
+    retry = retry_on_exception(
+                exceptions=(exceptions.RequestTimeout),
+                timeout=300,
+            )
+    retry(my_function)(arg1, arg2)
+    ```
     """
     def _retry(f):
         @functools.wraps(f)

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 OBJECTIVE = {
     "description": {
         "hash": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
@@ -35,7 +34,8 @@ OBJECTIVE = {
         "data_manager_key": "ccbaa3372bc74bce39ce3b138f558b3a7558958ef2f244576e18ed75b0cea994",
         "data_sample_keys": [
             "e11aeec290749e4c50c91305e10463eced8dbf3808971ec0c6ea0e36cb7ab3e1",
-        ]
+        ],
+        "metadata": {},
     },
     "metadata": {
         "foo": "bar"
@@ -61,7 +61,7 @@ DATASET = {
             "authorized_ids": []
         }
     },
-    "size": 100,
+    # "size": 100,
     "type": "Images",
     "train_data_sample_keys": [],
     "test_data_sample_keys": [],
@@ -129,8 +129,12 @@ COMPOSITE_ALGO = {
         "storage_address": ""
     },
     "owner": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4beade2d62a8b708fdde48fb0edea",
-    "permissions_public": False,
-    "permissions_authorized_ids": [],
+    "permissions": {
+        "process": {
+            "public": False,
+            "authorized_ids": [],
+        },
+    },
     "metadata": {
         "foo": "bar"
     }
@@ -151,18 +155,10 @@ TRAINTUPLE = {
             "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
         ],
         "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-        "perf": 0
     },
     "compute_plan_id": "",
     "in_models": None,
     "log": "[00-01-0032-d415995]",
-    "objective": {
-        "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-        "metrics": {
-            "hash": "c42dca31fbc2ebb5705643e3bb6ee666bbfd956de13dd03727f825ad8445b4d7",
-            "storage_address": ""
-        }
-    },
     "out_model": None,
     "permissions": {
         "process": {
@@ -186,25 +182,9 @@ AGGREGATETUPLE = {
         "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462f1eb813b94c3e67de29f6e4b2272ae60385f5",
-    "dataset": {
-        "worker": "e75db4df2532dc1313ebb5c2f62e1eb813b94c3e67de29f6e4b2272ae60385f5",
-        "keys": [
-            "31510dc1d8be788f7c5d28d05714f7efbfedb667762966b9adc02eadeaacebe9",
-            "03a1f878768ea8624942d46a3b438c379f2e626c2cf655023bcc3bed69d485d1"
-        ],
-        "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3afdd9dc8d40fe7d075c726ac073ca",
-        "perf": 0
-    },
     "compute_plan_id": "",
-    "in_models": None,
+    "in_models": [],
     "log": "[00-01-0032-d415995]",
-    "objective": {
-        "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048afd415e266aad38c09591ee71",
-        "metrics": {
-            "hash": "c42dca31fbc2ebb5705643e3bb6ee666bbfdf56de13dd03727f825ad8445b4d7",
-            "storage_address": ""
-        }
-    },
     "out_model": None,
     "permissions": {
         "process": {
@@ -217,7 +197,8 @@ AGGREGATETUPLE = {
     "tag": "My super tag",
     "metadata": {
         "foo": "bar"
-    }
+    },
+    "worker": ""
 }
 
 COMPOSITE_TRAINTUPLE = {
@@ -228,10 +209,11 @@ COMPOSITE_TRAINTUPLE = {
         "storage_address": ""
     },
     "in_head_model": {
-        "key": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142e",
+        "hash": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142e",
     },
     "in_trunk_model": {
-        "key": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142f",
+        "hash": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142f",
+        "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462e1eb813b94c3e67de29f6e4b2272ae60385f5",
     "dataset": {
@@ -241,27 +223,30 @@ COMPOSITE_TRAINTUPLE = {
             "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
         ],
         "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-        "perf": 0
     },
     "compute_plan_id": "",
     "log": "[00-01-0032-d415995]",
-    "objective": {
-        "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-        "metrics": {
-            "hash": "c42dca31fbc2ebb5705643e3bb6ee666bbfd956de13dd03727f825ad8445b4d7",
-            "storage_address": ""
-        }
-    },
     "out_head_model": {
-        "permissions": {},
+        "permissions": {
+            "process": {
+                "public": False,
+                "authorized_ids": []
+            }
+        },
         "out_model": {
             "hash": "8a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
         }
     },
     "out_trunk_model": {
-        "permissions": {},
+        "permissions": {
+            "process": {
+                "public": False,
+                "authorized_ids": []
+            }
+        },
         "out_model": {
             "hash": "9a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+            "storage_address": ""
         }
     },
     "rank": 0,
@@ -274,6 +259,10 @@ COMPOSITE_TRAINTUPLE = {
 
 TESTTUPLE = {
     "key": "97b53511e94cab17ea8b1c31982e0b0d8b9311e10d35f82bdafab4ea429b7414",
+    "traintuple_key": "1197bbfc4a189ea037a6835895a81bb80db37f52f82cc40d74e285b7194f4c91",
+    "traintuple_type": "traintuple",
+    "compute_plan_id": "",
+    "rank": 0,
     "algo": {
         "name": "Logistic regression",
         "hash": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
@@ -291,22 +280,11 @@ TESTTUPLE = {
         "perf": 0
     },
     "log": "Test - CPU:90.07 % - Mem:0.13 GB - GPU:0.00 % - GPU Mem:0.00 GB;",
-    "model": {
-        "traintuple_key": "593b8c8a94cf5d372f239c79ac2a4089f7ba4717cda8dc4753599a078e86493d",
-        "hash": "523882e8aaa3fd65bfd5f4bd0153ad6a21487f55c50b922bbf26015c6e975965",
-        "storage_address": "",
-    },
     "objective": {
         "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
         "metrics": {
             "hash": "c42dca31fbc2ebb5705643e3bb6ee666bbfd956de13dd03727f825ad8445b4d7",
             "storage_address": "",
-        }
-    },
-    "permissions": {
-        "process": {
-            "public": False,
-            "authorized_ids": []
         }
     },
     "status": "done",
@@ -369,5 +347,8 @@ COMPUTE_PLAN = {
     "id_to_key": {
         "62378ca1b5c84e73a3d588adab7e20b2":
         "1197bbfc4a189ea037a6835895a81bb80db37f52f82cc40d74e285b7194f4c91",
+    },
+    "metadata": {
+        "foo": "bar"
     }
 }

--- a/tests/sdk/test_add.py
+++ b/tests/sdk/test_add.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import pytest
 import substra
+from substra.sdk import models
 
 import pydantic
 
@@ -26,7 +27,7 @@ def test_add_dataset(client, dataset_query, mocker):
     key = client.add_dataset(dataset_query)
     response = client.get_dataset(key)
 
-    assert response == datastore.DATASET
+    assert response == models.Dataset(**datastore.DATASET)
     m_post.assert_called()
     m_get.assert_called()
 
@@ -61,7 +62,7 @@ def test_add_objective(client, objective_query, mocker):
     key = client.add_objective(objective_query)
     response = client.get_objective(key)
 
-    assert response == datastore.OBJECTIVE
+    assert response == models.Objective(**datastore.OBJECTIVE)
     m_post.assert_called()
     m_get.assert_called()
 
@@ -72,7 +73,7 @@ def test_add_algo(client, algo_query, mocker):
     key = client.add_algo(algo_query)
     response = client.get_algo(key)
 
-    assert response == datastore.ALGO
+    assert response == models.Algo(**datastore.ALGO)
     m_post.assert_called()
     m_get.assert_called()
 
@@ -83,7 +84,7 @@ def test_add_aggregate_algo(client, algo_query, mocker):
     key = client.add_aggregate_algo(algo_query)
     response = client.get_aggregate_algo(key)
 
-    assert response == datastore.AGGREGATE_ALGO
+    assert response == models.AggregateAlgo(**datastore.AGGREGATE_ALGO)
     m_post.assert_called()
     m_get.assert_called()
 
@@ -94,7 +95,7 @@ def test_add_composite_algo(client, algo_query, mocker):
     key = client.add_composite_algo(algo_query)
     response = client.get_composite_algo(key)
 
-    assert response == datastore.COMPOSITE_ALGO
+    assert response == models.CompositeAlgo(**datastore.COMPOSITE_ALGO)
     m_post.assert_called()
     m_get.assert_called()
 

--- a/tests/sdk/test_cancel.py
+++ b/tests/sdk/test_cancel.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from substra.sdk import models
+
 from .. import datastore
 from .utils import mock_requests
 
@@ -21,5 +23,5 @@ def test_cancel_compute_plan(client, mocker):
 
     response = client.cancel_compute_plan("magic-key")
 
-    assert response == datastore.COMPUTE_PLAN
+    assert response == models.ComputePlan(**datastore.COMPUTE_PLAN)
     m.assert_called()

--- a/tests/sdk/test_get.py
+++ b/tests/sdk/test_get.py
@@ -14,6 +14,7 @@
 
 import pytest
 import substra
+from substra.sdk import models, schemas
 
 from .. import datastore
 from .utils import mock_requests
@@ -39,7 +40,7 @@ def test_get_asset(asset_name, client, mocker):
 
     response = method("magic-key")
 
-    assert response == item
+    assert response == models.SCHEMA_TO_MODEL[schemas.Type(asset_name)](**item)
     m.assert_called()
 
 

--- a/tests/sdk/test_list.py
+++ b/tests/sdk/test_list.py
@@ -14,6 +14,8 @@
 
 import pytest
 
+from substra.sdk import models, schemas
+
 from .. import datastore
 from .utils import mock_requests
 
@@ -38,7 +40,7 @@ def test_list_asset(asset_name, client, mocker):
 
     response = method()
 
-    assert response == [item]
+    assert response == [models.SCHEMA_TO_MODEL[schemas.Type(asset_name)](**item)]
     m.assert_called()
 
 
@@ -49,7 +51,7 @@ def test_list_asset_with_filters(client, mocker):
     filters = ["algo:name:ABC", "OR", "data_manager:name:EFG"]
     response = client.list_algo(filters)
 
-    assert response == items
+    assert response == [models.Algo(**item) for item in items]
     m.assert_called()
 
 

--- a/tests/sdk/test_update.py
+++ b/tests/sdk/test_update.py
@@ -12,20 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from substra.sdk import models
+
 from .. import datastore
 from .utils import mock_requests
 
 
 def test_update_dataset(client, mocker):
-    item = datastore.DATASET
-    m = mock_requests(mocker, "post", response=item)
+    m = mock_requests(mocker, "post", response={"key": "dataset_key"})
 
     response = client.link_dataset_with_objective(
         'a key',
         'an another key',
     )
 
-    assert response == item
+    assert response == "dataset_key"
     m.assert_called()
 
 
@@ -36,6 +37,6 @@ def test_update_compute_plan(client, mocker):
 
     response = client.update_compute_plan('foo', {})
 
-    assert response == item
+    assert response == models.ComputePlan(**item)
     m.assert_called
     m_get.assert_called

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from click.testing import CliRunner
 import pytest
 
 import substra
+from substra.sdk import models
 from substra.cli.interface import cli, error_printer
 
 from . import datastore
@@ -103,29 +104,29 @@ def test_command_login(workdir, mocker):
     m.assert_called()
 
 
-@pytest.mark.parametrize('asset_name,key_field', [
-    ('objective', 'key'),
-    ('dataset', 'key'),
-    ('algo', 'key'),
-    ('aggregate_algo', 'key'),
-    ('composite_algo', 'key'),
-    ('testtuple', 'key'),
-    ('traintuple', 'key'),
-    ('aggregatetuple', 'key'),
-    ('composite_traintuple', 'key'),
-    ('compute_plan', 'compute_plan_id'),
+@pytest.mark.parametrize('asset_name,key_field,model', [
+    ('objective', 'key', models.Objective),
+    ('dataset', 'key', models.Dataset),
+    ('algo', 'key', models.Algo),
+    ('aggregate_algo', 'key', models.AggregateAlgo),
+    ('composite_algo', 'key', models.CompositeAlgo),
+    ('testtuple', 'key', models.Testtuple),
+    ('traintuple', 'key', models.Traintuple),
+    ('aggregatetuple', 'key', models.Aggregatetuple),
+    ('composite_traintuple', 'key', models.CompositeTraintuple),
+    ('compute_plan', 'compute_plan_id', models.ComputePlan),
 ])
-def test_command_list(asset_name, key_field, workdir, mocker):
-    item = getattr(datastore, asset_name.upper())
+def test_command_list(asset_name, key_field, model, workdir, mocker):
+    item = model(**getattr(datastore, asset_name.upper()))
     method_name = f'list_{asset_name}'
     m = mock_client_call(mocker, method_name, [item])
     output = client_execute(workdir, ['list', asset_name])
     m.assert_called()
-    assert item[key_field] in output
+    assert getattr(item, key_field) in output
 
 
 def test_command_list_node(workdir, mocker):
-    mock_client_call(mocker, 'list_node', datastore.NODES)
+    mock_client_call(mocker, 'list_node', [models.Node(**node) for node in datastore.NODES])
     output = client_execute(workdir, ['list', 'node'])
     assert output == ('NODE ID                     \n'
                       'foo                         \n'
@@ -307,25 +308,25 @@ def test_command_add_data_sample_already_exists(workdir, mocker):
     m.assert_called()
 
 
-@pytest.mark.parametrize('asset_name,key_field', [
-    ('objective', 'key'),
-    ('dataset', 'key'),
-    ('algo', 'key'),
-    ('aggregate_algo', 'key'),
-    ('composite_algo', 'key'),
-    ('testtuple', 'key'),
-    ('traintuple', 'key'),
-    ('aggregatetuple', 'key'),
-    ('composite_traintuple', 'key'),
-    ('compute_plan', 'compute_plan_id'),
+@pytest.mark.parametrize('asset_name,key_field,model', [
+    ('objective', 'key', models.Objective),
+    ('dataset', 'key', models.Dataset),
+    ('algo', 'key', models.Algo),
+    ('aggregate_algo', 'key', models.AggregateAlgo),
+    ('composite_algo', 'key', models.CompositeAlgo),
+    ('testtuple', 'key', models.Testtuple),
+    ('traintuple', 'key', models.Traintuple),
+    ('aggregatetuple', 'key', models.Aggregatetuple),
+    ('composite_traintuple', 'key', models.CompositeTraintuple),
+    ('compute_plan', 'compute_plan_id', models.ComputePlan),
 ])
-def test_command_get(asset_name, key_field, workdir, mocker):
-    item = getattr(datastore, asset_name.upper())
+def test_command_get(asset_name, key_field, model, workdir, mocker):
+    item = model(**getattr(datastore, asset_name.upper()))
     method_name = f'get_{asset_name}'
     m = mock_client_call(mocker, method_name, item)
     output = client_execute(workdir, ['get', asset_name, 'fakekey'])
     m.assert_called()
-    assert item[key_field] in output
+    assert getattr(item, key_field) in output
 
 
 def test_command_describe(workdir, mocker):
@@ -343,7 +344,11 @@ def test_command_download(workdir, mocker):
 
 
 def test_command_cancel_compute_plan(workdir, mocker):
-    m = mock_client_call(mocker, 'cancel_compute_plan', datastore.COMPUTE_PLAN)
+    m = mock_client_call(
+        mocker,
+        'cancel_compute_plan',
+        models.ComputePlan(**datastore.COMPUTE_PLAN)
+    )
     client_execute(workdir, ['cancel', 'compute_plan', 'fakekey'])
     m.assert_called()
 


### PR DESCRIPTION
Substra SDK: return a Pydantic object instead of a dict

## Changes

- [x] moved 'models.py' from local backend to substra.sdk
- [x] update the sdk/backends/remote/backend.py to convert the dict returned to a Pydantic object
- [x] update the local backend to return objects too
- fix:
    - [x] the tests (datastore and tests)
    - [x] the examples
    - [x] the CLI
- [x] Updated the documentation to automatically generate a doc on the SDK input objects

Companion PR: https://github.com/SubstraFoundation/substra-tests/pull/144