### PR TITLE
Add support for 'multi nodes' to the debug mode

### DIFF
--- a/references/sdk.md
+++ b/references/sdk.md
@@ -36,6 +36,8 @@ add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec
 ```
 
 Create new aggregate algo asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
@@ -51,6 +53,8 @@ add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpe
 ```
 
 Create a new aggregate tuple asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
@@ -66,6 +70,8 @@ add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec]) -> str
 ```
 
 Create new algo asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
@@ -80,6 +86,8 @@ add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec
 ```
 
 Create new composite algo asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
@@ -96,6 +104,9 @@ add_composite_traintuple(self, data: Union[dict, substra.sdk.schemas.CompositeTr
 Create new composite traintuple asset.
 As specified in the data structure, output trunk models cannot be made
 public.
+
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
@@ -175,9 +186,10 @@ add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec])
 ```
 
 Create new dataset asset and return its key.
-In debug mode, add the following key:`substra.DEBUG_OWNER` to the metadata,
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
 the value becomes the node owner of the data, and all tuples using this data
-have their worker set to this node.
+have their worker set to this node. This has no impact on how the tuples are
+executed except if chainkey support is enabled.
 
 **Arguments:**
  - `data (Union[dict, schemas.DatasetSpec], required)`: If it is a dict, it must have the same
@@ -192,6 +204,8 @@ add_objective(self, data: Union[dict, substra.sdk.schemas.ObjectiveSpec]) -> str
 ```
 
 Create new objective asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.ObjectiveSpec], required)`: If it is a dict, it must have the same keys
@@ -206,6 +220,8 @@ add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec]) -> str
 ```
 
 Create new testtuple asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
@@ -220,6 +236,8 @@ add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec]) -> s
 ```
 
 Create new traintuple asset.
+In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+the value becomes the 'creator' of the objective.
 
 **Arguments:**
  - `data (Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -37,7 +37,7 @@ add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec
 
 Create new aggregate algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the aggregate algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
@@ -54,7 +54,7 @@ add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpe
 
 Create a new aggregate tuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the aggregate tuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
@@ -71,7 +71,7 @@ add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec]) -> str
 
 Create new algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
@@ -87,7 +87,7 @@ add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec
 
 Create new composite algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the composite algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
@@ -106,7 +106,7 @@ As specified in the data structure, output trunk models cannot be made
 public.
 
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the composite traintuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
@@ -221,7 +221,7 @@ add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec]) -> str
 
 Create new testtuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the testtuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
@@ -237,7 +237,7 @@ add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec]) -> s
 
 Create new traintuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the traintuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -175,7 +175,7 @@ add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec])
 ```
 
 Create new dataset asset and return its key.
-In debug mode, add the following key:`substra.sdk.DEBUG_OWNER` to the metadata,
+In debug mode, add the following key:`substra.DEBUG_OWNER` to the metadata,
 the value becomes the node owner of the data, and all tuples using this data
 have their worker set to this node.
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -175,6 +175,9 @@ add_dataset(self, data: Union[dict, substra.sdk.schemas.DatasetSpec])
 ```
 
 Create new dataset asset and return its key.
+In debug mode, add the following key:`substra.sdk.DEBUG_OWNER` to the metadata,
+the value becomes the node owner of the data, and all tuples using this data
+have their worker set to this node.
 
 **Arguments:**
  - `data (Union[dict, schemas.DatasetSpec], required)`: If it is a dict, it must have the same

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -260,7 +260,7 @@ Dataset as stored in the Objective asset
 - data_manager_key: str
 - data_sample_keys: List[str]
 - metadata: Mapping[str, str]
-- worker: Optional[str]
+- worker: str
 ```
 
 ## _Metric

--- a/substra/__init__.py
+++ b/substra/__init__.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from substra.__version__ import __version__
-from substra.sdk import Client, exceptions
+from substra.sdk import Client, exceptions, DEBUG_OWNER
 
 
 __all__ = [
     '__version__',
     'Client',
     'exceptions',
+    'DEBUG_OWNER',
 ]

--- a/substra/sdk/__init__.py
+++ b/substra/sdk/__init__.py
@@ -14,8 +14,10 @@
 
 from substra.sdk.client import Client
 from substra.sdk.utils import retry_on_exception
+from substra.sdk.backends.local.backend import DEBUG_OWNER
 
 __all__ = [
     'Client',
     'retry_on_exception',
+    'DEBUG_OWNER',
 ]

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -433,7 +433,8 @@ class Local(base.BaseBackend):
             test_dataset = {
                 "data_manager_key": spec.test_data_manager_key,
                 "data_sample_keys": spec.test_data_sample_keys,
-                "metadata": dataset.metadata
+                "metadata": dataset.metadata,
+                "worker": dataset.owner,
             }
             if not dataset.objective_key:
                 dataset.objective_key = key

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -32,6 +32,7 @@ _VOLUME_OPENER = {"bind": "/sandbox/opener/__init__.py", "mode": "ro"}
 _VOLUME_OUTPUT_PRED = {"bind": "/sandbox/pred", "mode": "rw"}
 _VOLUME_LOCAL = {"bind": "/sandbox/local", "mode": "rw"}
 _VOLUME_LOCAL_READ_ONLY = {"bind": "/sandbox/local", "mode": "ro"}
+_VOLUME_CHAINKEYS = {"bind": "/sandbox/chainkeys", "mode": "rw"}
 
 _VOLUME_INPUT_MODELS_RO = {"bind": "/sandbox/input_models", "mode": "ro"}
 _VOLUME_OUTPUT_MODELS_RW = {"bind": "/sandbox/output_models", "mode": "rw"}
@@ -54,10 +55,33 @@ def _get_address_in_container(model_key, volume, container_volume):
 class Worker:
     """ML Worker."""
 
-    def __init__(self, db: dal.DataAccess):
+    def __init__(self, db: dal.DataAccess, support_chainkeys: bool, chainkey_dir=None):
         self._wdir = os.path.join(os.getcwd(), "local-worker")
         self._db = db
         self._spawner = spawner.get()
+        self._support_chainkeys = support_chainkeys
+        self._chainkey_dir = chainkey_dir
+
+    def _get_owner(self, tuple_):
+        if isinstance(tuple_, models.Aggregatetuple):
+            return tuple_.worker
+        return tuple_.dataset.worker
+
+    def _get_chainkey_volume(self, tuple_):
+        owner = self._get_owner(tuple_)
+        compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_key)
+        tuple_chainkey_volume = self._chainkey_dir / owner / \
+            "computeplan" / compute_plan.tag / "chainkeys"
+        if not tuple_chainkey_volume.is_dir():
+            return None
+        return tuple_chainkey_volume
+
+    def _get_chainkey_env(self, tuple_):
+        owner = self._get_owner(tuple_)
+        node_name_id = json.loads((self._chainkey_dir / "node_name_id.json").read_text())
+        return {
+            'NODE_INDEX': node_name_id.get(owner, None),
+        }
 
     def _get_data_sample_paths_arg(self, data_volume, dataset):
         data_sample_paths = [
@@ -184,6 +208,10 @@ class Worker:
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL
+                if self._support_chainkeys:
+                    chainkey_volume = self._get_chainkey_volume(tuple_)
+                    if chainkey_volume is not None:
+                        volumes[chainkey_volume] = _VOLUME_CHAINKEYS
 
             if isinstance(tuple_, models.Aggregatetuple):
                 command = "aggregate"
@@ -216,10 +244,20 @@ class Worker:
                     command += " --fake-data"
                     command += f" --n-fake-samples {len(tuple_.dataset.data_sample_keys)}"
 
+            # Get the environment variables
+            envs = dict()
+            if tuple_.compute_plan_key:
+                if self._support_chainkeys:
+                    envs.update(self._get_chainkey_env(tuple_))
+
             # Execute the tuple
             container_name = f"algo-{algo.key}"
             logs = self._spawner.spawn(
-                container_name, str(algo.content.storage_address), command, volumes=volumes
+                container_name,
+                str(algo.content.storage_address),
+                command,
+                volumes=volumes,
+                envs=envs,
             )
 
             # save move output models
@@ -285,6 +323,9 @@ class Worker:
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL
+                if self._support_chainkeys:
+                    chainkey_volume = self._get_chainkey_volume(tuple_)
+                    volumes[chainkey_volume] = _VOLUME_CHAINKEYS
 
             # compute testtuple command
             command = "predict"

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -32,7 +32,7 @@ class DataAccess:
     """
 
     def __init__(self, remote_backend: typing.Optional[backend.Remote]):
-        self._db = db.get()
+        self._db = db.InMemoryDb()
         self._remote = remote_backend
         self._tmp_dir = tempfile.TemporaryDirectory(prefix="/tmp/")
 
@@ -114,9 +114,9 @@ class DataAccess:
             attr.storage_address = asset_path
             return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         if self.is_local(key):
-            return self._db.get(type_, key)
+            return self._db.get(type_, key, log)
         elif self._remote:
             return self._remote.get(type_, key)
         else:

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -37,12 +37,13 @@ class InMemoryDb:
 
         return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         """Return asset."""
         try:
             return self._data[type_][key]
         except KeyError:
-            logger.error(f"{type_} with key '{key}' not found.")
+            if log:
+                logger.error(f"{type_} with key '{key}' not found.")
             raise exceptions.NotFound(f"Wrong pk {key}", 404)
 
     def list(self, type_):
@@ -58,19 +59,3 @@ class InMemoryDb:
 
         self._data[type_][key] = asset
         return asset
-
-
-_SHARED_DB = None
-
-
-def reset():
-    global _SHARED_DB
-    _SHARED_DB = InMemoryDb()
-    return _SHARED_DB
-
-
-def get():
-    global _SHARED_DB
-    if not _SHARED_DB:
-        reset()
-    return _SHARED_DB

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -303,7 +303,7 @@ class Client(object):
         """Create new algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the algo.
 
         Args:
             data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
@@ -323,7 +323,7 @@ class Client(object):
         """Create new aggregate algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the aggregate algo.
 
         Args:
             data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
@@ -344,7 +344,7 @@ class Client(object):
         """Create new composite algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the composite algo.
 
         Args:
             data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
@@ -364,7 +364,7 @@ class Client(object):
         """Create new traintuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the traintuple.
 
         Args:
             data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
@@ -384,7 +384,7 @@ class Client(object):
         """Create a new aggregate tuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the aggregate tuple.
 
         Args:
             data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
@@ -408,7 +408,7 @@ class Client(object):
         public.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the composite traintuple.
 
         Args:
             data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
@@ -429,7 +429,7 @@ class Client(object):
         """Create new testtuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the testtuple.
 
         Args:
             data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -263,7 +263,7 @@ class Client(object):
     def add_dataset(self, data: Union[dict, schemas.DatasetSpec]):
         """Create new dataset asset and return its key.
 
-        In debug mode, add the following key:`substra.sdk.DEBUG_OWNER` to the metadata,
+        In debug mode, add the following key:`substra.DEBUG_OWNER` to the metadata,
         the value becomes the node owner of the data, and all tuples using this data
         have their worker set to this node.
 

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -263,9 +263,10 @@ class Client(object):
     def add_dataset(self, data: Union[dict, schemas.DatasetSpec]):
         """Create new dataset asset and return its key.
 
-        In debug mode, add the following key:`substra.DEBUG_OWNER` to the metadata,
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
         the value becomes the node owner of the data, and all tuples using this data
-        have their worker set to this node.
+        have their worker set to this node. This has no impact on how the tuples are
+        executed except if chainkey support is enabled.
 
         Args:
             data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
@@ -284,6 +285,9 @@ class Client(object):
     ) -> str:
         """Create new objective asset.
 
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
+
         Args:
             data (Union[dict, schemas.ObjectiveSpec]): If it is a dict, it must have the same keys
                 as specified in [schemas.ObjectiveSpec](sdk_schemas.md#ObjectiveSpec).
@@ -297,6 +301,9 @@ class Client(object):
     @logit
     def add_algo(self, data: Union[dict, schemas.AlgoSpec]) -> str:
         """Create new algo asset.
+
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
 
         Args:
             data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
@@ -314,6 +321,9 @@ class Client(object):
         data: Union[dict, schemas.AggregateAlgoSpec],
     ) -> str:
         """Create new aggregate algo asset.
+
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
 
         Args:
             data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
@@ -333,6 +343,9 @@ class Client(object):
     ) -> str:
         """Create new composite algo asset.
 
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
+
         Args:
             data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.CompositeAlgoSpec](sdk_schemas.md#CompositeAlgoSpec).
@@ -350,6 +363,9 @@ class Client(object):
     ) -> str:
         """Create new traintuple asset.
 
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
+
         Args:
             data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
@@ -366,6 +382,9 @@ class Client(object):
         data: Union[dict, schemas.AggregatetupleSpec]
     ) -> str:
         """Create a new aggregate tuple asset.
+
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
 
         Args:
             data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
@@ -388,6 +407,9 @@ class Client(object):
         As specified in the data structure, output trunk models cannot be made
         public.
 
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
+
         Args:
             data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
                 same keys as specified in
@@ -405,6 +427,9 @@ class Client(object):
         data: Union[dict, schemas.TesttupleSpec]
     ) -> str:
         """Create new testtuple asset.
+
+        In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
+        the value becomes the 'creator' of the objective.
 
         Args:
             data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -263,6 +263,10 @@ class Client(object):
     def add_dataset(self, data: Union[dict, schemas.DatasetSpec]):
         """Create new dataset asset and return its key.
 
+        In debug mode, add the following key:`substra.sdk.DEBUG_OWNER` to the metadata,
+        the value becomes the node owner of the data, and all tuples using this data
+        have their worker set to this node.
+
         Args:
             data (Union[dict, schemas.DatasetSpec]): If it is a dict, it must have the same
                 keys as specified in [schemas.DatasetSpec](sdk_schemas.md#DatasetSpec).

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -103,7 +103,7 @@ class _ObjectiveDataset(schemas._PydanticConfig):
     data_manager_key: str
     data_sample_keys: List[str]
     metadata: Dict[str, str]
-    worker: Optional[str]
+    worker: str
 
 
 class _Metric(schemas._PydanticConfig):

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -36,6 +36,7 @@ OBJECTIVE = {
             "e11aeec2-9074-9e4c-50c9-1305e10463ec",
         ],
         "metadata": {},
+        "worker": "TEST_WORKER",
     },
     "metadata": {
         "foo": "bar"

--- a/tests/sdk/test_debug.py
+++ b/tests/sdk/test_debug.py
@@ -1,4 +1,3 @@
-import pytest
 import substra
 
 

--- a/tests/sdk/test_debug.py
+++ b/tests/sdk/test_debug.py
@@ -10,7 +10,7 @@ def test_client_tmp_dir():
 def test_client_multi_nodes_dataset(dataset_query):
     """Assert that the owner is gotten from the metadata in debug mode"""
     client = substra.Client(debug=True)
-    dataset_query['metadata'] = {substra.sdk.DEBUG_OWNER: 'owner_1'}
+    dataset_query['metadata'] = {substra.DEBUG_OWNER: 'owner_1'}
 
     key = client.add_dataset(dataset_query)
     asset = client.get_dataset(key)

--- a/tests/sdk/test_debug.py
+++ b/tests/sdk/test_debug.py
@@ -1,7 +1,18 @@
-
+import pytest
 import substra
 
 
 def test_client_tmp_dir():
+    """Test the creation of a temp directory for the debug client"""
     client = substra.Client(debug=True)
     assert client.temp_directory
+
+
+def test_client_multi_nodes_dataset(dataset_query):
+    """Assert that the owner is gotten from the metadata in debug mode"""
+    client = substra.Client(debug=True)
+    dataset_query['metadata'] = {substra.sdk.DEBUG_OWNER: 'owner_1'}
+
+    key = client.add_dataset(dataset_query)
+    asset = client.get_dataset(key)
+    assert asset.owner == 'owner_1'


### PR DESCRIPTION
## Description

In "normal" mode, the user connects to a node, adds the data on this node. When a DS creates a traintuple (or another task), it is executed where the data is: on the node of the dataset. To know which node a dataset is on, get the `dataset.owner` attribute.

The goal of this PR is to simulate this behaviour in debug mode.

- **What it does**: 
  - for the [chainkey use case](https://github.com/SubstraFoundation/substra/pull/239/files), get the appropriate chainkey for each tuple. So with this other PR, the public feature 'support chainkeys' is added to the debug mode.
- **What it does not do**: there is no check on the permissions in debug mode, so impossible to test them with this (but they are computed so the user can display them)


## Changes

In debug mode, the user can assign a specific node as the "owner" of the data: 
- when creating a dataset asset, add a special key in the `metadata` field: `substra.DEBUG_OWNER`. The value will be the owner of the dataset.

This MR also implements the management of the "worker" as in the backend:
- the "worker" in `traintuple.dataset.worker`, `composite_traintuple.dataset.worker`, `objective.test_dataset.worker` is equal to the `owner` of the dataset they are linked to.
- as before, the "worker" of an aggregate tuple (`aggregatetuple.worker`) is specified by the user

The default owner is `local-backend`.

### EDIT

Following the PR comments, added the possibility to change the `creator` of all assets with the `substra.DEBUG_OWNER` key in the metadata. This is only for display.

## Example (incomplete code)

```python
client = substra.Client(debug=True)
dataset_query = { ... }  # All the arguments to create a dataset
dataset_query['metadata'] = {substra.sdk.DEBUG_OWNER: 'owner_1'}
dataset_key = client.add_dataset(dataset_query)
asset = client.get_dataset(key)
assert asset.owner == 'owner_1'

traintuple_query = { ... }  # All the arguments to create a traintuple
traintuple_query['data_manager_key'] = dataset_key
traintuple_key = client.add_traintuple(traintuple_query)
traintuple = client.get_traintuple(traintuple_key)
assert traintuple.dataset.worker == 'owner_1'
```

## How to test