### PR TITLE
feat: export model + node info

### DIFF
--- a/references/cli.md
+++ b/references/cli.md
@@ -16,6 +16,7 @@
 - [substra get](#substra-get)
 - [substra list](#substra-list)
 - [substra describe](#substra-describe)
+- [substra node info](#substra-node-info)
 - [substra download](#substra-download)
 - [substra leaderboard](#substra-leaderboard)
 - [substra cancel compute_plan](#substra-cancel-compute_plan)
@@ -642,21 +643,57 @@ Options:
   --help                          Show this message and exit.
 ```
 
+## substra node info
+
+```bash
+Usage: substra node info [OPTIONS]
+
+  Display node info.
+
+Options:
+  --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                  Enable logging and set log level
+  --config PATH                   Config path (default ~/.substra).
+  --profile TEXT                  Profile name to use.
+  --tokens FILE                   Tokens file path to use (default ~/.substra-
+                                  tokens).
+
+  --verbose                       Enable verbose mode.
+  -o, --output [pretty|yaml|json]
+                                  Set output format  [default: pretty]
+  --help                          Show this message and exit.
+```
+
 ## substra download
 
 ```bash
-Usage: substra download [OPTIONS]
-                        [algo|composite_algo|aggregate_algo|dataset|objective]
-                        KEY
+Usage: substra download [OPTIONS] [algo|composite_algo|aggregate_algo|dataset|
+                        objective|model] KEY
 
   Download asset implementation.
 
   - algo: the algo and its dependencies
   - dataset: the opener script
   - objective: the metrics and its dependencies
+  - model: the output model
 
 Options:
   --folder PATH                   destination folder
+  --from-traintuple               (model download only) if this option is set,
+                                  the KEY argument refers to a traintuple key
+
+  --from-aggregatetuple           (model download only) if this option is set,
+                                  the KEY argument refers to an aggregatetuple
+                                  key
+
+  --from-composite-head           (model download only) if this option is set,
+                                  the KEY argument refers to a composite
+                                  traintuple key
+
+  --from-composite-trunk          (model download only) if this option is set,
+                                  the KEY argument refers to a composite
+                                  traintuple key
+
   --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                   Enable logging and set log level
   --config PATH                   Config path (default ~/.substra).

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -296,6 +296,9 @@ download_aggregatetuple_model(self, tuple_key: str, folder) -> None
 ```
 
 Download aggregatetuple model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## download_algo
 ```python
 download_algo(self, key: str, destination_folder: str) -> None
@@ -316,12 +319,18 @@ download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None
 ```
 
 Download composite traintuple head model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## download_composite_traintuple_trunk_model
 ```python
 download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None
 ```
 
 Download composite traintuple trunk model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## download_dataset
 ```python
 download_dataset(self, key: str, destination_folder: str) -> None
@@ -335,6 +344,9 @@ download_model(self, key: str, folder) -> None
 ```
 
 Download model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## download_objective
 ```python
 download_objective(self, key: str, destination_folder: str) -> None
@@ -348,6 +360,9 @@ download_traintuple_model(self, tuple_key: str, folder) -> None
 ```
 
 Download traintuple model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## from_config_file
 ```python
 from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Union[str, NoneType] = None, retry_timeout: int = 300, debug: bool = False)

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -290,15 +290,6 @@ download_aggregate_algo(self, key: str, destination_folder: str) -> None
 
 Download aggregate algo resource.
 Download aggregate algo package in destination folder.
-## download_aggregatetuple_model
-```python
-download_aggregatetuple_model(self, tuple_key: str, folder) -> None
-```
-
-Download aggregatetuple model to destination file.
-This model was saved using the 'save_model' function of the algorithm.
-To load and use the model, please refer to the 'load_model' and 'predict' functions of the
-algorithm.
 ## download_algo
 ```python
 download_algo(self, key: str, destination_folder: str) -> None
@@ -313,24 +304,6 @@ download_composite_algo(self, key: str, destination_folder: str) -> None
 
 Download composite algo resource.
 Download composite algo package in destination folder.
-## download_composite_traintuple_head_model
-```python
-download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None
-```
-
-Download composite traintuple head model to destination file.
-This model was saved using the 'save_model' function of the algorithm.
-To load and use the model, please refer to the 'load_model' and 'predict' functions of the
-algorithm.
-## download_composite_traintuple_trunk_model
-```python
-download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None
-```
-
-Download composite traintuple trunk model to destination file.
-This model was saved using the 'save_model' function of the algorithm.
-To load and use the model, please refer to the 'load_model' and 'predict' functions of the
-algorithm.
 ## download_dataset
 ```python
 download_dataset(self, key: str, destination_folder: str) -> None
@@ -338,12 +311,39 @@ download_dataset(self, key: str, destination_folder: str) -> None
 
 Download data manager resource.
 Download opener script in destination folder.
+## download_head_model_from_composite_traintuple
+```python
+download_head_model_from_composite_traintuple(self, tuple_key: str, folder) -> None
+```
+
+Download composite traintuple head model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
 ## download_model
 ```python
 download_model(self, key: str, folder) -> None
 ```
 
 Download model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
+## download_model_from_aggregatetuple
+```python
+download_model_from_aggregatetuple(self, tuple_key: str, folder) -> None
+```
+
+Download aggregatetuple model to destination file.
+This model was saved using the 'save_model' function of the algorithm.
+To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+algorithm.
+## download_model_from_traintuple
+```python
+download_model_from_traintuple(self, tuple_key: str, folder) -> None
+```
+
+Download traintuple model to destination file.
 This model was saved using the 'save_model' function of the algorithm.
 To load and use the model, please refer to the 'load_model' and 'predict' functions of the
 algorithm.
@@ -354,12 +354,12 @@ download_objective(self, key: str, destination_folder: str) -> None
 
 Download objective resource.
 Download metrics script in destination folder.
-## download_traintuple_model
+## download_trunk_model_from_composite_traintuple
 ```python
-download_traintuple_model(self, tuple_key: str, folder) -> None
+download_trunk_model_from_composite_traintuple(self, tuple_key: str, folder) -> None
 ```
 
-Download traintuple model to destination file.
+Download composite traintuple trunk model to destination file.
 This model was saved using the 'save_model' function of the algorithm.
 To load and use the model, please refer to the 'load_model' and 'predict' functions of the
 algorithm.

--- a/references/sdk.md
+++ b/references/sdk.md
@@ -290,6 +290,12 @@ download_aggregate_algo(self, key: str, destination_folder: str) -> None
 
 Download aggregate algo resource.
 Download aggregate algo package in destination folder.
+## download_aggregatetuple_model
+```python
+download_aggregatetuple_model(self, tuple_key: str, folder) -> None
+```
+
+Download aggregatetuple model to destination file.
 ## download_algo
 ```python
 download_algo(self, key: str, destination_folder: str) -> None
@@ -304,6 +310,18 @@ download_composite_algo(self, key: str, destination_folder: str) -> None
 
 Download composite algo resource.
 Download composite algo package in destination folder.
+## download_composite_traintuple_head_model
+```python
+download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None
+```
+
+Download composite traintuple head model to destination file.
+## download_composite_traintuple_trunk_model
+```python
+download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None
+```
+
+Download composite traintuple trunk model to destination file.
 ## download_dataset
 ```python
 download_dataset(self, key: str, destination_folder: str) -> None
@@ -311,6 +329,12 @@ download_dataset(self, key: str, destination_folder: str) -> None
 
 Download data manager resource.
 Download opener script in destination folder.
+## download_model
+```python
+download_model(self, key: str, folder) -> None
+```
+
+Download model to destination file.
 ## download_objective
 ```python
 download_objective(self, key: str, destination_folder: str) -> None
@@ -318,6 +342,12 @@ download_objective(self, key: str, destination_folder: str) -> None
 
 Download objective resource.
 Download metrics script in destination folder.
+## download_traintuple_model
+```python
+download_traintuple_model(self, tuple_key: str, folder) -> None
+```
+
+Download traintuple model to destination file.
 ## from_config_file
 ```python
 from_config_file(profile_name: str = 'default', config_path: Union[str, pathlib.Path] = '~/.substra', tokens_path: Union[str, pathlib.Path] = '~/.substra-tokens', token: Union[str, NoneType] = None, retry_timeout: int = 300, debug: bool = False)
@@ -523,6 +553,12 @@ login(self, username, password)
 ```
 
 Login to a remote server. 
+## node_info
+```python
+node_info(self) -> str
+```
+
+Get node information.
 ## update_compute_plan
 ```python
 update_compute_plan(self, key: str, data: Union[dict, substra.sdk.schemas.UpdateComputePlanSpec], auto_batching: bool = True, batch_size: int = 20) -> substra.sdk.models.ComputePlan

--- a/substra/cli/interface.py
+++ b/substra/cli/interface.py
@@ -1051,25 +1051,25 @@ def node_info(ctx):
                   '(model download only) if this option is set, '
                   'the KEY argument refers to a traintuple key'
               ),
-              flag_value='traintuple')
+              flag_value='model_from_traintuple')
 @click.option('--from-aggregatetuple', 'model_src',
               help=(
                   '(model download only) if this option is set, '
                   'the KEY argument refers to an aggregatetuple key'
               ),
-              flag_value='aggregatetuple')
+              flag_value='model_from_aggregatetuple')
 @click.option('--from-composite-head', 'model_src',
               help=(
                   '(model download only) if this option is set, '
                   'the KEY argument refers to a composite traintuple key'
               ),
-              flag_value='composite_traintuple_head')
+              flag_value='head_model_from_composite_traintuple')
 @click.option('--from-composite-trunk', 'model_src',
               help=(
                   '(model download only) if this option is set, '
                   'the KEY argument refers to a composite traintuple key'
               ),
-              flag_value='composite_traintuple_trunk')
+              flag_value='trunk_model_from_composite_traintuple')
 @click_global_conf
 @click.pass_context
 @error_printer
@@ -1085,7 +1085,7 @@ def download(ctx, asset_name, key, folder, model_src):
     client = get_client(ctx.obj)
 
     if asset_name == assets.MODEL:
-        method = getattr(client, f'download_{model_src}_model' if model_src else 'download_model')
+        method = getattr(client, f'download_{model_src}' if model_src else 'download_model')
     else:
         method = getattr(client, f'download_{asset_name.lower()}')
 

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -263,7 +263,7 @@ class BaseAlgoPrinter(AssetPrinter):
 
 class NodeInfoPrinter(BasePrinter):
     single_fields = (
-        Field('MSP_ID', 'msp_id'),
+        Field('HOST', 'host'),
         Field('CHANNEL', 'channel'),
         MappingField('CONFIG', 'config'),
     )

--- a/substra/cli/printers.py
+++ b/substra/cli/printers.py
@@ -261,6 +261,17 @@ class BaseAlgoPrinter(AssetPrinter):
     download_message = 'Download this algorithm\'s code:'
 
 
+class NodeInfoPrinter(BasePrinter):
+    single_fields = (
+        Field('MSP_ID', 'msp_id'),
+        Field('CHANNEL', 'channel'),
+        MappingField('CONFIG', 'config'),
+    )
+
+    def print(self, data):
+        self.print_details(data, self.single_fields, expand=True)
+
+
 class ComputePlanPrinter(AssetPrinter):
     asset_name = 'compute_plan'
 

--- a/substra/sdk/backends/local/backend.py
+++ b/substra/sdk/backends/local/backend.py
@@ -949,6 +949,13 @@ class Local(base.BaseBackend):
         else:
             self._db.remote_download(asset_type, url_field_path, key, destination)
 
+    def download_model(self, key, destination_file):
+        if self._db.is_local(key):
+            asset = self._db.get(type_=schemas.Type.Model, key=key)
+            shutil.copyfile(asset.storage_address, destination_file)
+        else:
+            self._db.remote_download_model(key, destination_file)
+
     def describe(self, asset_type, key):
         if self._db.is_local(key):
             asset = self._db.get(type_=asset_type, key=key)
@@ -958,6 +965,9 @@ class Local(base.BaseBackend):
                 return f.read()
         else:
             return self._db.get_remote_description(asset_type, key)
+
+    def node_info(self):
+        return {"type": "local backend"}
 
     def leaderboard(self, objective_key, sort='desc'):
         objective = self._db.get(schemas.Type.Objective, objective_key)

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -104,11 +104,9 @@ class Worker:
         model_dir = _mkdir(os.path.join(self._wdir, "models", tuple_.key))
         model_path = os.path.join(model_dir, model_name)
         shutil.copy(tmp_path, model_path)
-        model = models.OutModel(key=self._db.get_local_key(str(uuid.uuid4())),
-                                checksum=fs.hash_file(model_path),
-                                storage_address=model_path)
-        self._db.add(model)
-        return model
+        return models.OutModel(key=self._db.get_local_key(str(uuid.uuid4())),
+                               checksum=fs.hash_file(model_path),
+                               storage_address=model_path)
 
     def _get_command_models_composite(self, is_train, tuple_, models_volume, container_volume):
         command = ""

--- a/substra/sdk/backends/local/compute/worker.py
+++ b/substra/sdk/backends/local/compute/worker.py
@@ -104,8 +104,11 @@ class Worker:
         model_dir = _mkdir(os.path.join(self._wdir, "models", tuple_.key))
         model_path = os.path.join(model_dir, model_name)
         shutil.copy(tmp_path, model_path)
-        return models.OutModel(key=str(uuid.uuid4()), checksum=fs.hash_file(model_path),
-                               storage_address=model_path)
+        model = models.OutModel(key=self._db.get_local_key(str(uuid.uuid4())),
+                                checksum=fs.hash_file(model_path),
+                                storage_address=model_path)
+        self._db.add(model)
+        return model
 
     def _get_command_models_composite(self, is_train, tuple_, models_volume, container_volume):
         command = ""

--- a/substra/sdk/backends/local/dal.py
+++ b/substra/sdk/backends/local/dal.py
@@ -85,6 +85,9 @@ class DataAccess:
     def remote_download(self, asset_type, url_field_path, key, destination):
         self._remote.download(asset_type, url_field_path, key, destination)
 
+    def remote_download_model(self, key, destination_file):
+        self._remote.download_model(key, destination_file)
+
     def get_remote_description(self, asset_type, key):
         return self._remote.describe(asset_type, key)
 

--- a/substra/sdk/backends/remote/backend.py
+++ b/substra/sdk/backends/remote/backend.py
@@ -235,11 +235,23 @@ class Remote(base.BaseBackend):
 
         return destination
 
+    def download_model(self, key, destination_file):
+        response = self._client.get_data(f'{self._client.base_url}/model/{key}/file/', stream=True)
+        chunk_size = 1024
+        with open(destination_file, 'wb') as f:
+            for chunk in response.iter_content(chunk_size):
+                f.write(chunk)
+        return destination_file
+
     def describe(self, asset_type, key):
         data = self.get(asset_type, key)
         url = data.description.storage_address
         r = self._client.get_data(url)
         return r.text
+
+    def node_info(self):
+        response = self._client.get_data(f'{self._client.base_url}/info/')
+        return response.json()
 
     def leaderboard(self, objective_key, sort='desc'):
         return self._client.request(

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 class Client():
     """REST Client to communicate with Substra server."""
 
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
     def __init__(self, url, insecure, token):
         self._default_kwargs = {
             'verify': not insecure,

--- a/substra/sdk/backends/remote/rest_client.py
+++ b/substra/sdk/backends/remote/rest_client.py
@@ -138,6 +138,7 @@ class Client():
 
         return r
 
+    @utils.retry_on_exception(exceptions=(exceptions.GatewayUnavailable))
     def _request(self, request_name, url, **request_kwargs):
         """Wrapper to __request to emit a log for each HTTP request."""
         ts = time.time()
@@ -152,7 +153,6 @@ class Client():
             elaps = (te - ts) * 1000
             logger.debug(f'{request_name} {url}: done in {elaps:.2f}ms error={error}')
 
-    @utils.retry_on_exception(exceptions=(exceptions.GatewayUnavailable))
     def request(self, request_name, asset_name, path=None, json_response=True,
                 **request_kwargs):
         """Base request."""

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -789,7 +789,7 @@ class Client(object):
 
         if not model:
             desc = f'{head_trunk} ' if head_trunk else ""
-            msg = f'{tuple_type} {tuple_key} has no {desc}out-model'
+            msg = f'{tuple_type} {tuple_key}, status "{tuple.status}" has no {desc}out-model'
             raise exceptions.NotFound(msg, 404)
 
         self.download_model(model.key, folder)

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -723,27 +723,52 @@ class Client(object):
 
     @logit
     def download_model(self, key: str, folder) -> None:
-        """Download model to destination file."""
+        """Download model to destination file.
+
+        This model was saved using the 'save_model' function of the algorithm.
+        To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+        algorithm.
+        """
         self._backend.download_model(key, os.path.join(folder, f'model_{key}'))
 
     @logit
     def download_traintuple_model(self, tuple_key: str, folder) -> None:
-        """Download traintuple model to destination file."""
+        """Download traintuple model to destination file.
+
+        This model was saved using the 'save_model' function of the algorithm.
+        To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+        algorithm.
+        """
         self._download_tuple_model(schemas.Type.Traintuple, tuple_key, folder)
 
     @logit
     def download_aggregatetuple_model(self, tuple_key: str, folder) -> None:
-        """Download aggregatetuple model to destination file."""
+        """Download aggregatetuple model to destination file.
+
+        This model was saved using the 'save_model' function of the algorithm.
+        To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+        algorithm.
+        """
         self._download_tuple_model(schemas.Type.Aggregatetuple, tuple_key, folder)
 
     @logit
     def download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None:
-        """Download composite traintuple head model to destination file."""
+        """Download composite traintuple head model to destination file.
+
+        This model was saved using the 'save_model' function of the algorithm.
+        To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+        algorithm.
+        """
         self._download_tuple_model(schemas.Type.CompositeTraintuple, tuple_key, folder, "head")
 
     @logit
     def download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None:
-        """Download composite traintuple trunk model to destination file."""
+        """Download composite traintuple trunk model to destination file.
+
+        This model was saved using the 'save_model' function of the algorithm.
+        To load and use the model, please refer to the 'load_model' and 'predict' functions of the
+        algorithm.
+        """
         self._download_tuple_model(schemas.Type.CompositeTraintuple, tuple_key, folder, "trunk")
 
     def _download_tuple_model(self, tuple_type, tuple_key, folder, head_trunk=None) -> None:

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -769,7 +769,8 @@ class Client(object):
         To load and use the model, please refer to the 'load_model' and 'predict' functions of the
         algorithm.
         """
-        self._download_model_from_tuple(schemas.Type.CompositeTraintuple, tuple_key, folder, "trunk")
+        self._download_model_from_tuple(schemas.Type.CompositeTraintuple, tuple_key, folder,
+                                        "trunk")
 
     def _download_model_from_tuple(self, tuple_type, tuple_key, folder, head_trunk=None) -> None:
         """Download model to a destination file."""

--- a/substra/sdk/client.py
+++ b/substra/sdk/client.py
@@ -732,46 +732,46 @@ class Client(object):
         self._backend.download_model(key, os.path.join(folder, f'model_{key}'))
 
     @logit
-    def download_traintuple_model(self, tuple_key: str, folder) -> None:
+    def download_model_from_traintuple(self, tuple_key: str, folder) -> None:
         """Download traintuple model to destination file.
 
         This model was saved using the 'save_model' function of the algorithm.
         To load and use the model, please refer to the 'load_model' and 'predict' functions of the
         algorithm.
         """
-        self._download_tuple_model(schemas.Type.Traintuple, tuple_key, folder)
+        self._download_model_from_tuple(schemas.Type.Traintuple, tuple_key, folder)
 
     @logit
-    def download_aggregatetuple_model(self, tuple_key: str, folder) -> None:
+    def download_model_from_aggregatetuple(self, tuple_key: str, folder) -> None:
         """Download aggregatetuple model to destination file.
 
         This model was saved using the 'save_model' function of the algorithm.
         To load and use the model, please refer to the 'load_model' and 'predict' functions of the
         algorithm.
         """
-        self._download_tuple_model(schemas.Type.Aggregatetuple, tuple_key, folder)
+        self._download_model_from_tuple(schemas.Type.Aggregatetuple, tuple_key, folder)
 
     @logit
-    def download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None:
+    def download_head_model_from_composite_traintuple(self, tuple_key: str, folder) -> None:
         """Download composite traintuple head model to destination file.
 
         This model was saved using the 'save_model' function of the algorithm.
         To load and use the model, please refer to the 'load_model' and 'predict' functions of the
         algorithm.
         """
-        self._download_tuple_model(schemas.Type.CompositeTraintuple, tuple_key, folder, "head")
+        self._download_model_from_tuple(schemas.Type.CompositeTraintuple, tuple_key, folder, "head")
 
     @logit
-    def download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None:
+    def download_trunk_model_from_composite_traintuple(self, tuple_key: str, folder) -> None:
         """Download composite traintuple trunk model to destination file.
 
         This model was saved using the 'save_model' function of the algorithm.
         To load and use the model, please refer to the 'load_model' and 'predict' functions of the
         algorithm.
         """
-        self._download_tuple_model(schemas.Type.CompositeTraintuple, tuple_key, folder, "trunk")
+        self._download_model_from_tuple(schemas.Type.CompositeTraintuple, tuple_key, folder, "trunk")
 
-    def _download_tuple_model(self, tuple_type, tuple_key, folder, head_trunk=None) -> None:
+    def _download_model_from_tuple(self, tuple_type, tuple_key, folder, head_trunk=None) -> None:
         """Download model to a destination file."""
         tuple = self._backend.get(tuple_type, tuple_key)
 

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -28,11 +28,13 @@ class RequestException(SDKException):
         super().__init__(msg)
 
     @classmethod
-    def from_request_exception(cls, request_exception, msg=None):
-        if msg is None:
-            msg = str(request_exception)
-        else:
+    def from_request_exception(cls, request_exception):
+        msg = None
+        try:
+            msg = request_exception.response.json()['message']
             msg = f"{request_exception}: {msg}"
+        except Exception:
+            msg = str(request_exception)
 
         try:
             status_code = request_exception.response.status_code

--- a/substra/sdk/exceptions.py
+++ b/substra/sdk/exceptions.py
@@ -73,7 +73,12 @@ class InvalidRequest(HTTPError):
             error = request_exception.response.json()
         except ValueError:
             error = request_exception.response
-        msg = error.get("message", str(error))
+
+        get_method = getattr(error, "get", None)
+        if callable(get_method):
+            msg = get_method("message", str(error))
+        else:
+            msg = str(error)
 
         try:
             status_code = request_exception.response.status_code

--- a/substra/sdk/models.py
+++ b/substra/sdk/models.py
@@ -179,6 +179,8 @@ class OutModel(schemas._PydanticConfig):
     checksum: str
     storage_address: UriPath
 
+    type_: ClassVar[str] = schemas.Type.Model
+
 
 class _TraintupleAlgo(schemas._PydanticConfig):
     """Algo associated to a traintuple"""

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -162,7 +162,11 @@ TRAINTUPLE = {
     "compute_plan_key": "",
     "in_models": None,
     "log": "[00-01-0032-d415995]",
-    "out_model": None,
+    "out_model": {
+        "key": "11a1f878-768e-a862-4942-d46a3b438c37",
+        "checksum": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+        "storage_address": ""
+    },
     "permissions": {
         "process": {
             "public": False,
@@ -189,7 +193,11 @@ AGGREGATETUPLE = {
     "compute_plan_key": "",
     "in_models": [],
     "log": "[00-01-0032-d415995]",
-    "out_model": None,
+    "out_model": {
+        "key": "11a1f878-768e-a862-4942-d46a3b438c37",
+        "checksum": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+        "storage_address": ""
+    },
     "permissions": {
         "process": {
             "public": False,
@@ -363,4 +371,10 @@ COMPUTE_PLAN = {
     "metadata": {
         "foo": "bar"
     }
+}
+
+MODEL = {
+    "key": "8a90514f-88c7-0002-608a-9868681dd158",
+    "checksum": "8a90514f88c70002608a9868681dd1589ea598e78d00a8cd7783c3ea0f9ceb09",
+    "storage_address": "/some/path/model",
 }

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -90,10 +90,10 @@ def test_download_content_not_found(asset_name, tmp_path, client, mocker):
 
 @pytest.mark.parametrize(
     'method_name, expected_type', [
-        ('download_traintuple_model', schemas.Type.Traintuple),
-        ('download_aggregatetuple_model', schemas.Type.Aggregatetuple),
-        ('download_composite_traintuple_head_model', schemas.Type.CompositeTraintuple),
-        ('download_composite_traintuple_trunk_model', schemas.Type.CompositeTraintuple),
+        ('download_model_from_traintuple', schemas.Type.Traintuple),
+        ('download_model_from_aggregatetuple', schemas.Type.Aggregatetuple),
+        ('download_head_model_from_composite_traintuple', schemas.Type.CompositeTraintuple),
+        ('download_trunk_model_from_composite_traintuple', schemas.Type.CompositeTraintuple),
     ]
 )
 @patch.object(backends.Remote, 'get')

--- a/tests/sdk/test_download.py
+++ b/tests/sdk/test_download.py
@@ -30,7 +30,7 @@ from unittest.mock import patch
         ('aggregate_algo', 'aggregate_algo.tar.gz'),
         ('composite_algo', 'composite_algo.tar.gz'),
         ('objective', 'metrics.py'),
-        ('model', 'model.txt'),
+        ('model', 'model_foo'),
     ]
 )
 def test_download_asset(asset_name, filename, tmp_path, client, mocker):
@@ -42,11 +42,7 @@ def test_download_asset(asset_name, filename, tmp_path, client, mocker):
     m = mock_requests_responses(mocker, 'get', responses)
 
     method = getattr(client, f'download_{asset_name}')
-
-    if asset_name == 'model':
-        method("foo", str(tmp_path) + '/' + filename)
-    else:
-        method("foo", tmp_path)
+    method("foo", tmp_path)
 
     temp_file = str(tmp_path) + '/' + filename
     assert os.path.exists(temp_file)
@@ -79,8 +75,7 @@ def test_download_content_not_found(asset_name, tmp_path, client, mocker):
     ]
 
     if asset_name == 'model':
-        tmp_path = str(tmp_path) + '/' + 'model.txt'
-        responses = [responses[1]]  # No metadata step for model download
+        responses = [responses[1]]  # No metadata for model download
         expected_call_count = 1
 
     m = mock_requests_responses(mocker, 'get', responses)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -322,6 +322,40 @@ def test_command_download(workdir, mocker):
     m.assert_called()
 
 
+def test_command_download_model(workdir, mocker):
+    m = mock_client_call(mocker, 'download_model')
+    client_execute(workdir, ['download', 'model', 'fakekey', '--file', './somefile'])
+    m.assert_called()
+
+    m = mock_client_call(mocker, 'download_traintuple_model')
+    client_execute(
+        workdir,
+        ['download', 'model', '--from-traintuple', 'fakekey', '--file', './somefile']
+    )
+    m.assert_called()
+
+    m = mock_client_call(mocker, 'download_aggregatetuple_model')
+    client_execute(
+        workdir,
+        ['download', 'model', '--from-aggregatetuple', 'fakekey', '--file', './somefile']
+    )
+    m.assert_called()
+
+    m = mock_client_call(mocker, 'download_composite_traintuple_head_model')
+    client_execute(
+        workdir,
+        ['download', 'model', '--from-composite-head', 'fakekey', '--file', './somefile']
+    )
+    m.assert_called()
+
+    m = mock_client_call(mocker, 'download_composite_traintuple_trunk_model')
+    client_execute(
+        workdir,
+        ['download', 'model', '--from-composite-trunk', 'fakekey', '--file', './somefile']
+    )
+    m.assert_called()
+
+
 def test_command_cancel_compute_plan(workdir, mocker):
     m = mock_client_call(
         mocker,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,28 +327,28 @@ def test_command_download_model(workdir, mocker):
     client_execute(workdir, ['download', 'model', 'fakekey'])
     m.assert_called()
 
-    m = mock_client_call(mocker, 'download_traintuple_model')
+    m = mock_client_call(mocker, 'download_model_from_traintuple')
     client_execute(
         workdir,
         ['download', 'model', '--from-traintuple', 'fakekey']
     )
     m.assert_called()
 
-    m = mock_client_call(mocker, 'download_aggregatetuple_model')
+    m = mock_client_call(mocker, 'download_model_from_aggregatetuple')
     client_execute(
         workdir,
         ['download', 'model', '--from-aggregatetuple', 'fakekey']
     )
     m.assert_called()
 
-    m = mock_client_call(mocker, 'download_composite_traintuple_head_model')
+    m = mock_client_call(mocker, 'download_head_model_from_composite_traintuple')
     client_execute(
         workdir,
         ['download', 'model', '--from-composite-head', 'fakekey']
     )
     m.assert_called()
 
-    m = mock_client_call(mocker, 'download_composite_traintuple_trunk_model')
+    m = mock_client_call(mocker, 'download_trunk_model_from_composite_traintuple')
     client_execute(
         workdir,
         ['download', 'model', '--from-composite-trunk', 'fakekey']

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,34 +324,34 @@ def test_command_download(workdir, mocker):
 
 def test_command_download_model(workdir, mocker):
     m = mock_client_call(mocker, 'download_model')
-    client_execute(workdir, ['download', 'model', 'fakekey', '--file', './somefile'])
+    client_execute(workdir, ['download', 'model', 'fakekey'])
     m.assert_called()
 
     m = mock_client_call(mocker, 'download_traintuple_model')
     client_execute(
         workdir,
-        ['download', 'model', '--from-traintuple', 'fakekey', '--file', './somefile']
+        ['download', 'model', '--from-traintuple', 'fakekey']
     )
     m.assert_called()
 
     m = mock_client_call(mocker, 'download_aggregatetuple_model')
     client_execute(
         workdir,
-        ['download', 'model', '--from-aggregatetuple', 'fakekey', '--file', './somefile']
+        ['download', 'model', '--from-aggregatetuple', 'fakekey']
     )
     m.assert_called()
 
     m = mock_client_call(mocker, 'download_composite_traintuple_head_model')
     client_execute(
         workdir,
-        ['download', 'model', '--from-composite-head', 'fakekey', '--file', './somefile']
+        ['download', 'model', '--from-composite-head', 'fakekey']
     )
     m.assert_called()
 
     m = mock_client_call(mocker, 'download_composite_traintuple_trunk_model')
     client_execute(
         workdir,
-        ['download', 'model', '--from-composite-trunk', 'fakekey', '--file', './somefile']
+        ['download', 'model', '--from-composite-trunk', 'fakekey']
     )
     m.assert_called()
 


### PR DESCRIPTION
Companion PRs:

- https://github.com/SubstraFoundation/substra-tests/pull/182
- https://github.com/SubstraFoundation/substra-chaincode/pull/141
- https://github.com/SubstraFoundation/substra-backend/pull/395

--- 

This PR adds the new CLI commands

```sh
substra node info
substra download_model <MODEL_KEY>
substra download_model --from-traintuple <TUPLE_KEY>
substra download_model --from-aggregatetuple <TUPLE_KEY>
substra download_model --from-composite-head <TUPLE_KEY>
substra download_model --from-composite-trunk <TUPLE_KEY>
```

and the respective SDK functions 

```python
node_info(self) -> str
download_model(self, key: str, folder) -> None
download_traintuple_model(self, tuple_key: str, folder) -> None
download_aggregatetuple_model(self, tuple_key: str, folder) -> None
download_composite_traintuple_head_model(self, tuple_key: str, folder) -> None
download_composite_traintuple_trunk_model(self, tuple_key: str, folder) -> None
```

The model is exported to a file `model_<MODEL_KEY>` in the supplied folder (or `./` if no folder is supplied).

This PR also fixes the CLI error message displayed for erroneous asset downloads: the CLI output was `message` instead of the full actual message.

## Examples

### Get node information

```sh
$ substra node info
MSP_ID      MyOrg1MSP
CHANNEL     mychannel
CONFIG      - model_export_enabled:True
```

### Export model

```sh
$ substra download model 7a637f52-0569-4a3b-aaa7-b0e25a32e437
$ cat model_7a637f52-0569-4a3b-aaa7-b0e25a32e437
{"value": 2.4000000000000004}
```

### Export model by tuple key

```sh
$ substra download model --from-composite-head 168e7a72-372f-4ab5-8dc5-d3841061fd06
$ cat model_7a637f52-0569-4a3b-aaa7-b0e25a32e437
{"value": 2.4000000000000004}
```

