### PR TITLE
Fix update CP with schema as input

### DIFF
--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -630,7 +630,7 @@ class Client(object):
             models.ComputePlan: updated compute plan, as described in the
             [models.ComputePlan](sdk_models.md#ComputePlan) model
         """
-        spec = schemas.UpdateComputePlanSpec(**data)
+        spec = self._get_spec(schemas.UpdateComputePlanSpec, data)
         spec_options = {
             "auto_batching": auto_batching,
             "batch_size": batch_size,

--- a/tests/sdk/test_update.py
+++ b/tests/sdk/test_update.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from substra.sdk import models
+from substra.sdk import models, schemas
 
 from .. import datastore
 from .utils import mock_requests
@@ -36,6 +36,18 @@ def test_update_compute_plan(client, mocker):
     m_get = mock_requests(mocker, "get", response=datastore.COMPUTE_PLAN)
 
     response = client.update_compute_plan('foo', {})
+
+    assert response == models.ComputePlan(**item)
+    m.assert_called
+    m_get.assert_called
+
+
+def test_update_compute_plan_with_schema(client, mocker):
+    item = datastore.COMPUTE_PLAN
+    m = mock_requests(mocker, "post", response=item)
+    m_get = mock_requests(mocker, "get", response=datastore.COMPUTE_PLAN)
+
+    response = client.update_compute_plan('foo', schemas.UpdateComputePlanSpec())
 
     assert response == models.ComputePlan(**item)
     m.assert_called


### PR DESCRIPTION
## Bugfix

### Description

Call the client function `update_compute_plan` with `data` of type schemas.UpdateComputePlanSpec fails.  
trying with `data` of type dict works

### Changes

Fixed the bug and added a test
