### PR TITLE
Generate the documentation of the SDK - arguments as markdown instead of block quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ script:
   - flake8 substra
   - pip install -e .[test]
   - python setup.py test
+  # Generate the CLI documentation
   - python bin/generate_cli_documentation.py --output-path references/cli.md.tmp
   - cmp --silent references/cli.md references/cli.md.tmp
-  - pydocmd simple substra.sdk+ substra.sdk.Client+ substra.sdk.retry_on_exception+ > references/sdk.md.tmp
+  # Generate the SDK documentation
+  - python bin/generate_sdk_documentation.py --output-path='references/sdk.md.tmp'
   - cmp --silent references/sdk.md references/sdk.md.tmp
   - python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
   - cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,11 @@ doc-cli:
 	python bin/generate_cli_documentation.py
 
 doc-sdk:
-	pydocmd simple substra.sdk+ substra.sdk.Client+ substra.sdk.retry_on_exception+ > references/sdk.md
-
-doc-schemas:
+	python bin/generate_sdk_documentation.py
 	python bin/generate_sdk_schemas_documentation.py
 	python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md'
 
-doc: doc-cli doc-sdk doc-schemas
+doc: doc-cli doc-sdk
 
 test: pyclean
 	python setup.py test

--- a/bin/generate_sdk_documentation.py
+++ b/bin/generate_sdk_documentation.py
@@ -52,7 +52,7 @@ def generate_function_help(fh, asset):
         fh.write(f"\n**{param.args[0].title()}:**\n")
         if len(param.args) > 1:
             for extra_param in param.args[1:]:
-                fh.write(f"\n - {extra_param}: ")
+                fh.write(f"\n - `{extra_param}`: ")
         fh.write(f"{param.description}\n")
 
 

--- a/bin/generate_sdk_documentation.py
+++ b/bin/generate_sdk_documentation.py
@@ -38,7 +38,7 @@ def generate_function_help(fh, asset):
         fh.write(f"{docstring.long_description}\n")
     # Write the arguments as a list
     if len(docstring.params) > 0:
-        fh.write("\nArguments:\n")
+        fh.write("\n**Arguments:**\n")
     for param in docstring.params:
         type_and_optional = ""
         if param.type_name or param.is_optional is not None:
@@ -46,10 +46,10 @@ def generate_function_help(fh, asset):
             if param.is_optional:
                 text_optional = 'optional'
             type_and_optional = f"({param.type_name}, {text_optional})"
-        fh.write(f" - {param.arg_name}{type_and_optional}: {param.description}\n")
+        fh.write(f" - `{param.arg_name} {type_and_optional}`: {param.description}\n")
     # Write everything else as is
     for param in [meta_param for meta_param in docstring.meta if not isinstance(meta_param, docstring_parser.DocstringParam)]:
-        fh.write(f"\n{param.args[0].title()}:\n")
+        fh.write(f"\n**{param.args[0].title()}:**\n")
         if len(param.args) > 1:
             for extra_param in param.args[1:]:
                 fh.write(f"\n - {extra_param}: ")

--- a/bin/generate_sdk_documentation.py
+++ b/bin/generate_sdk_documentation.py
@@ -1,0 +1,104 @@
+import argparse
+import docstring_parser
+import inspect
+from pathlib import Path
+import sys
+
+from substra import Client
+from substra.sdk.utils import retry_on_exception
+
+
+MODULE_LIST = [
+    Client,
+    retry_on_exception
+]
+
+KEYWORDS = [
+    "Args",
+    "Returns",
+    "Yields",
+    "Raises",
+    "Example"
+]
+
+
+def generate_function_help(fh, asset):
+    """Write the description of a function"""
+    fh.write(f"# {asset.__name__}\n")
+    signature = str(inspect.signature(asset))
+    fh.write("```python\n")
+    fh.write(f"{asset.__name__}{signature}")
+    fh.write("\n```")
+    fh.write("\n\n")
+    # Write the docstring
+    docstring = inspect.getdoc(asset)
+    docstring = docstring_parser.parse(inspect.getdoc(asset))
+    fh.write(f"{docstring.short_description}\n")
+    if docstring.long_description:
+        fh.write(f"{docstring.long_description}\n")
+    # Write the arguments as a list
+    if len(docstring.params) > 0:
+        fh.write("\nArguments:\n")
+    for param in docstring.params:
+        type_and_optional = ""
+        if param.type_name or param.is_optional is not None:
+            text_optional = 'required'
+            if param.is_optional:
+                text_optional = 'optional'
+            type_and_optional = f"({param.type_name}, {text_optional})"
+        fh.write(f" - {param.arg_name}{type_and_optional}: {param.description}\n")
+    # Write everything else as is
+    for param in [meta_param for meta_param in docstring.meta if not isinstance(meta_param, docstring_parser.DocstringParam)]:
+        fh.write(f"\n{param.args[0].title()}:\n")
+        if len(param.args) > 1:
+            for extra_param in param.args[1:]:
+                fh.write(f"\n - {extra_param}: ")
+        fh.write(f"{param.description}\n")
+
+
+def generate_properties_help(fh, public_methods):
+    properties = [
+        (f_name, f_method) for f_name, f_method in public_methods
+        if isinstance(f_method, property)
+    ]
+    for f_name, f_method in properties:
+        fh.write(f"## {f_name}\n")
+        fh.write(f"_This is a property._  \n")
+        fh.write(f"{f_method.__doc__}\n")
+
+
+def generate_help(fh):
+
+    fh.write("# substra.sdk\n\n")
+
+    for asset in MODULE_LIST:
+        if inspect.isclass(asset):  # Class
+            public_methods = [
+                (f_name, f_method)
+                for f_name, f_method
+                in inspect.getmembers(asset)
+                if not f_name.startswith('_')
+            ]
+            generate_function_help(fh, asset)
+            generate_properties_help(fh, public_methods)
+            for f_name, f_method in public_methods:
+                if not isinstance(f_method, property):
+                    fh.write("#")  # Title for the methods are one level below
+                    generate_function_help(fh, f_method)
+        elif callable(asset):
+            generate_function_help(fh, asset)
+
+
+def write_help(path):
+    with path.open('w') as fh:
+        generate_help(fh)
+
+
+if __name__ == '__main__':
+    default_path = Path(__file__).resolve().parents[1] / "references" / "sdk.md"
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output-path', type=str, default=str(default_path.resolve()), required=False)
+
+    args = parser.parse_args(sys.argv[1:])
+    write_help(Path(args.output_path))

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -2,288 +2,118 @@
 
 # Client
 ```python
-Client(self, url: Union[str, NoneType] = None, token: Union[str, NoneType] = None, retry_timeout: int = 300, insecure: bool = False, debug: bool = False)
+Client(url: Union[str, NoneType] = None, token: Union[str, NoneType] = None, retry_timeout: int = 300, insecure: bool = False, debug: bool = False)
 ```
+
 Create a client
 
-Args:
-
-    url (str, optional): URL of the Substra platform. Mandatory
-        to connect to a Substra platform. If no URL is given debug must be True and all
-        assets must be created locally.
-        Defaults to None.
-
-    token (str, optional): Token to authenticate to the Substra platform.
-        If no token is given, use the 'login' function to authenticate.
-        Defaults to None.
-
-    retry_timeout (int, optional): Number of seconds before attempting a retry call in case
-        of timeout.
-        Defaults to 5 minutes.
-
-    insecure (bool, optional): If True, the client can call a not-certifed backend. This is
-        for development purposes.
-        Defaults to False.
-
-    debug (bool, optional): Whether to use the default or debug mode.
-        In debug mode, new assets are created locally but can access assets from
-        the deployed Substra platform. The platform is in read-only mode.
-        Defaults to False.
-
+Arguments:
+ - url(str, optional): URL of the Substra platform. Mandatory
+to connect to a Substra platform. If no URL is given debug must be True and all
+assets must be created locally.
+Defaults to None.
+ - token(str, optional): Token to authenticate to the Substra platform.
+If no token is given, use the 'login' function to authenticate.
+Defaults to None.
+ - retry_timeout(int, optional): Number of seconds before attempting a retry call in case
+of timeout.
+Defaults to 5 minutes.
+ - insecure(bool, optional): If True, the client can call a not-certifed backend. This is
+for development purposes.
+Defaults to False.
+ - debug(bool, optional): Whether to use the default or debug mode.
+In debug mode, new assets are created locally but can access assets from
+the deployed Substra platform. The platform is in read-only mode.
+Defaults to False.
 ## temp_directory
+_This is a property._  
 Temporary directory for storing assets in debug mode.
-Deleted when the client is deleted.
-
-## login
-```python
-Client.login(self, username, password)
-```
-Login to a remote server.
-## from_config_file
-```python
-Client.from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Union[str, NoneType] = None, retry_timeout: int = 300, debug: bool = False)
-```
-Returns a new Client configured with profile data from configuration files.
-
-Args:
-
-    profile_name (str, optional): Name of the profile to load.
-        Defaults to 'default'.
-
-    config_path (Union[str, pathlib.Path], optional): Path to the
-        configuration file.
-        Defaults to '~/.substra'.
-
-    tokens_path (Union[str, pathlib.Path], optional): Path to the tokens file.
-        Defaults to '~/.substra-tokens'.
-
-    token (str, optional): Token to use for authentication (will be used
-        instead of any token found at tokens_path). Defaults to None.
-
-    retry_timeout (int, optional): Number of seconds before attempting a retry call in case
-        of timeout. Defaults to 5 minutes.
-
-    debug (bool): Whether to use the default or debug mode. In debug mode, new assets are
-        created locally but can get remote assets. The deployed platform is in
-        read-only mode.
-        Defaults to False.
-
-Returns:
-    Client: The new client.
-
-## add_data_sample
-```python
-Client.add_data_sample(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True, exist_ok: bool = False) -> str
-```
-Create a new data sample asset and return its key.
-
-If a data sample with the same content already exists, an `AlreadyExists` exception will be
-raised.
-
-Args:
-
-    data (Union[dict, schemas.DataSampleSpec]): data sample to add. If it is a dict,
-    it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
-
-    local (bool, optional):
-        If `local` is true, `path` must refer to a directory located on the local
-        filesystem. The file content will be transferred to the server through an
-        HTTP query, so this mode should be used for relatively small files (<10mo).
-
-        If `local` is false, `path` must refer to a directory located on the server
-        filesystem. This directory must be accessible (readable) by the server.  This
-        mode is well suited for all kind of file sizes. Defaults to True.
-
-    exist_ok (bool, optional):
-        If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-        existing asset key will be returned. Defaults to False.
-
-Returns:
-    str: key of the data sample
-
-## add_data_samples
-```python
-Client.add_data_samples(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True) -> List[str]
-```
-Create many data sample assets and return  a list of keys.
-
-Create multiple data samples through a single HTTP request.
-This method is well suited for adding multiple small files only. For adding a
-large amount of data it is recommended to add them one by one. It allows a
-better control in case of failures.
-
-If data samples with the same content as any of the paths already exists, an `AlreadyExists`
-exception will be raised.
-
-Args:
-
-    data (Union[dict, schemas.DataSampleSpec]): data samples to add. If it is a dict,
-        it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
-
-        The `paths` in the data dictionary must be a list of paths where each path
-        points to a directory representing one data sample.
-
-    local (bool, optional):  Please refer to the method `Client.add_data_sample`.
-        Defaults to True.
-
-Returns:
-    List[str]: List of the data sample keys
-
-## add_dataset
-```python
-Client.add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec], exist_ok: bool = False)
-```
-Create new dataset asset and return its key.
-
-If a dataset with the same opener already exists, an `AlreadyExists` exception will be
-raised.
-
-Args:
-
-    data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
-        keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
-        will be ignored and the existing asset key will be returned.
-        Defaults to False.
-
-Returns:
-    str: Key of the dataset
-
-## add_objective
-```python
-Client.add_objective(self, data: Union[dict, substra.sdk.schemas.ObjectiveSpec], exist_ok: bool = False) -> str
-```
-Create new objective asset.
-
-If an objective with the same description already exists, an `AlreadyExists` exception will
-be raised.
-
-Args:
-
-    data (Union[dict, schemas.ObjectiveSpec]): If it is a dict, it must have the same keys
-        as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
-        will be ignored and the existing asset key will be returned. Defaults to False.
-
-Returns:
-    str: Key of the objective
-
-## add_algo
-```python
-Client.add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec], exist_ok: bool = False) -> str
-```
-Create new algo asset.
-
-If an algo with the same archive file already exists, an `AlreadyExists` exception will be
-raised.
-
-Args:
-
-    data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
-        as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
-        ignored and the existing asset key will be returned. Defaults to False.
-
-Returns:
-    str: Key of the algo
-
+        Deleted when the client is deleted.
+        
 ## add_aggregate_algo
 ```python
-Client.add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec], exist_ok: bool = False) -> str
+add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec], exist_ok: bool = False) -> str
 ```
-Create new aggregate algo asset.
 
+Create new aggregate algo asset.
 If an aggregate algo with the same archive file already exists, an `AlreadyExists`
 exception will be raised.
 
-Args:
+Arguments:
+ - data(Union[dict, schemas.AggregateAlgoSpec], required): If it is a dict,
+it must have the same keys as specified in
+[schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
 
-    data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
-        it must have the same keys as specified in
-        [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
+Returns:
 
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
-
- Returns:
-    str: Key of the asset
-
-## add_composite_algo
-```python
-Client.add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec], exist_ok: bool = False) -> str
-```
-Create new composite algo asset.
-
-If a composite algo with the same archive file already exists, an `AlreadyExists`
-exception will be raised.
-
-Args:
-
-    data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
-        keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
-
- Returns:
-    str: Key of the asset
-
-## add_traintuple
-```python
-Client.add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec], exist_ok: bool = False) -> str
-```
-Create new traintuple asset.
-
-An `AlreadyExists` exception will be raised if a traintuple already exists that:
-* has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
-* and was created through the same node you are using
-
-Args:
-
-    data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
-        keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
-
- Returns:
-    str: Key of the asset
-
+ - str: Key of the asset
 ## add_aggregatetuple
 ```python
-Client.add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpec], exist_ok: bool = False) -> str
+add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpec], exist_ok: bool = False) -> str
 ```
-Create a new aggregate tuple asset.
 
+Create a new aggregate tuple asset.
 An `AlreadyExists` exception will be raised if an aggregatetuple already exists that:
 * has the same `algo_key` and `in_models_keys`
 * and was created through the same node you are using
 
-Args:
+Arguments:
+ - data(Union[dict, schemas.AggregatetupleSpec], required): If it is a dict, it must have the same
+keys as specified in
+[schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
 
-    data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
-        keys as specified in
-        [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
+Returns:
 
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
+ - str: Key of the asset
+## add_algo
+```python
+add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec], exist_ok: bool = False) -> str
+```
 
- Returns:
-    str: Key of the asset
+Create new algo asset.
+If an algo with the same archive file already exists, an `AlreadyExists` exception will be
+raised.
 
+Arguments:
+ - data(Union[dict, schemas.AlgoSpec], required): If it is a dict, it must have the same keys
+as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
+ignored and the existing asset key will be returned. Defaults to False.
+
+Returns:
+
+ - str: Key of the algo
+## add_composite_algo
+```python
+add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec], exist_ok: bool = False) -> str
+```
+
+Create new composite algo asset.
+If a composite algo with the same archive file already exists, an `AlreadyExists`
+exception will be raised.
+
+Arguments:
+ - data(Union[dict, schemas.CompositeAlgoSpec], required): If it is a dict, it must have the same
+keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
+
+Returns:
+
+ - str: Key of the asset
 ## add_composite_traintuple
 ```python
-Client.add_composite_traintuple(self, data: Union[dict, substra.sdk.schemas.CompositeTraintupleSpec], exist_ok: bool = False) -> str
+add_composite_traintuple(self, data: Union[dict, substra.sdk.schemas.CompositeTraintupleSpec], exist_ok: bool = False) -> str
 ```
-Create new composite traintuple asset.
 
+Create new composite traintuple asset.
 As specified in the data structure, output trunk models cannot be made
 public.
 
@@ -292,322 +122,478 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
   `in_head_models_key` and `in_trunk_model_key`
 * and was created through the same node you are using
 
-Args:
+Arguments:
+ - data(Union[dict, schemas.CompositeTraintupleSpec], required): If it is a dict, it must have the
+same keys as specified in
+[schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
 
-    data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
-        same keys as specified in
-        [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
+Returns:
 
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
+ - str: Key of the asset
+## add_compute_plan
+```python
+add_compute_plan(self, data: Union[dict, substra.sdk.schemas.ComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
+```
 
- Returns:
-    str: Key of the asset
+Create new compute plan asset.
+As specified in the data dict structure, output trunk models of composite
+traintuples cannot be made public.
 
+Arguments:
+ - data(Union[dict, schemas.ComputePlanSpec], required): If it is a dict, it must have the same
+keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
+ - auto_batching(bool, optional): Set 'auto_batching' to False to upload all the tuples of
+the compute plan at once. Defaults to True.
+ - batch_size(int, optional): If 'auto_batching' is True, change `batch_size` to define
+the number oftuples uploaded in each batch (default 20).
+
+Returns:
+
+ - models.ComputePlan: Created compute plan
+## add_data_sample
+```python
+add_data_sample(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True, exist_ok: bool = False) -> str
+```
+
+Create a new data sample asset and return its key.
+If a data sample with the same content already exists, an `AlreadyExists` exception will be
+raised.
+
+Arguments:
+ - data(Union[dict, schemas.DataSampleSpec], required): data sample to add. If it is a dict,
+it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+ - local(bool, optional): If `local` is true, `path` must refer to a directory located
+on the local filesystem. The file content will be transferred to the server
+through an HTTP query, so this mode should be used for relatively small files
+(<10mo).
+
+If `local` is false, `path` must refer to a directory located on the server
+filesystem. This directory must be accessible (readable) by the server.  This
+mode is well suited for all kind of file sizes. Defaults to True.
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will
+be ignored and the existing asset key will be returned. Defaults to False.
+
+Returns:
+
+ - str: key of the data sample
+## add_data_samples
+```python
+add_data_samples(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True) -> List[str]
+```
+
+Create many data sample assets and return  a list of keys.
+Create multiple data samples through a single HTTP request.
+This method is well suited for adding multiple small files only. For adding a
+large amount of data it is recommended to add them one by one. It allows a
+better control in case of failures.
+
+If data samples with the same content as any of the paths already exists, an `AlreadyExists`
+exception will be raised.
+
+Arguments:
+ - data(Union[dict, schemas.DataSampleSpec], required): data samples to add. If it is a dict,
+it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+The `paths` in the data dictionary must be a list of paths where each path
+points to a directory representing one data sample.
+ - local(bool, optional):  Please refer to the method `Client.add_data_sample`.
+Defaults to True.
+
+Returns:
+
+ - List[str]: List of the data sample keys
+## add_dataset
+```python
+add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec], exist_ok: bool = False)
+```
+
+Create new dataset asset and return its key.
+If a dataset with the same opener already exists, an `AlreadyExists` exception will be
+raised.
+
+Arguments:
+ - data(Union[dict, schemas.DatasetSpec], required): If it is a dict, it must have the same
+keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+will be ignored and the existing asset key will be returned.
+Defaults to False.
+
+Returns:
+
+ - str: Key of the dataset
+## add_objective
+```python
+add_objective(self, data: Union[dict, substra.sdk.schemas.ObjectiveSpec], exist_ok: bool = False) -> str
+```
+
+Create new objective asset.
+If an objective with the same description already exists, an `AlreadyExists` exception will
+be raised.
+
+Arguments:
+ - data(Union[dict, schemas.ObjectiveSpec], required): If it is a dict, it must have the same keys
+as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+will be ignored and the existing asset key will be returned. Defaults to False.
+
+Returns:
+
+ - str: Key of the objective
 ## add_testtuple
 ```python
-Client.add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec], exist_ok: bool = False) -> str
+add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec], exist_ok: bool = False) -> str
 ```
-Create new testtuple asset.
 
+Create new testtuple asset.
 An `AlreadyExists` exception will be raised if a testtuple already exists that:
 * has the same `traintuple_key`, `objective_key`, `data_manager_key` and
   `test_data_sample_keys`
 * and was created through the same node you are using
 
-Args:
-
-    data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same
-        keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
-
-    exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
-        exceptions will be ignored and the existing asset key will be returned.
-        Defaults to False.
-
- Returns:
-    str: Key of the asset
-
-## add_compute_plan
-```python
-Client.add_compute_plan(self, data: Union[dict, substra.sdk.schemas.ComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
-```
-Create new compute plan asset.
-
-As specified in the data dict structure, output trunk models of composite
-traintuples cannot be made public.
-
-Args:
-
-    data (Union[dict, schemas.ComputePlanSpec]): If it is a dict, it must have the same
-        keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
-
-    auto_batching (bool, optional): Set 'auto_batching' to False to upload all the tuples of
-        the compute plan at once. Defaults to True.
-
-    batch_size (int, optional): If 'auto_batching' is True, change `batch_size` to define
-        the number oftuples uploaded in each batch (default 20).
+Arguments:
+ - data(Union[dict, schemas.TesttupleSpec], required): If it is a dict, it must have the same
+keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
 
 Returns:
-    models.ComputePlan: Created compute plan
 
-## get_algo
+ - str: Key of the asset
+## add_traintuple
 ```python
-Client.get_algo(self, key: str) -> substra.sdk.models.Algo
+add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec], exist_ok: bool = False) -> str
 ```
-Get algo by key, the returned object is described
-in the [models.Algo](sdk_models.md#Algo) model
-## get_compute_plan
+
+Create new traintuple asset.
+An `AlreadyExists` exception will be raised if a traintuple already exists that:
+* has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
+* and was created through the same node you are using
+
+Arguments:
+ - data(Union[dict, schemas.TraintupleSpec], required): If it is a dict, it must have the same
+keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
+ - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+exceptions will be ignored and the existing asset key will be returned.
+Defaults to False.
+
+Returns:
+
+ - str: Key of the asset
+## cancel_compute_plan
 ```python
-Client.get_compute_plan(self, key: str) -> substra.sdk.models.ComputePlan
+cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
 ```
-Get compute plan by key, the returned object is described
+
+Cancel execution of compute plan, the returned object is described
 in the [models.ComputePlan](sdk_models.md#ComputePlan) model
+## describe_aggregate_algo
+```python
+describe_aggregate_algo(self, key: str) -> str
+```
+
+Get aggregate algo description.
+## describe_algo
+```python
+describe_algo(self, key: str) -> str
+```
+
+Get algo description.
+## describe_composite_algo
+```python
+describe_composite_algo(self, key: str) -> str
+```
+
+Get composite algo description.
+## describe_dataset
+```python
+describe_dataset(self, key: str) -> str
+```
+
+Get dataset description.
+## describe_objective
+```python
+describe_objective(self, key: str) -> str
+```
+
+Get objective description.
+## download_aggregate_algo
+```python
+download_aggregate_algo(self, key: str, destination_folder: str) -> None
+```
+
+Download aggregate algo resource.
+Download aggregate algo package in destination folder.
+## download_algo
+```python
+download_algo(self, key: str, destination_folder: str) -> None
+```
+
+Download algo resource.
+Download algo package in destination folder.
+## download_composite_algo
+```python
+download_composite_algo(self, key: str, destination_folder: str) -> None
+```
+
+Download composite algo resource.
+Download composite algo package in destination folder.
+## download_dataset
+```python
+download_dataset(self, key: str, destination_folder: str) -> None
+```
+
+Download data manager resource.
+Download opener script in destination folder.
+## download_objective
+```python
+download_objective(self, key: str, destination_folder: str) -> None
+```
+
+Download objective resource.
+Download metrics script in destination folder.
+## from_config_file
+```python
+from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Union[str, NoneType] = None, retry_timeout: int = 300, debug: bool = False)
+```
+
+Returns a new Client configured with profile data from configuration files.
+
+Arguments:
+ - profile_name(str, optional): Name of the profile to load.
+Defaults to 'default'.
+ - config_path(Union[str, pathlib.Path], optional): Path to the
+configuration file.
+Defaults to '~/.substra'.
+ - tokens_path(Union[str, pathlib.Path], optional): Path to the tokens file.
+Defaults to '~/.substra-tokens'.
+ - token(str, optional): Token to use for authentication (will be used
+instead of any token found at tokens_path). Defaults to None.
+ - retry_timeout(int, optional): Number of seconds before attempting a retry call in case
+of timeout. Defaults to 5 minutes.
+ - debug(bool, required): Whether to use the default or debug mode. In debug mode, new assets are
+created locally but can get remote assets. The deployed platform is in
+read-only mode.
+Defaults to False.
+
+Returns:
+
+ - Client: The new client.
 ## get_aggregate_algo
 ```python
-Client.get_aggregate_algo(self, key: str) -> substra.sdk.models.AggregateAlgo
+get_aggregate_algo(self, key: str) -> substra.sdk.models.AggregateAlgo
 ```
+
 Get aggregate algo by key, the returned object is described
 in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model
+## get_aggregatetuple
+```python
+get_aggregatetuple(self, key: str) -> substra.sdk.models.Aggregatetuple
+```
+
+Get aggregatetuple by key, the returned object is described
+in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
+## get_algo
+```python
+get_algo(self, key: str) -> substra.sdk.models.Algo
+```
+
+Get algo by key, the returned object is described
+in the [models.Algo](sdk_models.md#Algo) model
 ## get_composite_algo
 ```python
-Client.get_composite_algo(self, key: str) -> substra.sdk.models.CompositeAlgo
+get_composite_algo(self, key: str) -> substra.sdk.models.CompositeAlgo
 ```
+
 Get composite algo by key, the returned object is described
 in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model
+## get_composite_traintuple
+```python
+get_composite_traintuple(self, key: str) -> substra.sdk.models.CompositeTraintuple
+```
+
+Get composite traintuple by key, the returned object is described
+in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
+## get_compute_plan
+```python
+get_compute_plan(self, key: str) -> substra.sdk.models.ComputePlan
+```
+
+Get compute plan by key, the returned object is described
+in the [models.ComputePlan](sdk_models.md#ComputePlan) model
 ## get_dataset
 ```python
-Client.get_dataset(self, key: str) -> substra.sdk.models.Dataset
+get_dataset(self, key: str) -> substra.sdk.models.Dataset
 ```
+
 Get dataset by key, the returned object is described
 in the [models.Dataset](sdk_models.md#Dataset) model
 ## get_objective
 ```python
-Client.get_objective(self, key: str) -> substra.sdk.models.Objective
+get_objective(self, key: str) -> substra.sdk.models.Objective
 ```
+
 Get objective by key, the returned object is described
 in the [models.Objective](sdk_models.md#Objective) model
 ## get_testtuple
 ```python
-Client.get_testtuple(self, key: str) -> substra.sdk.models.Testtuple
+get_testtuple(self, key: str) -> substra.sdk.models.Testtuple
 ```
+
 Get testtuple by key, the returned object is described
 in the [models.Testtuple](sdk_models.md#Testtuple) model
 ## get_traintuple
 ```python
-Client.get_traintuple(self, key: str) -> substra.sdk.models.Traintuple
+get_traintuple(self, key: str) -> substra.sdk.models.Traintuple
 ```
+
 Get traintuple by key, the returned object is described
 in the [models.Traintuple](sdk_models.md#Traintuple) model
-## get_aggregatetuple
+## leaderboard
 ```python
-Client.get_aggregatetuple(self, key: str) -> substra.sdk.models.Aggregatetuple
+leaderboard(self, objective_key: str, sort: str = 'desc') -> str
 ```
-Get aggregatetuple by key, the returned object is described
-in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
-## get_composite_traintuple
+
+Get objective leaderboard
+## link_dataset_with_data_samples
 ```python
-Client.get_composite_traintuple(self, key: str) -> substra.sdk.models.CompositeTraintuple
+link_dataset_with_data_samples(self, dataset_key: str, data_sample_keys: str) -> List[str]
 ```
-Get composite traintuple by key, the returned object is described
-in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
-## list_algo
+
+Link dataset with data samples.
+## link_dataset_with_objective
 ```python
-Client.list_algo(self, filters=None) -> List[substra.sdk.models.Algo]
+link_dataset_with_objective(self, dataset_key: str, objective_key: str) -> str
 ```
-List algos, the returned object is described
-in the [models.Algo](sdk_models.md#Algo) model
-## list_compute_plan
-```python
-Client.list_compute_plan(self, filters=None) -> List[substra.sdk.models.ComputePlan]
-```
-List compute plans, the returned object is described
-in the [models.ComputePlan](sdk_models.md#ComputePlan) model
+
+Link dataset with objective.
 ## list_aggregate_algo
 ```python
-Client.list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.AggregateAlgo]
+list_aggregate_algo(self, filters=None) -> List[substra.sdk.models.AggregateAlgo]
 ```
+
 List aggregate algos, the returned object is described
 in the [models.AggregateAlgo](sdk_models.md#AggregateAlgo) model
+## list_aggregatetuple
+```python
+list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Aggregatetuple]
+```
+
+List aggregatetuples, the returned object is described
+in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
+## list_algo
+```python
+list_algo(self, filters=None) -> List[substra.sdk.models.Algo]
+```
+
+List algos, the returned object is described
+in the [models.Algo](sdk_models.md#Algo) model
 ## list_composite_algo
 ```python
-Client.list_composite_algo(self, filters=None) -> List[substra.sdk.models.CompositeAlgo]
+list_composite_algo(self, filters=None) -> List[substra.sdk.models.CompositeAlgo]
 ```
+
 List composite algos, the returned object is described
 in the [models.CompositeAlgo](sdk_models.md#CompositeAlgo) model
+## list_composite_traintuple
+```python
+list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.CompositeTraintuple]
+```
+
+List composite traintuples, the returned object is described
+in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
+## list_compute_plan
+```python
+list_compute_plan(self, filters=None) -> List[substra.sdk.models.ComputePlan]
+```
+
+List compute plans, the returned object is described
+in the [models.ComputePlan](sdk_models.md#ComputePlan) model
 ## list_data_sample
 ```python
-Client.list_data_sample(self, filters=None) -> List[substra.sdk.models.DataSample]
+list_data_sample(self, filters=None) -> List[substra.sdk.models.DataSample]
 ```
+
 List data samples, the returned object is described
 in the [models.DataSample](sdk_models.md#DataSample) model
 ## list_dataset
 ```python
-Client.list_dataset(self, filters=None) -> List[substra.sdk.models.Dataset]
+list_dataset(self, filters=None) -> List[substra.sdk.models.Dataset]
 ```
+
 List datasets, the returned object is described
 in the [models.Dataset](sdk_models.md#Dataset) model
+## list_node
+```python
+list_node(self, *args, **kwargs) -> List[substra.sdk.models.Node]
+```
+
+List nodes, the returned object is described
+in the [models.Node](sdk_models.md#Node) model
 ## list_objective
 ```python
-Client.list_objective(self, filters=None) -> List[substra.sdk.models.Objective]
+list_objective(self, filters=None) -> List[substra.sdk.models.Objective]
 ```
+
 List objectives, the returned object is described
 in the [models.Objective](sdk_models.md#Objective) model
 ## list_testtuple
 ```python
-Client.list_testtuple(self, filters=None) -> List[substra.sdk.models.Testtuple]
+list_testtuple(self, filters=None) -> List[substra.sdk.models.Testtuple]
 ```
+
 List testtuples, the returned object is described
 in the [models.Testtuple](sdk_models.md#Testtuple) model
 ## list_traintuple
 ```python
-Client.list_traintuple(self, filters=None) -> List[substra.sdk.models.Traintuple]
+list_traintuple(self, filters=None) -> List[substra.sdk.models.Traintuple]
 ```
+
 List traintuples, the returned object is described
 in the [models.Traintuple](sdk_models.md#Traintuple) model
-## list_aggregatetuple
+## login
 ```python
-Client.list_aggregatetuple(self, filters=None) -> List[substra.sdk.models.Aggregatetuple]
+login(self, username, password)
 ```
-List aggregatetuples, the returned object is described
-in the [models.Aggregatetuple](sdk_models.md#Aggregatetuple) model
-## list_composite_traintuple
-```python
-Client.list_composite_traintuple(self, filters=None) -> List[substra.sdk.models.CompositeTraintuple]
-```
-List composite traintuples, the returned object is described
-in the [models.CompositeTraintuple](sdk_models.md#CompositeTraintuple) model
-## list_node
-```python
-Client.list_node(self, *args, **kwargs) -> List[substra.sdk.models.Node]
-```
-List nodes, the returned object is described
-in the [models.Node](sdk_models.md#Node) model
+
+Login to a remote server. 
 ## update_compute_plan
 ```python
-Client.update_compute_plan(self, compute_plan_id: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
+update_compute_plan(self, compute_plan_id: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
 ```
-Update compute plan.
 
+Update compute plan.
 As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
-Args:
-
-    compute_plan_id (str): Id of the compute plan
-
-    data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
-        it must have the same keys as specified in
-        [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
-
-    auto_batching (bool, optional): Set 'auto_batching' to False to upload all
-        the tuples of the compute plan at once. Defaults to True.
-
-    batch_size (int, optional): If 'auto_batching' is True, change `batch_size`
-        to define the number of tuples uploaded in each batch (default 20).
+Arguments:
+ - compute_plan_id(str, required): Id of the compute plan
+ - data(Union[dict, schemas.UpdateComputePlanSpec], required): If it is a dict,
+it must have the same keys as specified in
+[schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
+ - auto_batching(bool, optional): Set 'auto_batching' to False to upload all
+the tuples of the compute plan at once. Defaults to True.
+ - batch_size(int, optional): If 'auto_batching' is True, change `batch_size`
+to define the number of tuples uploaded in each batch (default 20).
 
 Returns:
-    models.ComputePlan: updated compute plan, as described in the
-    [models.ComputePlan](sdk_models.md#ComputePlan) model
 
-## link_dataset_with_objective
-```python
-Client.link_dataset_with_objective(self, dataset_key: str, objective_key: str) -> str
-```
-Link dataset with objective.
-## link_dataset_with_data_samples
-```python
-Client.link_dataset_with_data_samples(self, dataset_key: str, data_sample_keys: str) -> List[str]
-```
-Link dataset with data samples.
-## download_dataset
-```python
-Client.download_dataset(self, key: str, destination_folder: str) -> None
-```
-Download data manager resource.
-
-Download opener script in destination folder.
-
-## download_algo
-```python
-Client.download_algo(self, key: str, destination_folder: str) -> None
-```
-Download algo resource.
-
-Download algo package in destination folder.
-
-## download_aggregate_algo
-```python
-Client.download_aggregate_algo(self, key: str, destination_folder: str) -> None
-```
-Download aggregate algo resource.
-
-Download aggregate algo package in destination folder.
-
-## download_composite_algo
-```python
-Client.download_composite_algo(self, key: str, destination_folder: str) -> None
-```
-Download composite algo resource.
-
-Download composite algo package in destination folder.
-
-## download_objective
-```python
-Client.download_objective(self, key: str, destination_folder: str) -> None
-```
-Download objective resource.
-
-Download metrics script in destination folder.
-
-## describe_algo
-```python
-Client.describe_algo(self, key: str) -> str
-```
-Get algo description.
-## describe_aggregate_algo
-```python
-Client.describe_aggregate_algo(self, key: str) -> str
-```
-Get aggregate algo description.
-## describe_composite_algo
-```python
-Client.describe_composite_algo(self, key: str) -> str
-```
-Get composite algo description.
-## describe_dataset
-```python
-Client.describe_dataset(self, key: str) -> str
-```
-Get dataset description.
-## describe_objective
-```python
-Client.describe_objective(self, key: str) -> str
-```
-Get objective description.
-## leaderboard
-```python
-Client.leaderboard(self, objective_key: str, sort: str = 'desc') -> str
-```
-Get objective leaderboard
-## cancel_compute_plan
-```python
-Client.cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
-```
-Cancel execution of compute plan, the returned object is described
-in the [models.ComputePlan](sdk_models.md#ComputePlan) model
+ - models.ComputePlan: updated compute plan, as described in the
+[models.ComputePlan](sdk_models.md#ComputePlan) model
 # retry_on_exception
 ```python
 retry_on_exception(exceptions, timeout=300)
 ```
+
 Retry function in case of exception(s).
 
 Arguments:
-    exceptions: list of exception types that trigger a retry
-    timeout (int): timeout in seconds
+ - exceptions(list, required): list of exception types that trigger a retry
+ - timeout(int, optional): timeout in seconds
 
-Example:
-
+Examples:
 ```python
 from substra.sdk import exceptions, retry_on_exception
 
@@ -620,4 +606,3 @@ retry = retry_on_exception(
         )
 retry(my_function)(arg1, arg2)
 ```
-

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -8,20 +8,20 @@ Client(url: Union[str, NoneType] = None, token: Union[str, NoneType] = None, ret
 Create a client
 
 **Arguments:**
- - `url` `(str, optional)`: URL of the Substra platform. Mandatory
+ - `url (str, optional)`: URL of the Substra platform. Mandatory
 to connect to a Substra platform. If no URL is given debug must be True and all
 assets must be created locally.
 Defaults to None.
- - `token` `(str, optional)`: Token to authenticate to the Substra platform.
+ - `token (str, optional)`: Token to authenticate to the Substra platform.
 If no token is given, use the 'login' function to authenticate.
 Defaults to None.
- - `retry_timeout` `(int, optional)`: Number of seconds before attempting a retry call in case
+ - `retry_timeout (int, optional)`: Number of seconds before attempting a retry call in case
 of timeout.
 Defaults to 5 minutes.
- - `insecure` `(bool, optional)`: If True, the client can call a not-certifed backend. This is
+ - `insecure (bool, optional)`: If True, the client can call a not-certifed backend. This is
 for development purposes.
 Defaults to False.
- - `debug` `(bool, optional)`: Whether to use the default or debug mode.
+ - `debug (bool, optional)`: Whether to use the default or debug mode.
 In debug mode, new assets are created locally but can access assets from
 the deployed Substra platform. The platform is in read-only mode.
 Defaults to False.
@@ -40,16 +40,16 @@ If an aggregate algo with the same archive file already exists, an `AlreadyExist
 exception will be raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
+ - `data (Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## add_aggregatetuple
 ```python
 add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpec], exist_ok: bool = False) -> str
@@ -61,16 +61,16 @@ An `AlreadyExists` exception will be raised if an aggregatetuple already exists 
 * and was created through the same node you are using
 
 **Arguments:**
- - `data` `(Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in
 [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## add_algo
 ```python
 add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec], exist_ok: bool = False) -> str
@@ -81,14 +81,14 @@ If an algo with the same archive file already exists, an `AlreadyExists` excepti
 raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
+ - `data (Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
 as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will be
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will be
 ignored and the existing asset key will be returned. Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the algo
+ - `str`: Key of the algo
 ## add_composite_algo
 ```python
 add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec], exist_ok: bool = False) -> str
@@ -99,15 +99,15 @@ If a composite algo with the same archive file already exists, an `AlreadyExists
 exception will be raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## add_composite_traintuple
 ```python
 add_composite_traintuple(self, data: Union[dict, substra.sdk.schemas.CompositeTraintupleSpec], exist_ok: bool = False) -> str
@@ -123,16 +123,16 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
 * and was created through the same node you are using
 
 **Arguments:**
- - `data` `(Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
+ - `data (Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
 same keys as specified in
 [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## add_compute_plan
 ```python
 add_compute_plan(self, data: Union[dict, substra.sdk.schemas.ComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
@@ -143,16 +143,16 @@ As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.ComputePlanSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.ComputePlanSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
- - `auto_batching` `(bool, optional)`: Set 'auto_batching' to False to upload all the tuples of
+ - `auto_batching (bool, optional)`: Set 'auto_batching' to False to upload all the tuples of
 the compute plan at once. Defaults to True.
- - `batch_size` `(int, optional)`: If 'auto_batching' is True, change `batch_size` to define
+ - `batch_size (int, optional)`: If 'auto_batching' is True, change `batch_size` to define
 the number oftuples uploaded in each batch (default 20).
 
-**Returns**:
+**Returns:**
 
- - models.ComputePlan: Created compute plan
+ - `models.ComputePlan`: Created compute plan
 ## add_data_sample
 ```python
 add_data_sample(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True, exist_ok: bool = False) -> str
@@ -163,9 +163,9 @@ If a data sample with the same content already exists, an `AlreadyExists` except
 raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.DataSampleSpec], required)`: data sample to add. If it is a dict,
+ - `data (Union[dict, schemas.DataSampleSpec], required)`: data sample to add. If it is a dict,
 it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
- - `local` `(bool, optional)`: If `local` is true, `path` must refer to a directory located
+ - `local (bool, optional)`: If `local` is true, `path` must refer to a directory located
 on the local filesystem. The file content will be transferred to the server
 through an HTTP query, so this mode should be used for relatively small files
 (<10mo).
@@ -173,12 +173,12 @@ through an HTTP query, so this mode should be used for relatively small files
 If `local` is false, `path` must refer to a directory located on the server
 filesystem. This directory must be accessible (readable) by the server.  This
 mode is well suited for all kind of file sizes. Defaults to True.
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will
 be ignored and the existing asset key will be returned. Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: key of the data sample
+ - `str`: key of the data sample
 ## add_data_samples
 ```python
 add_data_samples(self, data: Union[dict, substra.sdk.schemas.DataSampleSpec], local: bool = True) -> List[str]
@@ -194,16 +194,16 @@ If data samples with the same content as any of the paths already exists, an `Al
 exception will be raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.DataSampleSpec], required)`: data samples to add. If it is a dict,
+ - `data (Union[dict, schemas.DataSampleSpec], required)`: data samples to add. If it is a dict,
 it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
 The `paths` in the data dictionary must be a list of paths where each path
 points to a directory representing one data sample.
- - `local` `(bool, optional)`:  Please refer to the method `Client.add_data_sample`.
+ - `local (bool, optional)`:  Please refer to the method `Client.add_data_sample`.
 Defaults to True.
 
-**Returns**:
+**Returns:**
 
- - List[str]: List of the data sample keys
+ - `List[str]`: List of the data sample keys
 ## add_dataset
 ```python
 add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec], exist_ok: bool = False)
@@ -214,15 +214,15 @@ If a dataset with the same opener already exists, an `AlreadyExists` exception w
 raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.DatasetSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.DatasetSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
 will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the dataset
+ - `str`: Key of the dataset
 ## add_objective
 ```python
 add_objective(self, data: Union[dict, substra.sdk.schemas.ObjectiveSpec], exist_ok: bool = False) -> str
@@ -233,14 +233,14 @@ If an objective with the same description already exists, an `AlreadyExists` exc
 be raised.
 
 **Arguments:**
- - `data` `(Union[dict, schemas.ObjectiveSpec], required)`: If it is a dict, it must have the same keys
+ - `data (Union[dict, schemas.ObjectiveSpec], required)`: If it is a dict, it must have the same keys
 as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
 will be ignored and the existing asset key will be returned. Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the objective
+ - `str`: Key of the objective
 ## add_testtuple
 ```python
 add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec], exist_ok: bool = False) -> str
@@ -253,15 +253,15 @@ An `AlreadyExists` exception will be raised if a testtuple already exists that:
 * and was created through the same node you are using
 
 **Arguments:**
- - `data` `(Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## add_traintuple
 ```python
 add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec], exist_ok: bool = False) -> str
@@ -273,15 +273,15 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
 * and was created through the same node you are using
 
 **Arguments:**
- - `data` `(Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same
+ - `data (Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
- - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok (bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - str: Key of the asset
+ - `str`: Key of the asset
 ## cancel_compute_plan
 ```python
 cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
@@ -362,25 +362,25 @@ from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.
 Returns a new Client configured with profile data from configuration files.
 
 **Arguments:**
- - `profile_name` `(str, optional)`: Name of the profile to load.
+ - `profile_name (str, optional)`: Name of the profile to load.
 Defaults to 'default'.
- - `config_path` `(Union[str, pathlib.Path], optional)`: Path to the
+ - `config_path (Union[str, pathlib.Path], optional)`: Path to the
 configuration file.
 Defaults to '~/.substra'.
- - `tokens_path` `(Union[str, pathlib.Path], optional)`: Path to the tokens file.
+ - `tokens_path (Union[str, pathlib.Path], optional)`: Path to the tokens file.
 Defaults to '~/.substra-tokens'.
- - `token` `(str, optional)`: Token to use for authentication (will be used
+ - `token (str, optional)`: Token to use for authentication (will be used
 instead of any token found at tokens_path). Defaults to None.
- - `retry_timeout` `(int, optional)`: Number of seconds before attempting a retry call in case
+ - `retry_timeout (int, optional)`: Number of seconds before attempting a retry call in case
 of timeout. Defaults to 5 minutes.
- - `debug` `(bool, required)`: Whether to use the default or debug mode. In debug mode, new assets are
+ - `debug (bool, required)`: Whether to use the default or debug mode. In debug mode, new assets are
 created locally but can get remote assets. The deployed platform is in
 read-only mode.
 Defaults to False.
 
-**Returns**:
+**Returns:**
 
- - Client: The new client.
+ - `Client`: The new client.
 ## get_aggregate_algo
 ```python
 get_aggregate_algo(self, key: str) -> substra.sdk.models.AggregateAlgo
@@ -569,18 +569,18 @@ As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
 **Arguments:**
- - `compute_plan_id` `(str, required)`: Id of the compute plan
- - `data` `(Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
+ - `compute_plan_id (str, required)`: Id of the compute plan
+ - `data (Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
- - `auto_batching` `(bool, optional)`: Set 'auto_batching' to False to upload all
+ - `auto_batching (bool, optional)`: Set 'auto_batching' to False to upload all
 the tuples of the compute plan at once. Defaults to True.
- - `batch_size` `(int, optional)`: If 'auto_batching' is True, change `batch_size`
+ - `batch_size (int, optional)`: If 'auto_batching' is True, change `batch_size`
 to define the number of tuples uploaded in each batch (default 20).
 
-**Returns**:
+**Returns:**
 
- - models.ComputePlan: updated compute plan, as described in the
+ - `models.ComputePlan`: updated compute plan, as described in the
 [models.ComputePlan](sdk_models.md#ComputePlan) model
 # retry_on_exception
 ```python
@@ -590,10 +590,10 @@ retry_on_exception(exceptions, timeout=300)
 Retry function in case of exception(s).
 
 **Arguments:**
- - `exceptions` `(list, required)`: list of exception types that trigger a retry
- - `timeout` `(int, optional)`: timeout in seconds
+ - `exceptions (list, required)`: list of exception types that trigger a retry
+ - `timeout (int, optional)`: timeout in seconds
 
-**Examples**:
+**Examples:**
 ```python
 from substra.sdk import exceptions, retry_on_exception
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -7,21 +7,21 @@ Client(url: Union[str, NoneType] = None, token: Union[str, NoneType] = None, ret
 
 Create a client
 
-Arguments:
- - url(str, optional): URL of the Substra platform. Mandatory
+**Arguments:**
+ - `url` `(str, optional)`: URL of the Substra platform. Mandatory
 to connect to a Substra platform. If no URL is given debug must be True and all
 assets must be created locally.
 Defaults to None.
- - token(str, optional): Token to authenticate to the Substra platform.
+ - `token` `(str, optional)`: Token to authenticate to the Substra platform.
 If no token is given, use the 'login' function to authenticate.
 Defaults to None.
- - retry_timeout(int, optional): Number of seconds before attempting a retry call in case
+ - `retry_timeout` `(int, optional)`: Number of seconds before attempting a retry call in case
 of timeout.
 Defaults to 5 minutes.
- - insecure(bool, optional): If True, the client can call a not-certifed backend. This is
+ - `insecure` `(bool, optional)`: If True, the client can call a not-certifed backend. This is
 for development purposes.
 Defaults to False.
- - debug(bool, optional): Whether to use the default or debug mode.
+ - `debug` `(bool, optional)`: Whether to use the default or debug mode.
 In debug mode, new assets are created locally but can access assets from
 the deployed Substra platform. The platform is in read-only mode.
 Defaults to False.
@@ -39,15 +39,15 @@ Create new aggregate algo asset.
 If an aggregate algo with the same archive file already exists, an `AlreadyExists`
 exception will be raised.
 
-Arguments:
- - data(Union[dict, schemas.AggregateAlgoSpec], required): If it is a dict,
+**Arguments:**
+ - `data` `(Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## add_aggregatetuple
@@ -60,15 +60,15 @@ An `AlreadyExists` exception will be raised if an aggregatetuple already exists 
 * has the same `algo_key` and `in_models_keys`
 * and was created through the same node you are using
 
-Arguments:
- - data(Union[dict, schemas.AggregatetupleSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in
 [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## add_algo
@@ -80,13 +80,13 @@ Create new algo asset.
 If an algo with the same archive file already exists, an `AlreadyExists` exception will be
 raised.
 
-Arguments:
- - data(Union[dict, schemas.AlgoSpec], required): If it is a dict, it must have the same keys
+**Arguments:**
+ - `data` `(Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
 as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will be
 ignored and the existing asset key will be returned. Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the algo
 ## add_composite_algo
@@ -98,14 +98,14 @@ Create new composite algo asset.
 If a composite algo with the same archive file already exists, an `AlreadyExists`
 exception will be raised.
 
-Arguments:
- - data(Union[dict, schemas.CompositeAlgoSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## add_composite_traintuple
@@ -122,15 +122,15 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
   `in_head_models_key` and `in_trunk_model_key`
 * and was created through the same node you are using
 
-Arguments:
- - data(Union[dict, schemas.CompositeTraintupleSpec], required): If it is a dict, it must have the
+**Arguments:**
+ - `data` `(Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
 same keys as specified in
 [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## add_compute_plan
@@ -142,15 +142,15 @@ Create new compute plan asset.
 As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
-Arguments:
- - data(Union[dict, schemas.ComputePlanSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.ComputePlanSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
- - auto_batching(bool, optional): Set 'auto_batching' to False to upload all the tuples of
+ - `auto_batching` `(bool, optional)`: Set 'auto_batching' to False to upload all the tuples of
 the compute plan at once. Defaults to True.
- - batch_size(int, optional): If 'auto_batching' is True, change `batch_size` to define
+ - `batch_size` `(int, optional)`: If 'auto_batching' is True, change `batch_size` to define
 the number oftuples uploaded in each batch (default 20).
 
-Returns:
+**Returns**:
 
  - models.ComputePlan: Created compute plan
 ## add_data_sample
@@ -162,10 +162,10 @@ Create a new data sample asset and return its key.
 If a data sample with the same content already exists, an `AlreadyExists` exception will be
 raised.
 
-Arguments:
- - data(Union[dict, schemas.DataSampleSpec], required): data sample to add. If it is a dict,
+**Arguments:**
+ - `data` `(Union[dict, schemas.DataSampleSpec], required)`: data sample to add. If it is a dict,
 it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
- - local(bool, optional): If `local` is true, `path` must refer to a directory located
+ - `local` `(bool, optional)`: If `local` is true, `path` must refer to a directory located
 on the local filesystem. The file content will be transferred to the server
 through an HTTP query, so this mode should be used for relatively small files
 (<10mo).
@@ -173,10 +173,10 @@ through an HTTP query, so this mode should be used for relatively small files
 If `local` is false, `path` must refer to a directory located on the server
 filesystem. This directory must be accessible (readable) by the server.  This
 mode is well suited for all kind of file sizes. Defaults to True.
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions will
 be ignored and the existing asset key will be returned. Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: key of the data sample
 ## add_data_samples
@@ -193,15 +193,15 @@ better control in case of failures.
 If data samples with the same content as any of the paths already exists, an `AlreadyExists`
 exception will be raised.
 
-Arguments:
- - data(Union[dict, schemas.DataSampleSpec], required): data samples to add. If it is a dict,
+**Arguments:**
+ - `data` `(Union[dict, schemas.DataSampleSpec], required)`: data samples to add. If it is a dict,
 it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
 The `paths` in the data dictionary must be a list of paths where each path
 points to a directory representing one data sample.
- - local(bool, optional):  Please refer to the method `Client.add_data_sample`.
+ - `local` `(bool, optional)`:  Please refer to the method `Client.add_data_sample`.
 Defaults to True.
 
-Returns:
+**Returns**:
 
  - List[str]: List of the data sample keys
 ## add_dataset
@@ -213,14 +213,14 @@ Create new dataset asset and return its key.
 If a dataset with the same opener already exists, an `AlreadyExists` exception will be
 raised.
 
-Arguments:
- - data(Union[dict, schemas.DatasetSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.DatasetSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
 will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the dataset
 ## add_objective
@@ -232,13 +232,13 @@ Create new objective asset.
 If an objective with the same description already exists, an `AlreadyExists` exception will
 be raised.
 
-Arguments:
- - data(Union[dict, schemas.ObjectiveSpec], required): If it is a dict, it must have the same keys
+**Arguments:**
+ - `data` `(Union[dict, schemas.ObjectiveSpec], required)`: If it is a dict, it must have the same keys
 as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists` exceptions
 will be ignored and the existing asset key will be returned. Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the objective
 ## add_testtuple
@@ -252,14 +252,14 @@ An `AlreadyExists` exception will be raised if a testtuple already exists that:
   `test_data_sample_keys`
 * and was created through the same node you are using
 
-Arguments:
- - data(Union[dict, schemas.TesttupleSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## add_traintuple
@@ -272,14 +272,14 @@ An `AlreadyExists` exception will be raised if a traintuple already exists that:
 * has the same `algo_key`, `data_manager_key`, `train_data_sample_keys` and `in_models_keys`
 * and was created through the same node you are using
 
-Arguments:
- - data(Union[dict, schemas.TraintupleSpec], required): If it is a dict, it must have the same
+**Arguments:**
+ - `data` `(Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same
 keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
- - exist_ok(bool, optional): If `exist_ok` is true, `AlreadyExists`
+ - `exist_ok` `(bool, optional)`: If `exist_ok` is true, `AlreadyExists`
 exceptions will be ignored and the existing asset key will be returned.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - str: Key of the asset
 ## cancel_compute_plan
@@ -361,24 +361,24 @@ from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.
 
 Returns a new Client configured with profile data from configuration files.
 
-Arguments:
- - profile_name(str, optional): Name of the profile to load.
+**Arguments:**
+ - `profile_name` `(str, optional)`: Name of the profile to load.
 Defaults to 'default'.
- - config_path(Union[str, pathlib.Path], optional): Path to the
+ - `config_path` `(Union[str, pathlib.Path], optional)`: Path to the
 configuration file.
 Defaults to '~/.substra'.
- - tokens_path(Union[str, pathlib.Path], optional): Path to the tokens file.
+ - `tokens_path` `(Union[str, pathlib.Path], optional)`: Path to the tokens file.
 Defaults to '~/.substra-tokens'.
- - token(str, optional): Token to use for authentication (will be used
+ - `token` `(str, optional)`: Token to use for authentication (will be used
 instead of any token found at tokens_path). Defaults to None.
- - retry_timeout(int, optional): Number of seconds before attempting a retry call in case
+ - `retry_timeout` `(int, optional)`: Number of seconds before attempting a retry call in case
 of timeout. Defaults to 5 minutes.
- - debug(bool, required): Whether to use the default or debug mode. In debug mode, new assets are
+ - `debug` `(bool, required)`: Whether to use the default or debug mode. In debug mode, new assets are
 created locally but can get remote assets. The deployed platform is in
 read-only mode.
 Defaults to False.
 
-Returns:
+**Returns**:
 
  - Client: The new client.
 ## get_aggregate_algo
@@ -568,17 +568,17 @@ Update compute plan.
 As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
-Arguments:
- - compute_plan_id(str, required): Id of the compute plan
- - data(Union[dict, schemas.UpdateComputePlanSpec], required): If it is a dict,
+**Arguments:**
+ - `compute_plan_id` `(str, required)`: Id of the compute plan
+ - `data` `(Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
- - auto_batching(bool, optional): Set 'auto_batching' to False to upload all
+ - `auto_batching` `(bool, optional)`: Set 'auto_batching' to False to upload all
 the tuples of the compute plan at once. Defaults to True.
- - batch_size(int, optional): If 'auto_batching' is True, change `batch_size`
+ - `batch_size` `(int, optional)`: If 'auto_batching' is True, change `batch_size`
 to define the number of tuples uploaded in each batch (default 20).
 
-Returns:
+**Returns**:
 
  - models.ComputePlan: updated compute plan, as described in the
 [models.ComputePlan](sdk_models.md#ComputePlan) model
@@ -589,11 +589,11 @@ retry_on_exception(exceptions, timeout=300)
 
 Retry function in case of exception(s).
 
-Arguments:
- - exceptions(list, required): list of exception types that trigger a retry
- - timeout(int, optional): timeout in seconds
+**Arguments:**
+ - `exceptions` `(list, required)`: list of exception types that trigger a retry
+ - `timeout` `(int, optional)`: timeout in seconds
 
-Examples:
+**Examples**:
 ```python
 from substra.sdk import exceptions, retry_on_exception
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click>=7.1.1
-pydoc-markdown==2.0.5
+docstring-parser==0.7.3

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -56,24 +56,19 @@ class Client(object):
     """Create a client
 
     Args:
-
         url (str, optional): URL of the Substra platform. Mandatory
             to connect to a Substra platform. If no URL is given debug must be True and all
             assets must be created locally.
             Defaults to None.
-
         token (str, optional): Token to authenticate to the Substra platform.
             If no token is given, use the 'login' function to authenticate.
             Defaults to None.
-
         retry_timeout (int, optional): Number of seconds before attempting a retry call in case
             of timeout.
             Defaults to 5 minutes.
-
         insecure (bool, optional): If True, the client can call a not-certifed backend. This is
             for development purposes.
             Defaults to False.
-
         debug (bool, optional): Whether to use the default or debug mode.
             In debug mode, new assets are created locally but can access assets from
             the deployed Substra platform. The platform is in read-only mode.
@@ -155,23 +150,17 @@ class Client(object):
         """Returns a new Client configured with profile data from configuration files.
 
         Args:
-
             profile_name (str, optional): Name of the profile to load.
                 Defaults to 'default'.
-
             config_path (Union[str, pathlib.Path], optional): Path to the
                 configuration file.
                 Defaults to '~/.substra'.
-
             tokens_path (Union[str, pathlib.Path], optional): Path to the tokens file.
                 Defaults to '~/.substra-tokens'.
-
             token (str, optional): Token to use for authentication (will be used
                 instead of any token found at tokens_path). Defaults to None.
-
             retry_timeout (int, optional): Number of seconds before attempting a retry call in case
                 of timeout. Defaults to 5 minutes.
-
             debug (bool): Whether to use the default or debug mode. In debug mode, new assets are
                 created locally but can get remote assets. The deployed platform is in
                 read-only mode.
@@ -180,6 +169,7 @@ class Client(object):
         Returns:
             Client: The new client.
         """
+
         config_path = os.path.expanduser(config_path)
         profile = cfg.ConfigManager(config_path).get_profile(profile_name)
         if not token:
@@ -209,22 +199,18 @@ class Client(object):
         raised.
 
         Args:
-
             data (Union[dict, schemas.DataSampleSpec]): data sample to add. If it is a dict,
-            it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
-
-            local (bool, optional):
-                If `local` is true, `path` must refer to a directory located on the local
-                filesystem. The file content will be transferred to the server through an
-                HTTP query, so this mode should be used for relatively small files (<10mo).
+                it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
+            local (bool, optional): If `local` is true, `path` must refer to a directory located
+                on the local filesystem. The file content will be transferred to the server
+                through an HTTP query, so this mode should be used for relatively small files
+                (<10mo).
 
                 If `local` is false, `path` must refer to a directory located on the server
                 filesystem. This directory must be accessible (readable) by the server.  This
                 mode is well suited for all kind of file sizes. Defaults to True.
-
-            exist_ok (bool, optional):
-                If `exist_ok` is true, `AlreadyExists` exceptions will be ignored and the
-                existing asset key will be returned. Defaults to False.
+            exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will
+                be ignored and the existing asset key will be returned. Defaults to False.
 
         Returns:
             str: key of the data sample
@@ -260,13 +246,10 @@ class Client(object):
         exception will be raised.
 
         Args:
-
             data (Union[dict, schemas.DataSampleSpec]): data samples to add. If it is a dict,
                 it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).
-
                 The `paths` in the data dictionary must be a list of paths where each path
                 points to a directory representing one data sample.
-
             local (bool, optional):  Please refer to the method `Client.add_data_sample`.
                 Defaults to True.
 
@@ -295,10 +278,8 @@ class Client(object):
         raised.
 
         Args:
-
             data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
                 will be ignored and the existing asset key will be returned.
                 Defaults to False.
@@ -321,10 +302,8 @@ class Client(object):
         be raised.
 
         Args:
-
             data (Union[dict, schemas.ObjectiveSpec]): If it is a dict, it must have the same keys
                 as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions
                 will be ignored and the existing asset key will be returned. Defaults to False.
 
@@ -342,10 +321,8 @@ class Client(object):
         raised.
 
         Args:
-
             data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
                 as specified in [schemas.AlgoSpec](sdk_schemas.md#AlgoSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists` exceptions will be
                 ignored and the existing asset key will be returned. Defaults to False.
 
@@ -367,16 +344,14 @@ class Client(object):
         exception will be raised.
 
         Args:
-
             data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
                 it must have the same keys as specified in
                 [schemas.AggregateAlgoSpec](sdk_schemas.md#AggregateAlgoSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.AggregateAlgoSpec, data)
@@ -394,15 +369,13 @@ class Client(object):
         exception will be raised.
 
         Args:
-
             data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.CompositeAlgoSpec, data)
@@ -421,15 +394,13 @@ class Client(object):
         * and was created through the same node you are using
 
         Args:
-
             data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.TraintupleSpec, data)
@@ -448,16 +419,14 @@ class Client(object):
         * and was created through the same node you are using
 
         Args:
-
             data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
                 keys as specified in
                 [schemas.AggregatetupleSpec](sdk_schemas.md#AggregatetupleSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.AggregatetupleSpec, data)
@@ -480,16 +449,14 @@ class Client(object):
         * and was created through the same node you are using
 
         Args:
-
             data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
                 same keys as specified in
                 [schemas.CompositeTraintupleSpec](sdk_schemas.md#CompositeTraintupleSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.CompositeTraintupleSpec, data)
@@ -509,15 +476,13 @@ class Client(object):
         * and was created through the same node you are using
 
         Args:
-
             data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.TesttupleSpec](sdk_schemas.md#TesttupleSpec).
-
             exist_ok (bool, optional): If `exist_ok` is true, `AlreadyExists`
                 exceptions will be ignored and the existing asset key will be returned.
                 Defaults to False.
 
-         Returns:
+        Returns:
             str: Key of the asset
         """
         spec = self._get_spec(schemas.TesttupleSpec, data)
@@ -536,13 +501,10 @@ class Client(object):
         traintuples cannot be made public.
 
         Args:
-
             data (Union[dict, schemas.ComputePlanSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.ComputePlanSpec](sdk_schemas.md#ComputePlanSpec).
-
             auto_batching (bool, optional): Set 'auto_batching' to False to upload all the tuples of
                 the compute plan at once. Defaults to True.
-
             batch_size (int, optional): If 'auto_batching' is True, change `batch_size` to define
                 the number oftuples uploaded in each batch (default 20).
 
@@ -702,16 +664,12 @@ class Client(object):
         traintuples cannot be made public.
 
         Args:
-
             compute_plan_id (str): Id of the compute plan
-
             data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
                 it must have the same keys as specified in
                 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
-
             auto_batching (bool, optional): Set 'auto_batching' to False to upload all
                 the tuples of the compute plan at once. Defaults to True.
-
             batch_size (int, optional): If 'auto_batching' is True, change `batch_size`
                 to define the number of tuples uploaded in each batch (default 20).
 

--- a/substra/sdk/utils.py
+++ b/substra/sdk/utils.py
@@ -151,24 +151,23 @@ def parse_filters(filters):
 def retry_on_exception(exceptions, timeout=300):
     """Retry function in case of exception(s).
 
-    Arguments:
-        exceptions: list of exception types that trigger a retry
-        timeout (int): timeout in seconds
+    Args:
+        exceptions (list): list of exception types that trigger a retry
+        timeout (int, optional): timeout in seconds
 
     Example:
+        ```python
+        from substra.sdk import exceptions, retry_on_exception
 
-    ```python
-    from substra.sdk import exceptions, retry_on_exception
+        def my_function(arg1, arg2):
+            pass
 
-    def my_function(arg1, arg2):
-        pass
-
-    retry = retry_on_exception(
-                exceptions=(exceptions.RequestTimeout),
-                timeout=300,
-            )
-    retry(my_function)(arg1, arg2)
-    ```
+        retry = retry_on_exception(
+                    exceptions=(exceptions.RequestTimeout),
+                    timeout=300,
+                )
+        retry(my_function)(arg1, arg2)
+        ```
     """
     def _retry(f):
         @functools.wraps(f)


### PR DESCRIPTION
The previous way of generating the SDK doc meant that we had to change from the default Google docstring.

For example, this:
```python
def my_func():
       """Returns a new Client configured with profile data from configuration files.

        Args:
            profile_name (str, optional): Name of the profile to load.
                Defaults to 'default'.
            retry_timeout (int, optional): Number of seconds before attempting a retry call in case
                of timeout. Defaults to 5 minutes.

        Returns:
            Client: The new client.
        """
```

Gave something like this: 

```
Returns a new Client configured with profile data from configuration files.

Args:
    profile_name (str, optional): Name of the profile to load. Defaults to 'default'. retry_timeout (int, optional): Number of seconds before attempting a retry call in case of timeout. Defaults to 5 minutes.

Returns: Client: The new client.
```

so we had to insert newlines in the docstring: 
```python
def my_func():
       """Returns a new Client configured with profile data from configuration files.

        Args:

            profile_name (str, optional): Name of the profile to load.
                Defaults to 'default'.

            retry_timeout (int, optional): Number of seconds before attempting a retry call in case
                of timeout. Defaults to 5 minutes.

        Returns:

            Client: The new client.
        """
```

Furthermore, any link inserted in the docstring, like `it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).` would not be rendered.

So, to stop having to change the docstring for the markdown, I updated the way the markdown was generated for the SDK. Instead of using pydocmd, it uses a manual script with the [docstring-parser](https://pypi.org/project/docstring-parser/) library to parse the docstring and display the arguments as a list. 

## What does it fix 

This fixes the links in the doc, for example: https://github.com/SubstraFoundation/substra/blob/master/references/sdk.md#add_data_samples
`data (Union[dict, schemas.DataSampleSpec]): data samples to add. If it is a dict,
    it must follow the [DataSampleSpec schema](sdk_schemas.md#DataSampleSpec).`

And the annoying newlines that we had to add in the Client method docstrings. 