### PR TITLE
DOC Update to README instructions for titanic

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -27,7 +27,7 @@ jobs:
           export FORCE_ROOTLESS_INSTALL=1
           curl -fsSL https://get.docker.com/rootless | sh
       - name: Install tools
-        run: pip install flake8 wheel docstring-parser
+        run: pip install flake8 wheel docstring-parser==0.7.3
       - name: Lint
         run: flake8 substra
       - name: Install substra

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Generate and validate CLI documentation
         run: |
           python bin/generate_cli_documentation.py --output-path references/cli.md.tmp
+          diff references/cli.md references/cli.md.tmp
           cmp --silent references/cli.md references/cli.md.tmp
       - name: Generate and validate SDK documentation
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,10 @@ jobs:
         run: |
           python bin/generate_sdk_documentation.py --output-path='references/sdk.md.tmp'
           cmp --silent references/sdk.md references/sdk.md.tmp
+          diff references/sdk.md references/sdk.md.tmp
           python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
           cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp
+          diff references/sdk_schemas.md references/sdk_schemas.md.tmp
           python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md.tmp'
           cmp --silent references/sdk_models.md references/sdk_models.md.tmp
+          diff references/sdk_models.md references/sdk_models.md.tmp

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,11 +45,12 @@ jobs:
       - name: Generate and validate SDK documentation
         run: |
           python bin/generate_sdk_documentation.py --output-path='references/sdk.md.tmp'
-          cmp --silent references/sdk.md references/sdk.md.tmp
           diff references/sdk.md references/sdk.md.tmp
-          python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
-          cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp
+          cmp --silent references/sdk.md references/sdk.md.tmp
+          python bin/generate_sdk_schemas_documentation.py --output-path
+          references/sdk_schemas.md.tmp
           diff references/sdk_schemas.md references/sdk_schemas.md.tmp
+          cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp
           python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md.tmp'
-          cmp --silent references/sdk_models.md references/sdk_models.md.tmp
           diff references/sdk_models.md references/sdk_models.md.tmp
+          cmp --silent references/sdk_models.md references/sdk_models.md.tmp

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,8 +47,7 @@ jobs:
           python bin/generate_sdk_documentation.py --output-path='references/sdk.md.tmp'
           diff references/sdk.md references/sdk.md.tmp
           cmp --silent references/sdk.md references/sdk.md.tmp
-          python bin/generate_sdk_schemas_documentation.py --output-path
-          references/sdk_schemas.md.tmp
+          python bin/generate_sdk_schemas_documentation.py --output-path references/sdk_schemas.md.tmp
           diff references/sdk_schemas.md references/sdk_schemas.md.tmp
           cmp --silent references/sdk_schemas.md references/sdk_schemas.md.tmp
           python bin/generate_sdk_schemas_documentation.py --models --output-path='references/sdk_models.md.tmp'

--- a/examples/titanic/README.md
+++ b/examples/titanic/README.md
@@ -99,6 +99,7 @@ as the associated scores. Alternatively, you can browse the frontend to look up 
 
 
 ## Testing our assets
+Note that this way of testing the code is being deprecated. Consider [using the debug mode](#Using the debug mode) instead
 
 ### Manually
 
@@ -108,14 +109,14 @@ as the associated scores. Alternatively, you can browse the frontend to look up 
 python assets/algo_random_forest/algo.py train \
   --debug \
   --opener-path assets/dataset/opener.py \
-  --data-samples-path assets/train_data_samples \
+  --data-sample-paths assets/train_data_samples/* \
   --output-model-path assets/model/model \
   --log-path assets/logs/train.log
 
 python assets/algo_random_forest/algo.py predict \
   --debug \
   --opener-path assets/dataset/opener.py \
-  --data-samples-path assets/train_data_samples \
+  --data-sample-paths assets/train_data_samples/* \
   --output-predictions-path assets/pred-train.csv \
   --models-path assets/model/ \
   --log-path assets/logs/train_predict.log \
@@ -124,7 +125,7 @@ python assets/algo_random_forest/algo.py predict \
 python assets/objective/metrics.py \
   --debug \
   --opener-path assets/dataset/opener.py \
-  --data-samples-path assets/train_data_samples \
+  --data-sample-paths assets/train_data_samples/* \
   --input-predictions-path assets/pred-train.csv \
   --output-perf-path assets/perf-train.json \
   --log-path assets/logs/train_metrics.log
@@ -136,7 +137,7 @@ python assets/objective/metrics.py \
 python assets/algo_random_forest/algo.py predict \
   --debug \
   --opener-path assets/dataset/opener.py \
-  --data-samples-path assets/test_data_samples \
+  --data-sample-paths assets/test_data_samples/* \
   --output-predictions-path assets/pred-test.csv \
   --models-path assets/model/ \
   --log-path assets/logs/test_predict.log \
@@ -145,7 +146,7 @@ python assets/algo_random_forest/algo.py predict \
 python assets/objective/metrics.py \
   --debug \
   --opener-path assets/dataset/opener.py \
-  --data-samples-path assets/test_data_samples \
+  --data-sample-paths assets/test_data_samples/* \
   --input-predictions-path assets/pred-test.csv \
   --output-perf-path assets/perf-test.json \
   --log-path assets/logs/test_metrics.log
@@ -155,4 +156,4 @@ python assets/objective/metrics.py \
 
 Substra provides a very handy debug mode that will simulate the workings of a node right on your machine.
 
-For more information, have a look at the [debugging example](../debugging/READMEmd).
+For more information, have a look at the [debugging example](../debugging/README.md).

--- a/examples/titanic/assets/algo_random_forest/Dockerfile
+++ b/examples/titanic/assets/algo_random_forest/Dockerfile
@@ -2,7 +2,7 @@
 FROM substrafoundation/substra-tools:0.7.0
 
 # install dependencies
-RUN pip3 install pandas numpy sklearn pillow scipy keras
+RUN pip3 install pandas numpy 'scikit-learn==0.24.2' pillow scipy keras
 
 # add your algorithm script to docker image
 ADD algo.py .

--- a/examples/titanic/assets/algo_random_forest/Dockerfile
+++ b/examples/titanic/assets/algo_random_forest/Dockerfile
@@ -2,7 +2,7 @@
 FROM substrafoundation/substra-tools:0.7.0
 
 # install dependencies
-RUN pip3 install pandas numpy 'scikit-learn==0.24.2' pillow scipy keras
+RUN pip3 install pandas numpy pillow scipy keras six 'scikit-learn==0.24.2'
 
 # add your algorithm script to docker image
 ADD algo.py .

--- a/examples/titanic/assets/algo_random_forest/algo.py
+++ b/examples/titanic/assets/algo_random_forest/algo.py
@@ -130,7 +130,7 @@ class Algo(tools.algo.Algo):
                                                oob_score=True,
                                                random_state=1,
                                                n_jobs=-1)
-        random_forest.fit(X, y)
+        random_forest.fit(X, y.values.ravel())
 
         return random_forest
 

--- a/references/sdk_models.md
+++ b/references/sdk_models.md
@@ -84,7 +84,7 @@ Testtuple
 - status: str
 - compute_plan_key: str
 - rank: int
-- traintuple_type: enum
+- traintuple_type: Type
 - metadata: Mapping[str, str]
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     keywords=['cli', 'substra'],
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
-    install_requires=['click', 'requests', 'docker', 'consolemd', 'pyyaml', 'pydantic>=1.5.1'],
+    install_requires=['click', 'requests', 'docker', 'consolemd', 'pyyaml', 'pydantic>=1.5.1', 'six'],
     python_requires='>=3.6',
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov', 'pytest-mock'],

--- a/setup.py
+++ b/setup.py
@@ -21,42 +21,50 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-with open(os.path.join(here, 'README.md'), 'r', 'utf-8') as fp:
+with open(os.path.join(here, "README.md"), "r", "utf-8") as fp:
     readme = fp.read()
 
 
 about = {}
-with open(os.path.join(here, 'substra', '__version__.py'), 'r', 'utf-8') as fp:
+with open(os.path.join(here, "substra", "__version__.py"), "r", "utf-8") as fp:
     exec(fp.read(), about)
 
 
 setup(
-    name='substra',
-    version=about['__version__'],
-    description='Substra CLI for interacting with substra-backend',
+    name="substra",
+    version=about["__version__"],
+    description="Substra CLI for interacting with substra-backend",
     long_description=readme,
     long_description_content_type="text/markdown",
-    url='https://github.com/SubstraFoundation/substra',
-    author='Owkin',
-    author_email='fldev@owkin.com',
-    license='Apache 2.0',
+    url="https://github.com/SubstraFoundation/substra",
+    author="Owkin",
+    author_email="fldev@owkin.com",
+    license="Apache 2.0",
     classifiers=[
-        'Intended Audience :: Developers',
-        'Topic :: Utilities',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
+        "Intended Audience :: Developers",
+        "Topic :: Utilities",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.6",
     ],
-    keywords=['cli', 'substra'],
-    packages=find_packages(exclude=['tests*']),
+    keywords=["cli", "substra"],
+    packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    install_requires=['click', 'requests', 'docker', 'consolemd', 'pyyaml', 'pydantic>=1.5.1', 'six'],
-    python_requires='>=3.6',
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'pytest-cov', 'pytest-mock'],
+    install_requires=[
+        "click==7.1.2",
+        "requests",
+        "docker",
+        "consolemd",
+        "pyyaml",
+        "pydantic>=1.5.1",
+        "six",
+    ],
+    python_requires=">=3.6",
+    setup_requires=["pytest-runner"],
+    tests_require=["pytest", "pytest-cov", "pytest-mock"],
     entry_points={
-        'console_scripts': [
-            'substra=substra.cli.interface:cli',
+        "console_scripts": [
+            "substra=substra.cli.interface:cli",
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
A couple of changes to the docs to keep up with  the most recent versions
and ravel y to avoid the warning

Perhaps the substra-docs could also be updated accordingly? 
ie, for example: https://github.com/SubstraFoundation/substra-documentation/blob/master/docs/_sources/demo.md.txt

CC: @Esadruhn 