### PR TITLE
Rename a few attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ sdist/
 .vscode
 .env
 .venv
+
+local-worker/

--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -79,9 +79,9 @@ compute_plan = client.add_compute_plan({
     'composite_traintuples': [],
     'aggregatetuples': [],
 })
-compute_plan_id = compute_plan.compute_plan_id
+key = compute_plan.key
 
 with open(compute_plan_keys_path, 'w') as f:
     json.dump(compute_plan.dict(exclude_none=False, by_alias=True), f, indent=2)
 
-print(f'Compute plan keys have been saved to {os.path.abspath(compute_plan_keys_path)}')
+print(f'Compute Plan keys have been saved to {os.path.abspath(compute_plan_keys_path)}')

--- a/examples/compute_plan/scripts/add_compute_plan.py
+++ b/examples/compute_plan/scripts/add_compute_plan.py
@@ -79,7 +79,6 @@ compute_plan = client.add_compute_plan({
     'composite_traintuples': [],
     'aggregatetuples': [],
 })
-key = compute_plan.key
 
 with open(compute_plan_keys_path, 'w') as f:
     json.dump(compute_plan.dict(exclude_none=False, by_alias=True), f, indent=2)

--- a/references/cli.md
+++ b/references/cli.md
@@ -745,7 +745,7 @@ Options:
 ## substra cancel compute_plan
 
 ```bash
-Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_KEY
+Usage: substra cancel compute_plan [OPTIONS] KEY
 
   Cancel execution of a compute plan.
 
@@ -815,7 +815,7 @@ Options:
 ## substra update compute_plan
 
 ```bash
-Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_KEY TUPLES_PATH
+Usage: substra update compute_plan [OPTIONS] KEY TUPLES_PATH
 
   Update compute plan.
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -745,7 +745,7 @@ Options:
 ## substra cancel compute_plan
 
 ```bash
-Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_ID
+Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_KEY
 
   Cancel execution of a compute plan.
 
@@ -815,7 +815,7 @@ Options:
 ## substra update compute_plan
 
 ```bash
-Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_ID TUPLES_PATH
+Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_KEY TUPLES_PATH
 
   Update compute plan.
 

--- a/references/cli.md
+++ b/references/cli.md
@@ -745,7 +745,7 @@ Options:
 ## substra cancel compute_plan
 
 ```bash
-Usage: substra cancel compute_plan [OPTIONS] KEY
+Usage: substra cancel compute_plan [OPTIONS] COMPUTE_PLAN_KEY
 
   Cancel execution of a compute plan.
 
@@ -815,7 +815,7 @@ Options:
 ## substra update compute_plan
 
 ```bash
-Usage: substra update compute_plan [OPTIONS] KEY TUPLES_PATH
+Usage: substra update compute_plan [OPTIONS] COMPUTE_PLAN_KEY TUPLES_PATH
 
   Update compute plan.
 

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -26,10 +26,10 @@ In debug mode, new assets are created locally but can access assets from
 the deployed Substra platform. The platform is in read-only mode.
 Defaults to False.
 ## temp_directory
-_This is a property._  
+_This is a property._
 Temporary directory for storing assets in debug mode.
         Deleted when the client is deleted.
-        
+
 ## add_aggregate_algo
 ```python
 add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec]) -> str
@@ -227,7 +227,7 @@ keys as specified in [schemas.TraintupleSpec](sdk_schemas.md#TraintupleSpec).
  - `str`: Key of the asset
 ## cancel_compute_plan
 ```python
-cancel_compute_plan(self, compute_plan_id: str) -> substra.sdk.models.ComputePlan
+cancel_compute_plan(self, key: str) -> substra.sdk.models.ComputePlan
 ```
 
 Cancel execution of compute plan, the returned object is described
@@ -501,10 +501,10 @@ in the [models.Traintuple](sdk_models.md#Traintuple) model
 login(self, username, password)
 ```
 
-Login to a remote server. 
+Login to a remote server.
 ## update_compute_plan
 ```python
-update_compute_plan(self, compute_plan_id: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
+update_compute_plan(self, compute_plan_key: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
 ```
 
 Update compute plan.
@@ -512,7 +512,7 @@ As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
 **Arguments:**
- - `compute_plan_id (str, required)`: Id of the compute plan
+ - `compute_plan_key (str, required)`: Id of the compute plan
  - `data (Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -26,10 +26,10 @@ In debug mode, new assets are created locally but can access assets from
 the deployed Substra platform. The platform is in read-only mode.
 Defaults to False.
 ## temp_directory
-_This is a property._
+_This is a property._  
 Temporary directory for storing assets in debug mode.
         Deleted when the client is deleted.
-
+        
 ## add_aggregate_algo
 ```python
 add_aggregate_algo(self, data: Union[dict, substra.sdk.schemas.AggregateAlgoSpec]) -> str
@@ -501,10 +501,10 @@ in the [models.Traintuple](sdk_models.md#Traintuple) model
 login(self, username, password)
 ```
 
-Login to a remote server.
+Login to a remote server. 
 ## update_compute_plan
 ```python
-update_compute_plan(self, compute_plan_key: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
+update_compute_plan(self, key: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan
 ```
 
 Update compute plan.
@@ -512,7 +512,7 @@ As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
 **Arguments:**
- - `compute_plan_key (str, required)`: Id of the compute plan
+ - `key (str, required)`: Id of the compute plan
  - `data (Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -512,7 +512,7 @@ As specified in the data dict structure, output trunk models of composite
 traintuples cannot be made public.
 
 **Arguments:**
- - `key (str, required)`: Id of the compute plan
+ - `key (str, required)`: Compute plan key
  - `data (Union[dict, schemas.UpdateComputePlanSpec], required)`: If it is a dict,
 it must have the same keys as specified in
 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -284,7 +284,7 @@ Algo associated to a traintuple
 Dataset as stored in a traintuple or composite traintuple
 ```python
 - key: str
-- opener_hash: str
+- opener_checksum: str
 - keys: List[str]
 - worker: str
 - metadata: Optional[Mapping[str, str]]
@@ -294,7 +294,7 @@ Dataset as stored in a traintuple or composite traintuple
 Dataset of a testtuple
 ```python
 - key: str
-- opener_hash: str
+- opener_checksum: str
 - perf: float
 - keys: List[str]
 - worker: str

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -82,7 +82,7 @@ Testtuple
 - tag: Optional[str]
 - log: str
 - status: str
-- compute_plan_id: str
+- compute_plan_key: str
 - rank: int
 - traintuple_type: enum
 - metadata: Mapping[str, str]
@@ -97,7 +97,7 @@ Traintuple
 - dataset: _TraintupleDataset
 - permissions: Permissions
 - tag: str
-- compute_plan_id: str
+- compute_plan_key: str
 - rank: int
 - status: str
 - log: str
@@ -115,7 +115,7 @@ Aggregatetuple
 - algo: _TraintupleAlgo
 - permissions: Permissions
 - tag: str
-- compute_plan_id: str
+- compute_plan_key: str
 - rank: Optional[int]
 - status: str
 - log: str
@@ -132,7 +132,7 @@ CompositeTraintuple
 - algo: _TraintupleAlgo
 - dataset: _TraintupleDataset
 - tag: str
-- compute_plan_id: str
+- compute_plan_key: str
 - rank: Optional[int]
 - status: str
 - log: str
@@ -170,7 +170,7 @@ AggregateAlgo
 ## ComputePlan
 ComputePlan
 ```python
-- compute_plan_id: str
+- key: str
 - status: str
 - traintuple_keys: Optional[List[str]]
 - composite_traintuple_keys: Optional[List[str]]

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -202,7 +202,7 @@ In model of a traintuple, aggregate tuple or in trunk
 model of a composite traintuple
 ```python
 - key: str
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
 - traintuple_key: Optional[str]
 ```
@@ -211,7 +211,7 @@ model of a composite traintuple
 In head model of a composite traintuple
 ```python
 - key: str
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str, NoneType]
 - traintuple_key: Optional[str]
 ```
@@ -221,7 +221,7 @@ Out model of a traintuple, aggregate tuple or out trunk
 model of a composite traintuple
 ```python
 - key: str
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
 ```
 
@@ -229,7 +229,7 @@ model of a composite traintuple
 Out head model of a composite traintuple
 ```python
 - key: str
-- hash_: str
+- checksum: str
 - storage_address: Optional[FilePath]
 ```
 
@@ -250,7 +250,7 @@ Out head model of a composite traintuple with permissions
 ## _File
 File as stored in the models
 ```python
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
 ```
 
@@ -267,7 +267,7 @@ Dataset as stored in the Objective asset
 Metric associated to a testtuple or objective
 ```python
 - name: Optional[str]
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
 ```
 
@@ -275,7 +275,7 @@ Metric associated to a testtuple or objective
 Algo associated to a traintuple
 ```python
 - key: str
-- hash_: str
+- checksum: str
 - storage_address: Union[pydantic.types.FilePath, pydantic.networks.AnyUrl, str]
 - name: str
 ```
@@ -285,7 +285,7 @@ Dataset as stored in a traintuple or composite traintuple
 ```python
 - key: str
 - opener_checksum: str
-- keys: List[str]
+- data_sample_keys: List[str]
 - worker: str
 - metadata: Optional[Mapping[str, str]]
 ```
@@ -296,7 +296,7 @@ Dataset of a testtuple
 - key: str
 - opener_checksum: str
 - perf: float
-- keys: List[str]
+- data_sample_keys: List[str]
 - worker: str
 ```
 

--- a/references/sdk_schemas.md
+++ b/references/sdk_schemas.md
@@ -76,7 +76,7 @@ Specification for creating a traintuple
 - train_data_sample_keys: List[str]
 - in_models_keys: Optional[List[str]]
 - tag: Optional[str]
-- compute_plan_id: Optional[str]
+- compute_plan_key: Optional[str]
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]
 ```
@@ -88,7 +88,7 @@ Specification for creating an aggregate tuple
 - worker: str
 - in_models_keys: List[str]
 - tag: Optional[str]
-- compute_plan_id: Optional[str]
+- compute_plan_key: Optional[str]
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]
 ```
@@ -102,7 +102,7 @@ Specification for creating a composite traintuple
 - in_head_model_key: Optional[str]
 - in_trunk_model_key: Optional[str]
 - tag: Optional[str]
-- compute_plan_id: Optional[str]
+- compute_plan_key: Optional[str]
 - out_trunk_model_permissions: PrivatePermissions
 - rank: Optional[int]
 - metadata: Optional[Mapping[str, str]]

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1167,14 +1167,14 @@ def cancel(ctx):
 
 
 @cancel.command('compute_plan')
-@click.argument('compute_plan_id', type=click.STRING)
+@click.argument('key', type=click.STRING)
 @click_global_conf_with_output_format
 @click.pass_context
-def cancel_compute_plan(ctx, compute_plan_id):
+def cancel_compute_plan(ctx, key):
     """Cancel execution of a compute plan."""
     client = get_client(ctx.obj)
     # method must exist in sdk
-    res = client.cancel_compute_plan(compute_plan_id)
+    res = client.cancel_compute_plan(key)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, profile=ctx.obj.profile)
 
@@ -1228,7 +1228,7 @@ def update_dataset(ctx, dataset_key, objective_key):
 
 
 @update.command('compute_plan')
-@click.argument('compute_plan_id', type=click.STRING)
+@click.argument('key', type=click.STRING)
 @click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
                 callback=load_json_from_path, metavar="TUPLES_PATH")
 @click.option('--no-auto-batching', '-n', is_flag=True,
@@ -1239,7 +1239,7 @@ def update_dataset(ctx, dataset_key, objective_key):
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def update_compute_plan(ctx, compute_plan_id, tuples, no_auto_batching, batch_size):
+def update_compute_plan(ctx, key, tuples, no_auto_batching, batch_size):
     """Update compute plan.
 
     The tuples path must point to a valid JSON file with the following schema:
@@ -1296,7 +1296,7 @@ def update_compute_plan(ctx, compute_plan_id, tuples, no_auto_batching, batch_si
                                    "The --batch_size option cannot be used when using "
                                    "--no_auto_batching.")
     client = get_client(ctx.obj)
-    res = client.update_compute_plan(compute_plan_id, tuples, not no_auto_batching, batch_size)
+    res = client.update_compute_plan(key, tuples, not no_auto_batching, batch_size)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, is_list=False)
 

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1167,14 +1167,14 @@ def cancel(ctx):
 
 
 @cancel.command('compute_plan')
-@click.argument('key', type=click.STRING)
+@click.argument('compute_plan_key', type=click.STRING)
 @click_global_conf_with_output_format
 @click.pass_context
-def cancel_compute_plan(ctx, key):
+def cancel_compute_plan(ctx, compute_plan_key):
     """Cancel execution of a compute plan."""
     client = get_client(ctx.obj)
     # method must exist in sdk
-    res = client.cancel_compute_plan(key)
+    res = client.cancel_compute_plan(compute_plan_key)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, profile=ctx.obj.profile)
 
@@ -1228,7 +1228,7 @@ def update_dataset(ctx, dataset_key, objective_key):
 
 
 @update.command('compute_plan')
-@click.argument('key', type=click.STRING)
+@click.argument('compute_plan_key', type=click.STRING)
 @click.argument('tuples', type=click.Path(exists=True, dir_okay=False),
                 callback=load_json_from_path, metavar="TUPLES_PATH")
 @click.option('--no-auto-batching', '-n', is_flag=True,
@@ -1239,7 +1239,7 @@ def update_dataset(ctx, dataset_key, objective_key):
 @click_global_conf_with_output_format
 @click.pass_context
 @error_printer
-def update_compute_plan(ctx, key, tuples, no_auto_batching, batch_size):
+def update_compute_plan(ctx, compute_plan_key, tuples, no_auto_batching, batch_size):
     """Update compute plan.
 
     The tuples path must point to a valid JSON file with the following schema:
@@ -1296,7 +1296,7 @@ def update_compute_plan(ctx, key, tuples, no_auto_batching, batch_size):
                                    "The --batch_size option cannot be used when using "
                                    "--no_auto_batching.")
     client = get_client(ctx.obj)
-    res = client.update_compute_plan(key, tuples, not no_auto_batching, batch_size)
+    res = client.update_compute_plan(compute_plan_key, tuples, not no_auto_batching, batch_size)
     printer = printers.get_asset_printer(assets.COMPUTE_PLAN, ctx.obj.output_format)
     printer.print(res, is_list=False)
 

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -264,7 +264,7 @@ class BaseAlgoPrinter(AssetPrinter):
 class ComputePlanPrinter(AssetPrinter):
     asset_name = 'compute_plan'
 
-    key_field = Field('Compute plan ID', 'compute_plan_id')
+    key_field = Field('Compute Plan key', 'key')
 
     list_fields = (
         CountField('Traintuples count', 'traintuple_keys'),
@@ -295,19 +295,19 @@ class ComputePlanPrinter(AssetPrinter):
 
         print('\nDisplay this compute_plan\'s traintuples:')
         print(f'\tsubstra list traintuple -f '
-              f'"traintuple:compute_plan_id:{key_value}" {profile_arg}')
+              f'"traintuple:compute_plan_key:{key_value}" {profile_arg}')
 
         print('\nDisplay this compute_plan\'s composite_traintuples:')
         print(f'\tsubstra list composite_traintuple'
-              f' -f "composite_traintuple:compute_plan_id:{key_value}" {profile_arg}')
+              f' -f "composite_traintuple:compute_plan_key:{key_value}" {profile_arg}')
 
         print('\nDisplay this compute_plan\'s aggregatetuples:')
         print(f'\tsubstra list aggregatetuple'
-              f' -f "aggregatetuple:compute_plan_id:{key_value}" {profile_arg}')
+              f' -f "aggregatetuple:compute_plan_key:{key_value}" {profile_arg}')
 
         print('\nDisplay this compute_plan\'s testtuples:')
         print(f'\tsubstra list testtuple'
-              f' -f "testtuple:compute_plan_id:{key_value}" {profile_arg}')
+              f' -f "testtuple:compute_plan_key:{key_value}" {profile_arg}')
 
 
 class AlgoPrinter(BaseAlgoPrinter):
@@ -383,7 +383,7 @@ class TraintuplePrinter(AssetPrinter):
         Field('Status', 'status'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
     )
     single_fields = (
         Field('Model key', 'out_model.key'),
@@ -394,7 +394,7 @@ class TraintuplePrinter(AssetPrinter):
         KeysField('Train data sample keys', 'dataset.keys'),
         InModelTraintupleKeysField('In model traintuple keys', 'in_models'),
         Field('Rank', 'rank'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
         Field('Tag', 'tag'),
         Field('Log', 'log'),
         Field('Creator', 'creator'),
@@ -420,7 +420,7 @@ class AggregateTuplePrinter(AssetPrinter):
         Field('Status', 'status'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
     )
     single_fields = (
         Field('Model key', 'out_model.key'),
@@ -430,7 +430,7 @@ class AggregateTuplePrinter(AssetPrinter):
         Field('Dataset key', 'dataset.key'),
         InModelTraintupleKeysField('In model keys', 'in_models'),
         Field('Rank', 'rank'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
         Field('Tag', 'tag'),
         Field('Log', 'log'),
         Field('Creator', 'creator'),
@@ -456,7 +456,7 @@ class CompositeTraintuplePrinter(AssetPrinter):
         Field('Status', 'status'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
     )
 
     single_fields = (
@@ -472,7 +472,7 @@ class CompositeTraintuplePrinter(AssetPrinter):
         Field('In head model key', 'in_head_model.traintuple_key'),
         Field('In trunk model key', 'in_trunk_model.traintuple_key'),
         Field('Rank', 'rank'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
         Field('Tag', 'tag'),
         Field('Log', 'log'),
         Field('Creator', 'creator'),
@@ -499,7 +499,7 @@ class TesttuplePrinter(AssetPrinter):
         Field('Perf', 'dataset.perf'),
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
     )
     single_fields = (
         Field('Traintuple key', 'traintuple_key'),
@@ -515,7 +515,7 @@ class TesttuplePrinter(AssetPrinter):
         Field('Rank', 'rank'),
         Field('Tag', 'tag'),
         Field('Metadata', 'metadata'),
-        Field('Compute Plan Id', 'compute_plan_id'),
+        Field('Compute Plan key', 'compute_plan_key'),
         Field('Log', 'log'),
         Field('Creator', 'creator'),
         Field('Worker', 'dataset.worker'),

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -264,8 +264,6 @@ class BaseAlgoPrinter(AssetPrinter):
 class ComputePlanPrinter(AssetPrinter):
     asset_name = 'compute_plan'
 
-    key_field = Field('Compute Plan key', 'key')
-
     list_fields = (
         CountField('Traintuples count', 'traintuple_keys'),
         CountField('Composite traintuples count', 'composite_traintuple_keys'),

--- a/substra/runner.py
+++ b/substra/runner.py
@@ -154,11 +154,11 @@ def compute_train(
 
         for inmodel in inmodels:
             src = os.path.abspath(inmodel)
-            model_hash = hashlib.sha256(src.encode()).hexdigest()
-            dst = os.path.join(outmodel_path, model_hash)
+            model_checksum = hashlib.sha256(src.encode()).hexdigest()
+            dst = os.path.join(outmodel_path, model_checksum)
             os.link(src, dst)
             print(f"Creating model symlink from {src} to {dst}")
-            model_keys.append(model_hash)
+            model_keys.append(model_checksum)
 
         if model_keys:
             models_command = ' '.join(model_keys)

--- a/substra/sdk/backends/base.py
+++ b/substra/sdk/backends/base.py
@@ -15,7 +15,7 @@ class BaseBackend(abc.ABC):
     def add(self, spec, spec_options=None):
         raise NotImplementedError
 
-    def update_compute_plan(self, compute_plan_id, spec):
+    def update_compute_plan(self, key, spec):
         raise NotImplementedError
 
     def link_dataset_with_objective(self, dataset_key, objective_key):
@@ -33,5 +33,5 @@ class BaseBackend(abc.ABC):
     def leaderboard(self, objective_key, sort='desc'):
         raise NotImplementedError
 
-    def cancel_compute_plan(self, compute_plan_id):
+    def cancel_compute_plan(self, key):
         raise NotImplementedError

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -254,7 +254,7 @@ class Local(base.BaseBackend):
         algo = self._db.get(traintuple.algo_type, traintuple.algo.key)
         return {
             'algo': {
-                'hash': algo.key,
+                'key': algo.key,
                 'name': algo.name,
                 'storage_address': str(algo.content.storage_address)
             },
@@ -298,11 +298,11 @@ class Local(base.BaseBackend):
                 },
             },
             content={
-                "hash": fs.hash_file(algo_file_path),
+                "checksum": fs.hash_file(algo_file_path),
                 "storage_address": algo_file_path
             },
             description={
-                "hash": fs.hash_file(algo_description_path),
+                "checksum": fs.hash_file(algo_description_path),
                 "storage_address": algo_description_path
             },
             metadata=spec.metadata if spec.metadata else dict(),
@@ -347,11 +347,11 @@ class Local(base.BaseBackend):
             train_data_sample_keys=list(),
             test_data_sample_keys=list(),
             opener={
-                "hash": fs.hash_file(dataset_file_path),
+                "checksum": fs.hash_file(dataset_file_path),
                 "storage_address": dataset_file_path
             },
             description={
-                "hash": fs.hash_file(dataset_description_path),
+                "checksum": fs.hash_file(dataset_description_path),
                 "storage_address": dataset_description_path
             },
             metadata=spec.metadata if spec.metadata else dict(),
@@ -450,12 +450,12 @@ class Local(base.BaseBackend):
                 },
             },
             description={
-                "hash": fs.hash_file(objective_description_path),
+                "checksum": fs.hash_file(objective_description_path),
                 "storage_address": objective_description_path
             },
             metrics={
                 "name": spec.metrics_name,
-                "hash": fs.hash_file(objective_file_path),
+                "checksum": fs.hash_file(objective_file_path),
                 "storage_address": objective_file_path
             },
             metadata=spec.metadata if spec.metadata else dict(),
@@ -556,13 +556,13 @@ class Local(base.BaseBackend):
             creator=_BACKEND_ID,
             algo={
                 "key": spec.algo_key,
-                "hash": algo.content.hash_,
+                "checksum": algo.content.checksum,
                 "name": algo.name,
                 "storage_address": algo.content.storage_address
             },
             dataset={
                 "key": spec.data_manager_key,
-                "opener_hash": data_manager.opener.hash_,
+                "opener_checksum": data_manager.opener.checksum,
                 "keys": spec.train_data_sample_keys,
                 "worker": _BACKEND_ID,
                 "metadata": {}
@@ -578,7 +578,7 @@ class Local(base.BaseBackend):
             in_models=[
                 {
                     "key": in_traintuple.out_model.key,
-                    "hash": in_traintuple.out_model.hash_,
+                    "checksum": in_traintuple.out_model.checksum,
                     "storage_address": in_traintuple.out_model.storage_address,
                     "traintuple_key": in_traintuple.key,
                 }
@@ -673,7 +673,7 @@ class Local(base.BaseBackend):
             certified=certified,
             dataset={
                 "key": dataset_key,
-                "opener_hash": dataset.opener.hash_,
+                "opener_checksum": dataset.opener.checksum,
                 "perf": -1,
                 "keys": test_data_sample_keys,
                 "worker": _BACKEND_ID,
@@ -711,7 +711,7 @@ class Local(base.BaseBackend):
             assert in_head_tuple.out_head_model
             in_head_model = models.InHeadModel(
                 key=in_head_tuple.out_head_model.out_model.key,
-                hash=in_head_tuple.out_head_model.out_model.hash_,
+                checksum=in_head_tuple.out_head_model.out_model.checksum,
                 storage_address=in_head_tuple.out_head_model.out_model.storage_address
             )
             in_tuples.append(in_head_tuple)
@@ -732,7 +732,7 @@ class Local(base.BaseBackend):
 
             in_trunk_model = models.InModel(
                 key=in_model.key,
-                hash=in_model.hash_,
+                checksum=in_model.checksum,
                 storage_address=in_model.storage_address
             )
             in_tuples.append(in_trunk_tuple)
@@ -762,13 +762,13 @@ class Local(base.BaseBackend):
             creator=_BACKEND_ID,
             algo={
                 "key": spec.algo_key,
-                "hash": algo.content.hash_,
+                "checksum": algo.content.checksum,
                 "name": algo.name,
                 "storage_address": algo.content.storage_address
             },
             dataset={
                 "key": spec.data_manager_key,
-                "opener_hash": dataset.opener.hash_,
+                "opener_checksum": dataset.opener.checksum,
                 "keys": spec.train_data_sample_keys,
                 "worker": _BACKEND_ID,
             },
@@ -812,7 +812,7 @@ class Local(base.BaseBackend):
                 in_tuple = self._db.get(schemas.Type.Traintuple, key=model_key)
                 in_models.append({
                     "key": in_tuple.out_model.key,
-                    "hash": in_tuple.out_model.hash_,
+                    "checksum": in_tuple.out_model.checksum,
                     "storage_address": in_tuple.out_model.storage_address,
                     "traintuple_key": in_tuple.key,
                 })
@@ -821,7 +821,7 @@ class Local(base.BaseBackend):
                 in_tuple = self._db.get(schemas.Type.CompositeTraintuple, key=model_key)
                 in_models.append({
                     "key": in_tuple.out_head_model.out_model.key,
-                    "hash": in_tuple.out_head_model.out_model.hash_,
+                    "checksum": in_tuple.out_head_model.out_model.checksum,
                     "storage_address": in_tuple.out_head_model.out_model.storage_address,
                     "traintuple_key": in_tuple.key,
                 })
@@ -846,7 +846,7 @@ class Local(base.BaseBackend):
             worker=spec.worker,
             algo={
                 "key": spec.algo_key,
-                "hash": algo.content.hash_,
+                "checksum": algo.content.checksum,
                 "name": algo.name,
                 "storage_address": algo.content.storage_address
             },

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -123,9 +123,9 @@ class Local(base.BaseBackend):
                 testtuple_keys or list(),
             ]
         ])
-        compute_plan_id = self._db.get_local_key(schemas._Spec.compute_key())
+        key = self._db.get_local_key(schemas._Spec.compute_key())
         compute_plan = models.ComputePlan(
-            compute_plan_id=compute_plan_id,
+            key=key,
             status=models.Status.waiting,
             traintuple_keys=traintuple_keys,
             composite_traintuple_keys=composite_traintuple_keys,
@@ -141,18 +141,18 @@ class Local(base.BaseBackend):
 
     def __create_compute_plan_from_tuple(self, spec, key, in_tuples):
         # compute plan and rank
-        if not spec.compute_plan_id and spec.rank == 0:
+        if not spec.compute_plan_key and spec.rank == 0:
             #  Create a compute plan
             compute_plan = self.__add_compute_plan(traintuple_keys=[key])
             rank = 0
-            compute_plan_id = compute_plan.compute_plan_id
-        elif not spec.compute_plan_id and spec.rank is not None:
+            compute_plan_key = compute_plan.key
+        elif not spec.compute_plan_key and spec.rank is not None:
             raise substra.sdk.exceptions.InvalidRequest(
                 "invalid inputs, a new ComputePlan should have a rank 0", 400
             )
-        elif spec.compute_plan_id:
-            compute_plan = self._db.get(schemas.Type.ComputePlan, spec.compute_plan_id)
-            compute_plan_id = compute_plan.compute_plan_id
+        elif spec.compute_plan_key:
+            compute_plan = self._db.get(schemas.Type.ComputePlan, spec.compute_plan_key)
+            compute_plan_key = compute_plan.key
             if spec.rank is not None:
                 # Use the rank given by the user
                 rank = spec.rank
@@ -164,7 +164,7 @@ class Local(base.BaseBackend):
                         [
                             in_tuple.rank
                             for in_tuple in in_tuples
-                            if in_tuple.compute_plan_id == compute_plan_id
+                            if in_tuple.compute_plan_key == compute_plan_key
                         ]
                     )
 
@@ -179,10 +179,10 @@ class Local(base.BaseBackend):
             compute_plan.status = models.Status.waiting
 
         else:
-            compute_plan_id = ""
+            compute_plan_key = ""
             rank = 0
 
-        return compute_plan_id, rank
+        return compute_plan_key, rank
 
     def __get_id_rank_in_compute_plan(self, type_, key, id_to_key):
         tuple_ = self._db.get(schemas.Type.Traintuple, key)
@@ -203,7 +203,7 @@ class Local(base.BaseBackend):
             if id_ in traintuples:
                 traintuple = traintuples[id_]
                 traintuple_spec = schemas.TraintupleSpec.from_compute_plan(
-                    compute_plan_id=compute_plan.compute_plan_id,
+                    compute_plan_key=compute_plan.key,
                     id_to_key=compute_plan.id_to_key,
                     rank=rank,
                     spec=traintuple
@@ -214,7 +214,7 @@ class Local(base.BaseBackend):
             elif id_ in aggregatetuples:
                 aggregatetuple = aggregatetuples[id_]
                 aggregatetuple_spec = schemas.AggregatetupleSpec.from_compute_plan(
-                    compute_plan_id=compute_plan.compute_plan_id,
+                    compute_plan_key=compute_plan.key,
                     id_to_key=compute_plan.id_to_key,
                     rank=rank,
                     spec=aggregatetuple
@@ -228,7 +228,7 @@ class Local(base.BaseBackend):
             elif id_ in compositetuples:
                 compositetuple = compositetuples[id_]
                 compositetuple_spec = schemas.CompositeTraintupleSpec.from_compute_plan(
-                    compute_plan_id=compute_plan.compute_plan_id,
+                    compute_plan_key=compute_plan.key,
                     id_to_key=compute_plan.id_to_key,
                     rank=rank,
                     spec=compositetuple
@@ -489,7 +489,7 @@ class Local(base.BaseBackend):
         visited = graph.compute_ranks(node_graph=tuple_graph)
 
         compute_plan = models.ComputePlan(
-            compute_plan_id=key,
+            key=key,
             tag=spec.tag or "",
             status=models.Status.waiting,
             metadata=spec.metadata or dict(),
@@ -543,7 +543,7 @@ class Local(base.BaseBackend):
             authorized_ids = list(authorized_ids)
 
         # compute plan and rank
-        compute_plan_id, rank = self.__create_compute_plan_from_tuple(
+        compute_plan_key, rank = self.__create_compute_plan_from_tuple(
             spec=spec,
             key=key,
             in_tuples=in_traintuples
@@ -571,7 +571,7 @@ class Local(base.BaseBackend):
                 "process": {"public": public, "authorized_ids": authorized_ids},
             },
             log="",
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             tag=spec.tag or "",
             status=models.Status.waiting,
@@ -648,9 +648,9 @@ class Local(base.BaseBackend):
 
         dataset = self._db.get(schemas.Type.Dataset, dataset_key)
 
-        if traintuple.compute_plan_id:
+        if traintuple.compute_plan_key:
             compute_plan = self._db.get(
-                schemas.Type.ComputePlan, traintuple.compute_plan_id
+                schemas.Type.ComputePlan, traintuple.compute_plan_key
             )
             if compute_plan.testtuple_keys is None:
                 compute_plan.testtuple_keys = [key]
@@ -682,7 +682,7 @@ class Local(base.BaseBackend):
             tag=spec.tag or "",
             status=models.Status.waiting,
             rank=traintuple.rank,
-            compute_plan_id=traintuple.compute_plan_id,
+            compute_plan_key=traintuple.compute_plan_key,
             metadata=spec.metadata if spec.metadata else dict(),
             **options,
         )
@@ -738,7 +738,7 @@ class Local(base.BaseBackend):
             in_tuples.append(in_trunk_tuple)
 
         # Compute plan
-        compute_plan_id, rank = self.__create_compute_plan_from_tuple(spec, key, in_tuples)
+        compute_plan_key, rank = self.__create_compute_plan_from_tuple(spec, key, in_tuples)
 
         # permissions
         trunk_model_permissions = schemas.Permissions(
@@ -773,7 +773,7 @@ class Local(base.BaseBackend):
                 "worker": _BACKEND_ID,
             },
             tag=spec.tag or '',
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             status=models.Status.waiting,
             log='',
@@ -829,7 +829,7 @@ class Local(base.BaseBackend):
             in_tuples.append(in_tuple)
 
         # Compute plan
-        compute_plan_id, rank = self.__create_compute_plan_from_tuple(spec, key, in_tuples)
+        compute_plan_key, rank = self.__create_compute_plan_from_tuple(spec, key, in_tuples)
 
         # Permissions
         public = False
@@ -857,7 +857,7 @@ class Local(base.BaseBackend):
                 }
             },
             tag=spec.tag or '',
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             status=models.Status.waiting,
             log='',
@@ -952,16 +952,16 @@ class Local(base.BaseBackend):
         }
         return board
 
-    def cancel_compute_plan(self, compute_plan_id):
+    def cancel_compute_plan(self, key):
         # Execution is synchronous in the local backend so this
         # function does not make sense.
         raise NotImplementedError
 
     def update_compute_plan(self,
-                            compute_plan_id: str,
+                            key: str,
                             spec: schemas.UpdateComputePlanSpec,
                             spec_options: dict = None):
-        compute_plan = self._db.get(schemas.Type.ComputePlan, compute_plan_id)
+        compute_plan = self._db.get(schemas.Type.ComputePlan, key)
 
         # Get all the new tuples and their dependencies
         (

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -255,7 +255,7 @@ class Local(base.BaseBackend):
         return {
             'algo': {
                 'key': algo.key,
-                'checksum': algo.checksum,
+                'checksum': algo.content.checksum,
                 'name': algo.name,
                 'storage_address': str(algo.content.storage_address)
             },
@@ -940,7 +940,7 @@ class Local(base.BaseBackend):
 
     def leaderboard(self, objective_key, sort='desc'):
         objective = self._db.get(schemas.Type.Objective, objective_key)
-        testtuples = self._db.list(schemas.Type.Testtuple)
+        testtuples = self._db.list(schemas.Type.Testtuple, filters=None)
         certified_testtuples = [
             self.__format_for_leaderboard(t)
             for t in testtuples

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -255,6 +255,7 @@ class Local(base.BaseBackend):
         return {
             'algo': {
                 'key': algo.key,
+                'checksum': algo.checksum,
                 'name': algo.name,
                 'storage_address': str(algo.content.storage_address)
             },

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -563,7 +563,7 @@ class Local(base.BaseBackend):
             dataset={
                 "key": spec.data_manager_key,
                 "opener_checksum": data_manager.opener.checksum,
-                "keys": spec.train_data_sample_keys,
+                "data_sample_keys": spec.train_data_sample_keys,
                 "worker": _BACKEND_ID,
                 "metadata": {}
             },
@@ -675,7 +675,7 @@ class Local(base.BaseBackend):
                 "key": dataset_key,
                 "opener_checksum": dataset.opener.checksum,
                 "perf": -1,
-                "keys": test_data_sample_keys,
+                "data_sample_keys": test_data_sample_keys,
                 "worker": _BACKEND_ID,
             },
             log="",
@@ -769,7 +769,7 @@ class Local(base.BaseBackend):
             dataset={
                 "key": spec.data_manager_key,
                 "opener_checksum": dataset.opener.checksum,
-                "keys": spec.train_data_sample_keys,
+                "data_sample_keys": spec.train_data_sample_keys,
                 "worker": _BACKEND_ID,
             },
             tag=spec.tag or '',

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -127,8 +127,8 @@ class Worker:
             algo = self._db.get_with_files(tuple_.algo_type, tuple_.algo.key)
 
             compute_plan = None
-            if tuple_.compute_plan_id:
-                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_id)
+            if tuple_.compute_plan_key:
+                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_key)
 
             volumes = dict()
             # Prepare input models
@@ -168,11 +168,11 @@ class Worker:
                     data_volume = self._get_data_volume(tuple_dir, tuple_)
                     volumes[data_volume] = _VOLUME_INPUT_DATASAMPLES
 
-            if tuple_.compute_plan_id:
+            if tuple_.compute_plan_key:
                 #  Shared compute plan volume
                 local_volume = _mkdir(
                     os.path.join(
-                        self._wdir, "compute_plans", "local", tuple_.compute_plan_id
+                        self._wdir, "compute_plans", "local", tuple_.compute_plan_key
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL
@@ -226,8 +226,8 @@ class Worker:
             tuple_.log = logs
             tuple_.status = models.Status.done
 
-            if tuple_.compute_plan_id:
-                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_id)
+            if tuple_.compute_plan_key:
+                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_key)
                 compute_plan.done_count += 1
                 if compute_plan.done_count == compute_plan.tuple_count:
                     compute_plan.status = models.Status.done
@@ -245,8 +245,8 @@ class Worker:
             dataset = self._db.get_with_files(schemas.Type.Dataset, tuple_.dataset.key)
 
             compute_plan = None
-            if tuple_.compute_plan_id:
-                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_id)
+            if tuple_.compute_plan_key:
+                compute_plan = self._db.get(schemas.Type.ComputePlan, tuple_.compute_plan_key)
 
             # prepare model and datasamples
             predictions_volume = _mkdir(os.path.join(tuple_dir, "pred"))
@@ -263,10 +263,10 @@ class Worker:
                 data_volume = self._get_data_volume(tuple_dir, tuple_)
                 volumes[data_volume] = _VOLUME_INPUT_DATASAMPLES
 
-            if tuple_.compute_plan_id:
+            if tuple_.compute_plan_key:
                 local_volume = _mkdir(
                     os.path.join(
-                        self._wdir, "compute_plans", "local", tuple_.compute_plan_id
+                        self._wdir, "compute_plans", "local", tuple_.compute_plan_key
                     )
                 )
                 volumes[local_volume] = _VOLUME_LOCAL

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -62,7 +62,7 @@ class Worker:
     def _get_data_volume(self, tuple_dir, tuple_):
         data_volume = _mkdir(os.path.join(tuple_dir, "data"))
         samples = [
-            self._db.get(schemas.Type.DataSample, key) for key in tuple_.dataset.keys
+            self._db.get(schemas.Type.DataSample, key) for key in tuple_.dataset.data_sample_keys
         ]
         for sample in samples:
             # TODO more efficient link (symlink?)
@@ -187,7 +187,7 @@ class Worker:
             if not isinstance(tuple_, models.Aggregatetuple) \
                     and not self._db.is_local(tuple_.dataset.key):
                 command += " --fake-data"
-                command += f" --n-fake-samples {len(tuple_.dataset.keys)}"
+                command += f" --n-fake-samples {len(tuple_.dataset.data_sample_keys)}"
 
             # Add the in_models to the command
             if isinstance(tuple_, models.CompositeTraintuple):
@@ -276,7 +276,7 @@ class Worker:
 
             if not self._db.is_local(dataset.key):
                 command += " --fake-data"
-                command += f" --n-fake-samples {len(tuple_.dataset.keys)}"
+                command += f" --n-fake-samples {len(tuple_.dataset.data_sample_keys)}"
 
             if tuple_.traintuple_type == schemas.Type.Traintuple \
                     or tuple_.traintuple_type == schemas.Type.Aggregatetuple:
@@ -323,7 +323,7 @@ class Worker:
                 command = f"--fake-data-mode {METRICS_NO_FAKE_Y}"
             else:
                 command = f"--fake-data-mode {METRICS_FAKE_Y}"
-                command += f" --n-fake-samples {len(tuple_.dataset.keys)}"
+                command += f" --n-fake-samples {len(tuple_.dataset.data_sample_keys)}"
 
             container_name = DOCKER_METRICS_TAG
             logs_predict = self._spawner.spawn(

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -74,7 +74,7 @@ class Worker:
         model_dir = _mkdir(os.path.join(self._wdir, "models", tuple_.key))
         model_path = os.path.join(model_dir, model_name)
         shutil.copy(tmp_path, model_path)
-        return models.OutModel(key=str(uuid.uuid4()), hash=fs.hash_file(model_path),
+        return models.OutModel(key=str(uuid.uuid4()), checksum=fs.hash_file(model_path),
                                storage_address=model_path)
 
     def _get_command_models_composite(self, is_train, tuple_, models_volume, container_volume):

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -15,7 +15,7 @@
 import collections
 import logging
 
-from substra.sdk import exceptions, models
+from substra.sdk import exceptions
 
 logger = logging.getLogger(__name__)
 

--- a/substra/sdk/backends/local/db.py
+++ b/substra/sdk/backends/local/db.py
@@ -30,11 +30,7 @@ class InMemoryDb:
     def add(self, asset):
         """Add an asset."""
         type_ = asset.__class__.type_
-
-        if type_ == models.ComputePlan.type_:
-            key = asset.compute_plan_id
-        else:
-            key = asset.key
+        key = asset.key
 
         self._data[type_][key] = asset
         logger.info(f"{type_} with key '{key}' has been created.")
@@ -55,10 +51,7 @@ class InMemoryDb:
 
     def update(self, asset):
         type_ = asset.__class__.type_
-        if type_ == models.ComputePlan.type_:
-            key = asset.compute_plan_id
-        else:
-            key = asset.key
+        key = asset.key
 
         if key not in self._data[type_]:
             raise exceptions.NotFound(f"Wrong pk {key}", 404)

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -158,7 +158,7 @@ class Remote(base.BaseBackend):
             first_spec = next(batches, None)
             tmp_spec = first_spec or spec  # Special case: no tuples
             asset = self.add(spec=tmp_spec, spec_options=deepcopy(spec_options))
-            compute_plan_key = asset.compute_plan_key
+            compute_plan_key = asset.key
             id_to_keys = asset.id_to_key
 
         # Update the compute plan

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -164,7 +164,7 @@ class Remote(base.BaseBackend):
         # Update the compute plan
         for tmp_spec in batches:
             asset = self.update_compute_plan(
-                compute_plan_key=compute_plan_key,
+                key=compute_plan_key,
                 spec=tmp_spec,
                 spec_options=deepcopy(spec_options)
             )

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -588,7 +588,7 @@ class Client(object):
         traintuples cannot be made public.
 
         Args:
-            key (str): Id of the compute plan
+            key (str): Compute plan key
             data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
                 it must have the same keys as specified in
                 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -577,7 +577,7 @@ class Client(object):
     @logit
     def update_compute_plan(
         self,
-        compute_plan_id: str,
+        key: str,
         data: Union[dict, schemas.UpdateComputePlanSpec],
         auto_batching: bool = True,
         batch_size: int = DEFAULT_BATCH_SIZE
@@ -588,7 +588,7 @@ class Client(object):
         traintuples cannot be made public.
 
         Args:
-            compute_plan_id (str): Id of the compute plan
+            key (str): Id of the compute plan
             data (Union[dict, schemas.UpdateComputePlanSpec]): If it is a dict,
                 it must have the same keys as specified in
                 [schemas.UpdateComputePlanSpec](sdk_schemas.md#UpdateComputePlanSpec).
@@ -607,7 +607,7 @@ class Client(object):
             "batch_size": batch_size,
         }
         return self._backend.update_compute_plan(
-            compute_plan_id,
+            key,
             spec,
             spec_options=spec_options
         )
@@ -723,7 +723,7 @@ class Client(object):
         return self._backend.leaderboard(objective_key, sort='desc')
 
     @logit
-    def cancel_compute_plan(self, compute_plan_id: str) -> models.ComputePlan:
+    def cancel_compute_plan(self, key: str) -> models.ComputePlan:
         """Cancel execution of compute plan, the returned object is described
         in the [models.ComputePlan](sdk_models.md#ComputePlan) model"""
-        return self._backend.cancel_compute_plan(compute_plan_id)
+        return self._backend.cancel_compute_plan(key)

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -99,9 +99,7 @@ class RequestTimeout(HTTPError):
         r = request_exception.response.json()
 
         try:
-            key = r.get('compute_plan_id') or (
-                r['key'] if 'key' in r else r['message'].get('key')
-            )
+            key = r['key'] if 'key' in r else r['message'].get('key')
         except (AttributeError, KeyError):
             # XXX this is the case when doing a POST query to update the
             #     data manager for instance

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -200,7 +200,7 @@ class Traintuple(_Model):
     dataset: _TraintupleDataset
     permissions: Permissions
     tag: str
-    compute_plan_id: str
+    compute_plan_key: str
     rank: int
     status: str
     log: str
@@ -220,7 +220,7 @@ class Aggregatetuple(_Model):
     algo: _TraintupleAlgo
     permissions: Permissions
     tag: str
-    compute_plan_id: str
+    compute_plan_key: str
     rank: Optional[int]
     status: str
     log: str
@@ -266,7 +266,7 @@ class CompositeTraintuple(_Model):
     algo: _TraintupleAlgo
     dataset: _TraintupleDataset
     tag: str
-    compute_plan_id: str
+    compute_plan_key: str
     rank: Optional[int]
     status: str
     log: str
@@ -309,7 +309,7 @@ class Testtuple(_Model):
     tag: Optional[str]
     log: str
     status: str
-    compute_plan_id: str
+    compute_plan_key: str
     rank: int
     traintuple_type: schemas.Type
     metadata: Dict[str, str]
@@ -323,7 +323,7 @@ class Testtuple(_Model):
 
 class ComputePlan(_Model):
     """ComputePlan"""
-    compute_plan_id: str
+    key: str
     status: str
     traintuple_keys: Optional[List[str]]
     composite_traintuple_keys: Optional[List[str]]
@@ -339,7 +339,7 @@ class ComputePlan(_Model):
     type_: ClassVar[str] = schemas.Type.ComputePlan
 
     def __str__(self):
-        return f"{self.__class__.type_.value}(key={self.compute_plan_id})"
+        return f"{self.__class__.type_.value}(key={self.key})"
 
 
 class Node(schemas._PydanticConfig):

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -112,10 +112,6 @@ class _Metric(schemas._PydanticConfig):
     checksum: str
     storage_address: UriPath
 
-    @property
-    def key(self):
-        return self.checksum
-
 
 class Objective(_Model):
     """Objective"""

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -77,7 +77,7 @@ class DataSample(_Model):
 
 class _File(schemas._PydanticConfig):
     """File as stored in the models"""
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: UriPath
 
 
@@ -109,12 +109,12 @@ class _ObjectiveDataset(schemas._PydanticConfig):
 class _Metric(schemas._PydanticConfig):
     """Metric associated to a testtuple or objective"""
     name: Optional[str]
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: UriPath
 
     @property
     def key(self):
-        return self.hash_
+        return self.checksum
 
 
 class Objective(_Model):
@@ -161,8 +161,8 @@ class CompositeAlgo(_Algo):
 class _TraintupleDataset(schemas._PydanticConfig):
     """Dataset as stored in a traintuple or composite traintuple"""
     key: str
-    opener_hash: str
-    keys: List[str]
+    opener_checksum: str
+    data_sample_keys: List[str]
     worker: str
     metadata: Optional[Dict[str, str]]
 
@@ -171,7 +171,7 @@ class InModel(schemas._PydanticConfig):
     """In model of a traintuple, aggregate tuple or in trunk
     model of a composite traintuple"""
     key: str
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: UriPath
     traintuple_key: Optional[str]
 
@@ -180,14 +180,14 @@ class OutModel(schemas._PydanticConfig):
     """Out model of a traintuple, aggregate tuple or out trunk
     model of a composite traintuple"""
     key: str
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: UriPath
 
 
 class _TraintupleAlgo(schemas._PydanticConfig):
     """Algo associated to a traintuple"""
     key: str
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: UriPath
     name: str
 
@@ -235,7 +235,7 @@ class Aggregatetuple(_Model):
 class InHeadModel(schemas._PydanticConfig):
     """In head model of a composite traintuple"""
     key: str
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: Optional[UriPath]  # Defined for local assets but not remote ones
     traintuple_key: Optional[str]
 
@@ -243,7 +243,7 @@ class InHeadModel(schemas._PydanticConfig):
 class OutHeadModel(schemas._PydanticConfig):
     """Out head model of a composite traintuple"""
     key: str
-    hash_: str = pydantic.Field(..., alias="hash")
+    checksum: str
     storage_address: Optional[FilePath]  # Defined for local assets but not remote ones
 
 
@@ -285,9 +285,9 @@ class CompositeTraintuple(_Model):
 class _TesttupleDataset(schemas._PydanticConfig):
     """Dataset of a testtuple"""
     key: str
-    opener_hash: str
+    opener_checksum: str
     perf: float
-    keys: List[str]
+    data_sample_keys: List[str]
     worker: str
 
 

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -278,7 +278,7 @@ class TraintupleSpec(_Spec):
     train_data_sample_keys: List[str]
     in_models_keys: Optional[List[str]]
     tag: Optional[str]
-    compute_plan_id: Optional[str]
+    compute_plan_key: Optional[str]
     rank: Optional[int]  # Rank of the traintuple in the compute plan
     metadata: Optional[Dict[str, str]]
 
@@ -289,7 +289,7 @@ class TraintupleSpec(_Spec):
     @classmethod
     def from_compute_plan(
         cls,
-        compute_plan_id: str,
+        compute_plan_key: str,
         id_to_key: typing.Dict[str, str],
         rank: int,
         spec: ComputePlanTraintupleSpec
@@ -302,7 +302,7 @@ class TraintupleSpec(_Spec):
                 id_to_key[parent_id] for parent_id in spec.in_models_ids
             ],
             tag=spec.tag,
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             metadata=spec.metadata
         )
@@ -314,7 +314,7 @@ class AggregatetupleSpec(_Spec):
     worker: str
     in_models_keys: List[str]
     tag: Optional[str]
-    compute_plan_id: Optional[str]
+    compute_plan_key: Optional[str]
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
 
@@ -325,7 +325,7 @@ class AggregatetupleSpec(_Spec):
     @classmethod
     def from_compute_plan(
         cls,
-        compute_plan_id: str,
+        compute_plan_key: str,
         id_to_key: typing.Dict[str, str],
         rank: int,
         spec: ComputePlanAggregatetupleSpec
@@ -338,7 +338,7 @@ class AggregatetupleSpec(_Spec):
                 for parent_id in spec.in_models_ids
             ],
             tag=spec.tag,
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             metadata=spec.metadata
         )
@@ -352,7 +352,7 @@ class CompositeTraintupleSpec(_Spec):
     in_head_model_key: Optional[str]
     in_trunk_model_key: Optional[str]
     tag: Optional[str]
-    compute_plan_id: Optional[str]
+    compute_plan_key: Optional[str]
     out_trunk_model_permissions: PrivatePermissions
     rank: Optional[int]
     metadata: Optional[Dict[str, str]]
@@ -363,7 +363,7 @@ class CompositeTraintupleSpec(_Spec):
     @classmethod
     def from_compute_plan(
         cls,
-        compute_plan_id: str,
+        compute_plan_key: str,
         id_to_key: typing.Dict[str, str],
         rank: int,
         spec: ComputePlanCompositeTraintupleSpec
@@ -380,7 +380,7 @@ class CompositeTraintupleSpec(_Spec):
                 "authorized_ids": spec.out_trunk_model_permissions.authorized_ids
             },
             tag=spec.tag,
-            compute_plan_id=compute_plan_id,
+            compute_plan_key=compute_plan_key,
             rank=rank,
             metadata=spec.metadata
         )

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -158,7 +158,7 @@ TRAINTUPLE = {
         ],
         "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
     },
-    "compute_plan_id": "",
+    "compute_plan_key": "",
     "in_models": None,
     "log": "[00-01-0032-d415995]",
     "out_model": None,
@@ -185,7 +185,7 @@ AGGREGATETUPLE = {
         "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462f1eb813b94c3e67de29f6e4b2272ae60385f5",
-    "compute_plan_id": "",
+    "compute_plan_key": "",
     "in_models": [],
     "log": "[00-01-0032-d415995]",
     "out_model": None,
@@ -231,7 +231,7 @@ COMPOSITE_TRAINTUPLE = {
         ],
         "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
     },
-    "compute_plan_id": "",
+    "compute_plan_key": "",
     "log": "[00-01-0032-d415995]",
     "out_head_model": {
         "permissions": {
@@ -270,7 +270,7 @@ TESTTUPLE = {
     "key": "97b53511-e94c-ab17-ea8b-1c31982e0b0d",
     "traintuple_key": "1197bbfc-4a18-9ea0-37a6-835895a81bb8",
     "traintuple_type": "traintuple",
-    "compute_plan_id": "",
+    "compute_plan_key": "",
     "rank": 0,
     "algo": {
         "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
@@ -342,7 +342,7 @@ NODES = [
 ]
 
 COMPUTE_PLAN = {
-    "compute_plan_id": "e983a185-5368-bd0a-0190-183af9a8e560",
+    "key": "e983a185-5368-bd0a-0190-183af9a8e560",
     "traintuple_keys": [
         "1197bbfc-4a18-9ea0-37a6-835895a81bb8"
     ],

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 OBJECTIVE = {
     "description": {
-        "hash": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+        "checksum": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
         "storage_address": "",
     },
     "key": "d5002e1c-d50b-d5de-5341-df8a7b7d11b6",
     "metrics": {
-        "hash": "750f622262854341bd44f55c1018949e9c119606ef5068bd7d137040a482a756",
+        "checksum": "750f622262854341bd44f55c1018949e9c119606ef5068bd7d137040a482a756",
         "name": "macro-average recall",
         "storage_address": "",
     },
@@ -45,13 +45,13 @@ OBJECTIVE = {
 DATASET = {
     "objective_key": "7a90514f-88c7-0002-608a-9868681dd158",
     "description": {
-        "hash": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+        "checksum": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
         "storage_address": "",
     },
     "key": "ccbaa337-2bc7-4bce-39ce-3b138f558b3a",
     "name": "ISIC 2018",
     "opener": {
-        "hash": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+        "checksum": "7a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
         "storage_address": "",
     },
     "owner": "c657699f8b03c19e6eadc7b474c23f26dd83454395266a673406f2cf44de2ca2",
@@ -74,11 +74,11 @@ ALGO = {
     "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
     "name": "Logistic regression",
     "content": {
-        "hash": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+        "checksum": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
         "storage_address": ""
     },
     "description": {
-        "hash": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
+        "checksum": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
         "storage_address": ""
     },
     "owner": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4feade2d62a8b708fdde48fb0edea",
@@ -98,11 +98,11 @@ AGGREGATE_ALGO = {
     "key": "7c9f9799-bf64-c100-6238-1583a9ffc535",
     "name": "Logistic regression",
     "content": {
-        "hash": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6g0c614d3f6f868f72a9d5",
+        "checksum": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6g0c614d3f6f868f72a9d5",
         "storage_address": ""
     },
     "description": {
-        "hash": "124a0725b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
+        "checksum": "124a0725b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
         "storage_address": ""
     },
     "owner": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4feade2d62a8b708fdde48fb0edeb",
@@ -121,11 +121,11 @@ COMPOSITE_ALGO = {
     "key": "7c9f9799-bf64-c100-0238-b583a9ffc535",
     "name": "Logistic regression",
     "content": {
-        "hash": "7c9f9799bf64c10002381b83a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+        "checksum": "7c9f9799bf64c10002381b83a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
         "storage_address": ""
     },
     "description": {
-        "hash": "124a0425b746d7b72282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
+        "checksum": "124a0425b746d7b72282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
         "storage_address": ""
     },
     "owner": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4beade2d62a8b708fdde48fb0edea",
@@ -145,18 +145,18 @@ TRAINTUPLE = {
     "algo": {
         "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
         "name": "Neural Network",
-        "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
+        "checksum": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
         "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462e1eb813b94c3e67de29f6e4b2272ae60385f5",
     "dataset": {
         "key": "8dd01465-003a-9b1e-01c9-9c904d86aa51",
         "worker": "e75db4df2532dc1313ebb5c2462e1eb813b94c3e67de29f6e4b2272ae60385f5",
-        "keys": [
+        "data_sample_keys": [
             "31510dc1-d8be-788f-7c5d-28d05714f7ef",
             "03a1f878-768e-a862-4942-d46a3b438c37"
         ],
-        "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+        "opener_checksum": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
     },
     "compute_plan_key": "",
     "in_models": None,
@@ -181,7 +181,7 @@ AGGREGATETUPLE = {
     "algo": {
         "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
         "name": "Neural Network",
-        "hash": "0acc5180e09b6a6ac250f4f3c172e2893f617aa1c22ef1f379019d20fe44142f",
+        "checksum": "0acc5180e09b6a6ac250f4f3c172e2893f617aa1c22ef1f379019d20fe44142f",
         "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462f1eb813b94c3e67de29f6e4b2272ae60385f5",
@@ -209,27 +209,27 @@ COMPOSITE_TRAINTUPLE = {
     "algo": {
         "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
         "name": "Neural Network",
-        "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
+        "checksum": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
         "storage_address": ""
     },
     "in_head_model": {
         "key": "0acc5180-e09b-6a6a-c250-f4e3d972e289",
-        "hash": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142e",
+        "checksum": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142e",
     },
     "in_trunk_model": {
         "key": "0acc5180-e09b-6a6a-c250-f4e3d972e289",
-        "hash": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142f",
+        "checksum": "0acc5180e09b6a6ac250f4e3d972e2893f617aa1c22ef1f379019d20fe44142f",
         "storage_address": ""
     },
     "creator": "e75db4df2532dc1313ebb5c2462e1eb813b94c3e67de29f6e4b2272ae60385f5",
     "dataset": {
         "key": "8dd01465-003a-9b1e-01c9-9c904d86aa51",
         "worker": "e75db4df2532dc1313ebb5c2462e1eb813b94c3e67de29f6e4b2272ae60385f5",
-        "keys": [
+        "data_sample_keys": [
             "31510dc1-d8be-788f-7c5d-28d05714f7ef",
             "03a1f878-768e-a862-4942-d46a3b438c37"
         ],
-        "opener_hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+        "opener_checksum": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
     },
     "compute_plan_key": "",
     "log": "[00-01-0032-d415995]",
@@ -242,7 +242,7 @@ COMPOSITE_TRAINTUPLE = {
         },
         "out_model": {
             "key": "8a90514f-88c7-0002-608a-9868681dd158",
-            "hash": "8a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+            "checksum": "8a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
         }
     },
     "out_trunk_model": {
@@ -254,7 +254,7 @@ COMPOSITE_TRAINTUPLE = {
         },
         "out_model": {
             "key": "9a90514f-88c7-0002-608a-9868681dd158",
-            "hash": "9a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+            "checksum": "9a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
             "storage_address": ""
         }
     },
@@ -275,7 +275,7 @@ TESTTUPLE = {
     "algo": {
         "key": "7c9f9799-bf64-c100-0238-1583a9ffc535",
         "name": "Logistic regression",
-        "hash": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
+        "checksum": "7c9f9799bf64c10002381583a9ffc535bc3f4bf14d6f0c614d3f6f868f72a9d5",
         "storage_address": "",
     },
     "certified": True,
@@ -283,18 +283,18 @@ TESTTUPLE = {
     "dataset": {
         "key": "ce9f292c-72e9-b826-9744-5117f9c2d1d1",
         "worker": "ab75010bacbd1a4b826dc2e9ead6f1e4e1c4feade2d62a8b708fdde48fb0edea",
-        "keys": [
+        "data_sample_keys": [
             "17d58b67-ae20-2801-8108-c9bf555fa58b",
             "8bf3bf4f-753a-32f2-7d18-c86405e7a406"
         ],
-        "opener_hash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
+        "opener_checksum": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
         "perf": 0
     },
     "log": "Test - CPU:90.07 % - Mem:0.13 GB - GPU:0.00 % - GPU Mem:0.00 GB;",
     "objective": {
         "key": "3d70ab46-d710-dacb-0f48-cb42db4874fa",
         "metrics": {
-            "hash": "c42dca31fbc2ebb5705643e3bb6ee666bbfd956de13dd03727f825ad8445b4d7",
+            "checksum": "c42dca31fbc2ebb5705643e3bb6ee666bbfd956de13dd03727f825ad8445b4d7",
             "storage_address": "",
         }
     },
@@ -310,12 +310,12 @@ LEADERBOARD = {
         "key": "c6a6139a-28b5-936c-1086-a49d7c772734",
         "name": "data-network - Objective 1",
         "description": {
-            "hash": "c6a6139a28b5936c1086a49d7c772734f4ad65f4580ca4ab14029a925847faf3",
+            "checksum": "c6a6139a28b5936c1086a49d7c772734f4ad65f4580ca4ab14029a925847faf3",
             "storage_address": ""
         },
         "metrics": {
             "name": "test metrics",
-            "hash": "48e748a15552ea2a8a258f6e8e75b1d67da5d6ca7471f80f9b69dae3cb950335",
+            "checksum": "48e748a15552ea2a8a258f6e8e75b1d67da5d6ca7471f80f9b69dae3cb950335",
             "storage_address": ""
         },
         "owner": "MyOrg2MSP",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -287,25 +287,25 @@ def test_command_add_data_sample_already_exists(workdir, mocker):
     m.assert_called()
 
 
-@pytest.mark.parametrize('asset_name,key_field,model', [
-    ('objective', 'key', models.Objective),
-    ('dataset', 'key', models.Dataset),
-    ('algo', 'key', models.Algo),
-    ('aggregate_algo', 'key', models.AggregateAlgo),
-    ('composite_algo', 'key', models.CompositeAlgo),
-    ('testtuple', 'key', models.Testtuple),
-    ('traintuple', 'key', models.Traintuple),
-    ('aggregatetuple', 'key', models.Aggregatetuple),
-    ('composite_traintuple', 'key', models.CompositeTraintuple),
-    ('compute_plan', 'key', models.ComputePlan),
+@pytest.mark.parametrize('asset_name,model', [
+    ('objective', models.Objective),
+    ('dataset', models.Dataset),
+    ('algo', models.Algo),
+    ('aggregate_algo', models.AggregateAlgo),
+    ('composite_algo', models.CompositeAlgo),
+    ('testtuple', models.Testtuple),
+    ('traintuple', models.Traintuple),
+    ('aggregatetuple', models.Aggregatetuple),
+    ('composite_traintuple', models.CompositeTraintuple),
+    ('compute_plan', models.ComputePlan),
 ])
-def test_command_get(asset_name, key_field, model, workdir, mocker):
+def test_command_get(asset_name, model, workdir, mocker):
     item = model(**getattr(datastore, asset_name.upper()))
     method_name = f'get_{asset_name}'
     m = mock_client_call(mocker, method_name, item)
     output = client_execute(workdir, ['get', asset_name, 'fakekey'])
     m.assert_called()
-    assert getattr(item, key_field) in output
+    assert item.key in output
 
 
 def test_command_describe(workdir, mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,7 +114,7 @@ def test_command_login(workdir, mocker):
     ('traintuple', 'key', models.Traintuple),
     ('aggregatetuple', 'key', models.Aggregatetuple),
     ('composite_traintuple', 'key', models.CompositeTraintuple),
-    ('compute_plan', 'compute_plan_id', models.ComputePlan),
+    ('compute_plan', 'key', models.ComputePlan),
 ])
 def test_command_list(asset_name, key_field, model, workdir, mocker):
     item = model(**getattr(datastore, asset_name.upper()))
@@ -297,7 +297,7 @@ def test_command_add_data_sample_already_exists(workdir, mocker):
     ('traintuple', 'key', models.Traintuple),
     ('aggregatetuple', 'key', models.Aggregatetuple),
     ('composite_traintuple', 'key', models.CompositeTraintuple),
-    ('compute_plan', 'compute_plan_id', models.ComputePlan),
+    ('compute_plan', 'key', models.ComputePlan),
 ])
 def test_command_get(asset_name, key_field, model, workdir, mocker):
     item = model(**getattr(datastore, asset_name.upper()))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,25 +104,25 @@ def test_command_login(workdir, mocker):
     m.assert_called()
 
 
-@pytest.mark.parametrize('asset_name,key_field,model', [
-    ('objective', 'key', models.Objective),
-    ('dataset', 'key', models.Dataset),
-    ('algo', 'key', models.Algo),
-    ('aggregate_algo', 'key', models.AggregateAlgo),
-    ('composite_algo', 'key', models.CompositeAlgo),
-    ('testtuple', 'key', models.Testtuple),
-    ('traintuple', 'key', models.Traintuple),
-    ('aggregatetuple', 'key', models.Aggregatetuple),
-    ('composite_traintuple', 'key', models.CompositeTraintuple),
-    ('compute_plan', 'key', models.ComputePlan),
+@pytest.mark.parametrize('asset_name,model', [
+    ('objective', models.Objective),
+    ('dataset', models.Dataset),
+    ('algo', models.Algo),
+    ('aggregate_algo', models.AggregateAlgo),
+    ('composite_algo', models.CompositeAlgo),
+    ('testtuple', models.Testtuple),
+    ('traintuple', models.Traintuple),
+    ('aggregatetuple', models.Aggregatetuple),
+    ('composite_traintuple', models.CompositeTraintuple),
+    ('compute_plan', models.ComputePlan),
 ])
-def test_command_list(asset_name, key_field, model, workdir, mocker):
+def test_command_list(asset_name, model, workdir, mocker):
     item = model(**getattr(datastore, asset_name.upper()))
     method_name = f'list_{asset_name}'
     m = mock_client_call(mocker, method_name, [item])
     output = client_execute(workdir, ['list', asset_name])
     m.assert_called()
-    assert getattr(item, key_field) in output
+    assert item.key in output
 
 
 def test_command_list_node(workdir, mocker):


### PR DESCRIPTION
Follow-up to https://github.com/SubstraFoundation/substra/pull/235

Companion PRs:

- https://github.com/SubstraFoundation/substra-backend/pull/345
- https://github.com/SubstraFoundation/substra-chaincode/pull/129
- https://github.com/SubstraFoundation/substra-tests/pull/158

Rename:

| Before | After |
|---|----|
| `compute_plan_id` | `compute_plan_key` (or simply `key`) |
|  `hash` | `checksum` |
| `data_manager.keys` | `data_manager.data_sample_keys` |
