### PR TITLE
debug mode - fix update CP after an add

### DIFF
--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -300,7 +300,8 @@ class TraintupleSpec(_Spec):
             train_data_sample_keys=spec.train_data_sample_keys,
             in_models_keys=[
                 # in model ids can either be ids or keys to other assets
-                id_to_key[parent_id] if parent_id in id_to_key else parent_id for parent_id in spec.in_models_ids
+                id_to_key[parent_id] if parent_id in id_to_key else parent_id
+                for parent_id in spec.in_models_ids
             ] if spec.in_models_ids is not None else list(),
             tag=spec.tag,
             compute_plan_key=compute_plan_key,

--- a/substra/sdk/schemas.py
+++ b/substra/sdk/schemas.py
@@ -299,7 +299,8 @@ class TraintupleSpec(_Spec):
             data_manager_key=spec.data_manager_key,
             train_data_sample_keys=spec.train_data_sample_keys,
             in_models_keys=[
-                id_to_key[parent_id] for parent_id in spec.in_models_ids
+                # in model ids can either be ids or keys to other assets
+                id_to_key[parent_id] if parent_id in id_to_key else parent_id for parent_id in spec.in_models_ids
             ] if spec.in_models_ids is not None else list(),
             tag=spec.tag,
             compute_plan_key=compute_plan_key,

--- a/tests/sdk/test_debug.py
+++ b/tests/sdk/test_debug.py
@@ -61,3 +61,49 @@ def test_client_multi_nodes_cp(asset_factory):
 
     assert path_cp_1.is_dir()
     assert path_cp_2.is_dir()
+
+
+def test_compute_plan_add_update(asset_factory):
+    client = substra.Client(debug=True)
+    compute_plan = client.add_compute_plan(
+        substra.sdk.schemas.ComputePlanSpec(
+            tag=None,
+            clean_models=False,
+            metadata=dict(),
+        ))
+
+    dataset_query = asset_factory.create_dataset()
+    dataset_key = client.add_dataset(dataset_query)
+
+    data_sample = asset_factory.create_data_sample(datasets=[dataset_key], test_only=False)
+    data_sample_key = client.add_data_sample(data_sample)
+
+    algo_query = asset_factory.create_algo()
+    algo_key = client.add_algo(algo_query)
+
+    traintuple_key = client.add_traintuple(
+        substra.sdk.schemas.TraintupleSpec(
+            algo_key=algo_key,
+            data_manager_key=dataset_key,
+            train_data_sample_keys=[data_sample_key],
+            in_models_keys=None,
+            compute_plan_key=compute_plan.key,
+            rank=None,
+            metadata=None,
+        )
+    )
+
+    traintuple = substra.sdk.schemas.ComputePlanTraintupleSpec(
+        algo_key=algo_key,
+        data_manager_key=dataset_key,
+        train_data_sample_keys=[data_sample_key],
+        in_models_ids=[traintuple_key],
+        traintuple_id=0,
+    )
+
+    compute_plan = client.update_compute_plan(
+        key=compute_plan.key,
+        data={
+            "traintuples": [traintuple],
+        }
+    )


### PR DESCRIPTION
### Description

Debug mode - bug fix

This is a bug fix on the update of a compute plan after having added other tuples by setting their compute plan key. The code of the error is similar to this:

```python
cp = client.create_compute_plan(...)
client.add_traintuple({compute_plan_key = cp.key, ...})
traintuple_specs = ... # specs of type substra.schemas.Type.ComputePlanTraintupleSpec, no in models
client.update_compute_plan({'traintuples': traintuple_specs})
```

(created a test to reproduce it)

### Changes

In the `update_compute_plan` function, for each tuple, in their in_model_ids, **ids and keys** are accepted.  
Ids can be the ids assets added during the same call or in a previous call to `update_compute_plan` (there are tests in substra-tests that expect this behaviour).   
That means that we need to save the `id_to_key` mapping between updates.

### How to test

- See the test I added on Substra: `substra/tests/sdk/test_debug.py::test_compute_plan_add_update`
- in substra-tests: `substra-tests/tests/test_execution_compute_plan.py::test_compute_plan_update`