### PR TITLE
fix: debug mode - fix get the number of samples in testtuple

### DIFF
--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -274,7 +274,7 @@ class Worker:
 
             if not self._db.is_local(dataset.key):
                 command += " --fake-data"
-                command += f" --n-fake-samples {len(objective.test_dataset.data_sample_keys)}"
+                command += f" --n-fake-samples {len(tuple_.dataset.keys)}"
 
             if tuple_.traintuple_type == schemas.Type.Traintuple \
                     or tuple_.traintuple_type == schemas.Type.Aggregatetuple:

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -321,7 +321,7 @@ class Worker:
                 command = f"--fake-data-mode {METRICS_NO_FAKE_Y}"
             else:
                 command = f"--fake-data-mode {METRICS_FAKE_Y}"
-                command += f" --n-fake-samples {len(objective.test_dataset.data_sample_keys)}"
+                command += f" --n-fake-samples {len(tuple_.dataset.keys)}"
 
             container_name = DOCKER_METRICS_TAG
             logs_predict = self._spawner.spawn(


### PR DESCRIPTION
### Description

In debug mode, when connected to a deployed platform and creating a testtuple in local associated to a remote dataset, the script counts the number of test data samples in the testtuple and generates as many fake data samples.   

The bug is that instead of counting the number of samples for this testtuple, it counts the number of test data samples linked to the objective.  
It gives a false result if the testtuple uses other samples (as defined by the user) and throws an error if the objective has no test dataset.

### Steps to reproduce

- locally deploy Substra
- add a dataset
- add an objective with `test_dataset=None `
- in debug mode: add a testtuple associated to this objective and dataset

Modifying the 'test_debug.py::test_execution_debug' in substra-tests like this works too to reproduce:
```python
def test_execution_debug(client, debug_client, factory, default_dataset):

    spec = factory.create_objective(dataset=None, data_samples=None)
    default_objective = client.add_objective(spec)

    spec = factory.create_algo()
    algo = client.add_algo(spec)

    #  Add the traintuple
    # create traintuple
    spec = factory.create_traintuple(
        algo=algo,
        dataset=default_dataset,
        data_samples=default_dataset.train_data_sample_keys[0],
    )
    traintuple = debug_client.add_traintuple(spec)
    assert traintuple.status == models.Status.done
    assert traintuple.out_model is not None

    # Add the testtuple
    spec = factory.create_testtuple(
        objective=default_objective,
        traintuple=traintuple,
        data_samples=default_dataset.test_data_sample_keys[0],
    )
    spec.data_manager_key = default_dataset.key
    testtuple = debug_client.add_testtuple(spec)
    assert testtuple.status == models.Status.done
    # assert testtuple.dataset.perf == 3
```