### PR TITLE
Enable chainkey support in debug mode

### DIFF
--- a/references/sdk.md
+++ b/references/sdk.md
@@ -37,7 +37,7 @@ add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec
 
 Create new aggregate algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the aggregate algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregateAlgoSpec], required)`: If it is a dict,
@@ -54,7 +54,7 @@ add_aggregatetuple(self, data: Union[dict, substra.sdk.schemas.AggregatetupleSpe
 
 Create a new aggregate tuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the aggregate tuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.AggregatetupleSpec], required)`: If it is a dict, it must have the same
@@ -71,7 +71,7 @@ add_algo(self, data: Union[dict, substra.sdk.schemas.AlgoSpec]) -> str
 
 Create new algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.AlgoSpec], required)`: If it is a dict, it must have the same keys
@@ -87,7 +87,7 @@ add_composite_algo(self, data: Union[dict, substra.sdk.schemas.CompositeAlgoSpec
 
 Create new composite algo asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the composite algo.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeAlgoSpec], required)`: If it is a dict, it must have the same
@@ -106,7 +106,7 @@ As specified in the data structure, output trunk models cannot be made
 public.
 
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the composite traintuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.CompositeTraintupleSpec], required)`: If it is a dict, it must have the
@@ -221,7 +221,7 @@ add_testtuple(self, data: Union[dict, substra.sdk.schemas.TesttupleSpec]) -> str
 
 Create new testtuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the testtuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.TesttupleSpec], required)`: If it is a dict, it must have the same
@@ -237,7 +237,7 @@ add_traintuple(self, data: Union[dict, substra.sdk.schemas.TraintupleSpec]) -> s
 
 Create new traintuple asset.
 In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-the value becomes the 'creator' of the objective.
+the value becomes the 'creator' of the traintuple.
 
 **Arguments:**
  - `data (Union[dict, schemas.TraintupleSpec], required)`: If it is a dict, it must have the same

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -841,9 +841,9 @@ class Local(base.BaseBackend):
             except exceptions.NotFound:
                 in_tuple = self._db.get(schemas.Type.CompositeTraintuple, key=model_key)
                 in_models.append({
-                    "key": in_tuple.out_head_model.out_model.key,
-                    "checksum": in_tuple.out_head_model.out_model.checksum,
-                    "storage_address": in_tuple.out_head_model.out_model.storage_address,
+                    "key": in_tuple.out_trunk_model.out_model.key,
+                    "checksum": in_tuple.out_trunk_model.out_model.checksum,
+                    "storage_address": in_tuple.out_trunk_model.out_model.storage_address,
                     "traintuple_key": in_tuple.key,
                 })
                 in_permissions.append(in_tuple.out_trunk_model.permissions.process)

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+from pathlib import Path
 import shutil
 import typing
 import warnings
@@ -29,9 +31,17 @@ DEBUG_OWNER = "debug_owner"
 
 class Local(base.BaseBackend):
     def __init__(self, backend, *args, **kwargs):
+        self._support_chainkeys = os.getenv("CHAINKEYS_ENABLED", False)
+        self._chainkey_dir = Path(os.getenv("CHAINKEYS_DIR", Path.home() / ".substra_chainkeys"))
+        if self._support_chainkeys:
+            print(f"Chainkeys support is on, the directory is {self._chainkey_dir}")
         # create a store to abstract the db
         self._db = dal.DataAccess(backend)
-        self._worker = compute.Worker(self._db)
+        self._worker = compute.Worker(
+            self._db,
+            support_chainkeys=self._support_chainkeys,
+            chainkey_dir=self._chainkey_dir
+        )
 
     @property
     def temp_directory(self):
@@ -193,7 +203,7 @@ class Local(base.BaseBackend):
         return compute_plan_key, rank
 
     def __get_id_rank_in_compute_plan(self, type_, key, id_to_key):
-        tuple_ = self._db.get(schemas.Type.Traintuple, key)
+        tuple_ = self._db.get(type_, key)
         id_ = next((k for k in id_to_key if id_to_key[k] == key), None)
         return id_, tuple_.rank
 
@@ -616,7 +626,7 @@ class Local(base.BaseBackend):
                 schemas.Type.Aggregatetuple
         ]:
             try:
-                traintuple = self._db.get(tuple_type, spec.traintuple_key)
+                traintuple = self._db.get(tuple_type, spec.traintuple_key, log=False)
                 break
             except exceptions.NotFound:
                 pass
@@ -731,7 +741,7 @@ class Local(base.BaseBackend):
             try:
                 # in trunk model is a composite traintuple out trunk model
                 in_trunk_tuple = self._db.get(
-                    schemas.Type.CompositeTraintuple, spec.in_trunk_model_key
+                    schemas.Type.CompositeTraintuple, spec.in_trunk_model_key, log=False
                 )
                 assert in_trunk_tuple.out_trunk_model
                 in_model = in_trunk_tuple.out_trunk_model.out_model
@@ -820,7 +830,7 @@ class Local(base.BaseBackend):
         in_permissions = list()
         for model_key in spec.in_models_keys:
             try:
-                in_tuple = self._db.get(schemas.Type.Traintuple, key=model_key)
+                in_tuple = self._db.get(schemas.Type.Traintuple, key=model_key, log=False)
                 in_models.append({
                     "key": in_tuple.out_model.key,
                     "checksum": in_tuple.out_model.checksum,
@@ -836,7 +846,7 @@ class Local(base.BaseBackend):
                     "storage_address": in_tuple.out_head_model.out_model.storage_address,
                     "traintuple_key": in_tuple.key,
                 })
-                in_permissions.append(in_tuple.out_head_model.permissions.process)
+                in_permissions.append(in_tuple.out_trunk_model.permissions.process)
             in_tuples.append(in_tuple)
 
         # Compute plan
@@ -1000,7 +1010,7 @@ class Local(base.BaseBackend):
         if compute_plan.aggregatetuple_keys:
             for key in compute_plan.aggregatetuple_keys:
                 id_, rank = self.__get_id_rank_in_compute_plan(
-                    schemas.Type.Traintuple,
+                    schemas.Type.Aggregatetuple,
                     key,
                     compute_plan.id_to_key
                 )
@@ -1009,7 +1019,7 @@ class Local(base.BaseBackend):
         if compute_plan.composite_traintuple_keys:
             for key in compute_plan.composite_traintuple_keys:
                 id_, rank = self.__get_id_rank_in_compute_plan(
-                    schemas.Type.Traintuple,
+                    schemas.Type.CompositeTraintuple,
                     key,
                     compute_plan.id_to_key
                 )

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import shutil
 import typing
 import warnings
+from distutils import util
 
 import substra
 from substra.sdk import schemas, models, exceptions, fs, graph, compute_plan as compute_plan_module
@@ -31,7 +32,7 @@ DEBUG_OWNER = "debug_owner"
 
 class Local(base.BaseBackend):
     def __init__(self, backend, *args, **kwargs):
-        self._support_chainkeys = os.getenv("CHAINKEYS_ENABLED", False)
+        self._support_chainkeys = bool(util.strtobool(os.getenv("CHAINKEYS_ENABLED", 'False')))
         self._chainkey_dir = Path(os.getenv("CHAINKEYS_DIR", Path.home() / ".substra_chainkeys"))
         if self._support_chainkeys:
             print(f"Chainkeys support is on, the directory is {self._chainkey_dir}")

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -69,7 +69,7 @@ class Worker:
 
     def _get_chainkey_volume(self, tuple_):
         owner = self._get_owner(tuple_)
-        compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_id)
+        compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_key)
         tuple_chainkey_volume = self._chainkey_dir / owner / \
             "computeplan" / compute_plan.tag / "chainkeys"
         if not tuple_chainkey_volume.is_dir():
@@ -246,7 +246,7 @@ class Worker:
 
             # Get the environment variables
             envs = dict()
-            if tuple_.compute_plan_id:
+            if tuple_.compute_plan_key:
                 if self._support_chainkeys:
                     envs.update(self._get_chainkey_env(tuple_))
 

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -32,6 +32,7 @@ _VOLUME_OPENER = {"bind": "/sandbox/opener/__init__.py", "mode": "ro"}
 _VOLUME_OUTPUT_PRED = {"bind": "/sandbox/pred", "mode": "rw"}
 _VOLUME_LOCAL = {"bind": "/sandbox/local", "mode": "rw"}
 _VOLUME_LOCAL_READ_ONLY = {"bind": "/sandbox/local", "mode": "ro"}
+_VOLUME_CHAINKEYS = {"bind": "/sandbox/chainkeys", "mode": "rw"}
 
 _VOLUME_INPUT_MODELS_RO = {"bind": "/sandbox/input_models", "mode": "ro"}
 _VOLUME_OUTPUT_MODELS_RW = {"bind": "/sandbox/output_models", "mode": "rw"}
@@ -54,10 +55,33 @@ def _get_address_in_container(model_key, volume, container_volume):
 class Worker:
     """ML Worker."""
 
-    def __init__(self, db: dal.DataAccess):
+    def __init__(self, db: dal.DataAccess, support_chainkeys: bool, chainkey_dir=None):
         self._wdir = os.path.join(os.getcwd(), "local-worker")
         self._db = db
         self._spawner = spawner.get()
+        self._support_chainkeys = support_chainkeys
+        self._chainkey_dir = chainkey_dir
+
+    def _get_owner(self, tuple_):
+        if isinstance(tuple_, models.Aggregatetuple):
+            return tuple_.worker
+        return tuple_.dataset.worker
+
+    def _get_chainkey_volume(self, tuple_):
+        owner = self._get_owner(tuple_)
+        compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_id)
+        tuple_chainkey_volume = self._chainkey_dir / owner / \
+            "computeplan" / compute_plan.tag / "chainkeys"
+        if not tuple_chainkey_volume.is_dir():
+            return None
+        return tuple_chainkey_volume
+
+    def _get_chainkey_env(self, tuple_):
+        owner = self._get_owner(tuple_)
+        node_name_id = json.loads((self._chainkey_dir / "node_name_id.json").read_text())
+        return {
+            'NODE_INDEX': node_name_id.get(owner, None),
+        }
 
     def _get_data_sample_paths_arg(self, data_volume, dataset):
         data_sample_paths = [
@@ -184,6 +208,10 @@ class Worker:
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL
+                if self._support_chainkeys:
+                    chainkey_volume = self._get_chainkey_volume(tuple_)
+                    if chainkey_volume is not None:
+                        volumes[chainkey_volume] = _VOLUME_CHAINKEYS
 
             if isinstance(tuple_, models.Aggregatetuple):
                 command = "aggregate"
@@ -216,10 +244,20 @@ class Worker:
                     command += " --fake-data"
                     command += f" --n-fake-samples {len(tuple_.dataset.data_sample_keys)}"
 
+            # Get the environment variables
+            envs = dict()
+            if tuple_.compute_plan_id:
+                if self._support_chainkeys:
+                    envs.update(self._get_chainkey_env(tuple_))
+
             # Execute the tuple
             container_name = f"algo-{algo.key}"
             logs = self._spawner.spawn(
-                container_name, str(algo.content.storage_address), command, volumes=volumes
+                container_name,
+                str(algo.content.storage_address),
+                command,
+                volumes=volumes,
+                envs=envs,
             )
 
             # save move output models
@@ -285,6 +323,9 @@ class Worker:
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL
+                if self._support_chainkeys:
+                    chainkey_volume = self._get_chainkey_volume(tuple_)
+                    volumes[chainkey_volume] = _VOLUME_CHAINKEYS
 
             # compute testtuple command
             command = "predict"

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -32,7 +32,7 @@ class DataAccess:
     """
 
     def __init__(self, remote_backend: typing.Optional[backend.Remote]):
-        self._db = db.get()
+        self._db = db.InMemoryDb()
         self._remote = remote_backend
         self._tmp_dir = tempfile.TemporaryDirectory(prefix="/tmp/")
 

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -114,9 +114,9 @@ class DataAccess:
             attr.storage_address = asset_path
             return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         if self.is_local(key):
-            return self._db.get(type_, key)
+            return self._db.get(type_, key, log)
         elif self._remote:
             return self._remote.get(type_, key)
         else:

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -37,12 +37,13 @@ class InMemoryDb:
 
         return asset
 
-    def get(self, type_, key: str):
+    def get(self, type_, key: str, log: bool = True):
         """Return asset."""
         try:
             return self._data[type_][key]
         except KeyError:
-            logger.error(f"{type_} with key '{key}' not found.")
+            if log:
+                logger.error(f"{type_} with key '{key}' not found.")
             raise exceptions.NotFound(f"Wrong pk {key}", 404)
 
     def list(self, type_):

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -59,19 +59,3 @@ class InMemoryDb:
 
         self._data[type_][key] = asset
         return asset
-
-
-_SHARED_DB = None
-
-
-def reset():
-    global _SHARED_DB
-    _SHARED_DB = InMemoryDb()
-    return _SHARED_DB
-
-
-def get():
-    global _SHARED_DB
-    if not _SHARED_DB:
-        reset()
-    return _SHARED_DB

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -303,7 +303,7 @@ class Client(object):
         """Create new algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the algo.
 
         Args:
             data (Union[dict, schemas.AlgoSpec]): If it is a dict, it must have the same keys
@@ -323,7 +323,7 @@ class Client(object):
         """Create new aggregate algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the aggregate algo.
 
         Args:
             data (Union[dict, schemas.AggregateAlgoSpec]): If it is a dict,
@@ -344,7 +344,7 @@ class Client(object):
         """Create new composite algo asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the composite algo.
 
         Args:
             data (Union[dict, schemas.CompositeAlgoSpec]): If it is a dict, it must have the same
@@ -364,7 +364,7 @@ class Client(object):
         """Create new traintuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the traintuple.
 
         Args:
             data (Union[dict, schemas.TraintupleSpec]): If it is a dict, it must have the same
@@ -384,7 +384,7 @@ class Client(object):
         """Create a new aggregate tuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the aggregate tuple.
 
         Args:
             data (Union[dict, schemas.AggregatetupleSpec]): If it is a dict, it must have the same
@@ -408,7 +408,7 @@ class Client(object):
         public.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the composite traintuple.
 
         Args:
             data (Union[dict, schemas.CompositeTraintupleSpec]): If it is a dict, it must have the
@@ -429,7 +429,7 @@ class Client(object):
         """Create new testtuple asset.
 
         In debug mode, add the following key: `substra.DEBUG_OWNER` to the metadata,
-        the value becomes the 'creator' of the objective.
+        the value becomes the 'creator' of the testtuple.
 
         Args:
             data (Union[dict, schemas.TesttupleSpec]): If it is a dict, it must have the same


### PR DESCRIPTION
## Description

Enable chainkey support in debug mode. This needs the 'debug_multi_nodes' feature #238 

## Changes

- init the local backend:
  - env variables "CHAINKEYS_ENABLED" and "CHAINKEYS_DIR". I chose environment variables to avoid having extra variables specific to the debug mode in the Client initialization.
- Worker: get the chainkey that matches the `tuple_.dataset.worker`, and give the env variable "NODE_INDEX" to the Docker container for the task

## Bug fixes

- aggregate tuple that has a composite traintuple in its in models: it took the head instead of the trunk
- Compute plan - get id to rank: always tried to get a traintuple from the db, even if composite traintuple or aggregatetuple
- DB in debug mode: the db was always the same so if you create several clients in the same context, they share the db (caused errors in the tests in melloddy since we check the number of datasets on the client)