### PR TITLE
Fix/docker import

### DIFF
--- a/substra/sdk/backends/local/compute/spawner.py
+++ b/substra/sdk/backends/local/compute/spawner.py
@@ -84,3 +84,7 @@ class DockerSpawner:
 
         container.remove()
         return execution_logs
+
+
+def get():
+    return DockerSpawner()

--- a/substra/sdk/backends/local/compute/spawner.py
+++ b/substra/sdk/backends/local/compute/spawner.py
@@ -20,9 +20,6 @@ import docker
 
 from substra.sdk import exceptions
 
-_DOCKER = docker.from_env()
-_USER = os.getuid()
-
 
 def _untar(archive, to_):
     with tarfile.open(archive) as tf:
@@ -51,19 +48,23 @@ class ExecutionError(Exception):
 class DockerSpawner:
     """Wrapper around docker daemon to execute a command in a container."""
 
+    def __init__(self):
+        self._docker = docker.from_env()
+        self._user = os.getuid()
+
     def spawn(self, name, archive_path, command, volumes=None, envs=None):
         """Spawn a docker container (blocking)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             _uncompress(archive_path, tmpdir)
-            _DOCKER.images.build(path=tmpdir, tag=name, rm=True)
+            self._docker.images.build(path=tmpdir, tag=name, rm=True)
 
-        container = _DOCKER.containers.run(
+        container = self._docker.containers.run(
             name,
             command=command,
             volumes=volumes or {},
             environment=envs,
             remove=False,
-            user=_USER,
+            user=self._user,
             userns_mode="host",
             detach=True,
             tty=True,
@@ -83,7 +84,3 @@ class DockerSpawner:
 
         container.remove()
         return execution_logs
-
-
-def get():
-    return DockerSpawner()


### PR DESCRIPTION
Fix the following bug: 

> we have to run the substra sdk in a docker container (this is the only way to install python in this environment). When we import substra in our script we end up with the traceback attached.
> It looks like we are trying to connect to the docker socket event if we don’t want to use the local backend and docker isn’t available.

The following line is executed when substra is imported:
`_DOCKER = docker.from_env()` in the file `substra/sdk/backends/local/compute/spawner.py`

- tested with substra-tests `pytest tests --local`
- not tested on a deployed instance