### PR TITLE
debug: move the chainkeys to local-worker

### DIFF
--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -28,12 +28,13 @@ _BACKEND_ID = "local-backend"
 _MAX_LEN_KEY_METADATA = 50
 _MAX_LEN_VALUE_METADATA = 100
 DEBUG_OWNER = "debug_owner"
+LOCAL_DIR = Path.cwd() / "local-worker"
 
 
 class Local(base.BaseBackend):
     def __init__(self, backend, *args, **kwargs):
         self._support_chainkeys = bool(util.strtobool(os.getenv("CHAINKEYS_ENABLED", 'False')))
-        self._chainkey_dir = Path(os.getenv("CHAINKEYS_DIR", Path.home() / ".substra_chainkeys"))
+        self._chainkey_dir = LOCAL_DIR / "chainkeys"
         if self._support_chainkeys:
             print(f"Chainkeys support is on, the directory is {self._chainkey_dir}")
         # create a store to abstract the db

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from pathlib import Path
 import shutil
 import typing
 import warnings
@@ -28,13 +27,12 @@ _BACKEND_ID = "local-backend"
 _MAX_LEN_KEY_METADATA = 50
 _MAX_LEN_VALUE_METADATA = 100
 DEBUG_OWNER = "debug_owner"
-LOCAL_DIR = Path.cwd() / "local-worker"
 
 
 class Local(base.BaseBackend):
     def __init__(self, backend, *args, **kwargs):
         self._support_chainkeys = bool(util.strtobool(os.getenv("CHAINKEYS_ENABLED", 'False')))
-        self._chainkey_dir = LOCAL_DIR / "chainkeys"
+        self._chainkey_dir = compute.LOCAL_DIR / "chainkeys"
         if self._support_chainkeys:
             print(f"Chainkeys support is on, the directory is {self._chainkey_dir}")
         # create a store to abstract the db

--- a/substra/sdk/backends/local/compute/__init__.py
+++ b/substra/sdk/backends/local/compute/__init__.py
@@ -1,6 +1,7 @@
-from substra.sdk.backends.local.compute.worker import Worker
+from substra.sdk.backends.local.compute.worker import Worker, LOCAL_DIR
 
 
 __all__ = [
     'Worker',
+    'LOCAL_DIR',
 ]

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -20,6 +20,7 @@ import uuid
 
 from substra.sdk import schemas, fs, models
 from substra.sdk.backends.local import dal
+from substra.sdk.backends.local.backend import LOCAL_DIR
 from substra.sdk.backends.local.compute import spawner
 
 _CONTAINER_MODEL_PATH = "/sandbox/model"
@@ -54,7 +55,7 @@ class Worker:
     """ML Worker."""
 
     def __init__(self, db: dal.DataAccess, support_chainkeys: bool, chainkey_dir=None):
-        self._wdir = os.path.join(os.getcwd(), "local-worker")
+        self._wdir = LOCAL_DIR
         self._db = db
         self._spawner = spawner.get()
         self._support_chainkeys = support_chainkeys

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -20,8 +20,9 @@ import uuid
 
 from substra.sdk import schemas, fs, models
 from substra.sdk.backends.local import dal
-from substra.sdk.backends.local.backend import LOCAL_DIR
 from substra.sdk.backends.local.compute import spawner
+
+LOCAL_DIR = pathlib.Path.cwd() / "local-worker"
 
 _CONTAINER_MODEL_PATH = "/sandbox/model"
 


### PR DESCRIPTION
In debug mode, when the chainkeys are enabled, they are created in `~/.substra_chainkeys`

What this PR changes:
- the folder `~/.substra_chainkeys` is now `local-worker/chainkeys`

That way, in debug mode everything is created inside the `local-worker` directory.