### PR TITLE
feat: login from SDK in examples and expose temp dir in debug mode

### DIFF
--- a/references/sdk.md
+++ b/references/sdk.md
@@ -30,6 +30,10 @@ Args:
         the deployed Substra platform. The platform is in read-only mode.
         Defaults to False.
 
+## temp_directory
+Temporary directory for storing assets in debug mode.
+Deleted when the client is deleted.
+
 ## login
 ```python
 Client.login(self, username, password)

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -32,6 +32,12 @@ class Local(base.BaseBackend):
         self._db = dal.DataAccess(backend)
         self._worker = compute.Worker(self._db)
 
+    @property
+    def temp_directory(self):
+        """Get the temporary directory where the assets are saved.
+        The directory is deleted at the end of the execution."""
+        return self._db.tmp_dir
+
     def login(self, username, password):
         self._db.login(username, password)
 

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -34,11 +34,11 @@ class DataAccess:
     def __init__(self, remote_backend: typing.Optional[backend.Remote]):
         self._db = db.get()
         self._remote = remote_backend
-        self.__tmp_dir = tempfile.TemporaryDirectory(prefix="/tmp/")
+        self._tmp_dir = tempfile.TemporaryDirectory(prefix="/tmp/")
 
     @property
-    def _tmp_dir(self):
-        return pathlib.Path(self.__tmp_dir.name)
+    def tmp_dir(self):
+        return pathlib.Path(self._tmp_dir.name)
 
     @staticmethod
     def is_local(key: str):
@@ -97,7 +97,7 @@ class DataAccess:
         else:
             asset_name, field_name = self._get_asset_content_filename(type_)
             asset = self._remote.get(type_, key)
-            tmp_directory = self._tmp_dir / key
+            tmp_directory = self.tmp_dir / key
             asset_path = tmp_directory / asset_name
 
             if not tmp_directory.exists():
@@ -137,7 +137,7 @@ class DataAccess:
         """Copy file or directory into the local temp dir to mimick
         the remote backend that saves the files given by the user.
         """
-        tmp_directory = self._tmp_dir / key
+        tmp_directory = self.tmp_dir / key
         tmp_file = tmp_directory / pathlib.Path(file_path).name
 
         if not tmp_directory.exists():

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -120,6 +120,14 @@ class Client(object):
             )
         return backend
 
+    @property
+    def temp_directory(self):
+        """Temporary directory for storing assets in debug mode.
+        Deleted when the client is deleted.
+        """
+        if isinstance(self._backend, backends.Local):
+            return self._backend.temp_directory
+
     @logit
     def login(self, username, password):
         """Login to a remote server. """

--- a/tests/sdk/test_debug.py
+++ b/tests/sdk/test_debug.py
@@ -1,0 +1,7 @@
+
+import substra
+
+
+def test_client_tmp_dir():
+    client = substra.Client(debug=True)
+    assert client.temp_directory


### PR DESCRIPTION
User feedback:

- Login from the SDK in the examples, instead of logging in from the CLI then use the SDK
- Expose the temporary directory in debug mode so that the user an pause the execution and check the assets

EDIT: only expose the temp dir following the discussions on the login